### PR TITLE
fix: compile issues, types missing

### DIFF
--- a/score/mw/log/detail/dlt_argument_counter.h
+++ b/score/mw/log/detail/dlt_argument_counter.h
@@ -14,6 +14,7 @@
 #ifndef SCORE_MW_LOG_DETAIL_DLT_ARGUMENT_COUNTER_H
 #define SCORE_MW_LOG_DETAIL_DLT_ARGUMENT_COUNTER_H
 
+#include <cstdint>
 #include "score/callback.hpp"
 #include "score/mw/log/detail/add_argument_result.h"
 

--- a/score/os/utils/abortable_blocking_reader.cpp
+++ b/score/os/utils/abortable_blocking_reader.cpp
@@ -18,6 +18,7 @@
 
 #include <cerrno>
 #include <chrono>
+#include <mutex>
 #include <thread>
 #include <utility>
 


### PR DESCRIPTION
When trying to build communication, my compiler was complaining about some missing symbols that seem to be caused by missing includes.