### PR TITLE
Add S-CORE devcontainer

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,3 +21,5 @@ common --//score/json:base_library=nlohmann
 common --extra_toolchains=@gcc_toolchain//:host_gcc_12
 build --incompatible_strict_action_env
 test --test_tag_filters=-manual
+
+test --test_output=errors

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "name": "eclipse-s-core",
+    "image": "ghcr.io/eclipse-score/devcontainer:latest"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bazel-*
 user.bazelrc
+.cache
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # baselibs
 base libraries including common functionality
+
+> [!NOTE]
+> This repository offers a [DevContainer](https://containers.dev/).
+> For setting this up and enabling code completion read [eclipse-score/devcontainer/README.md#inside-the-container](https://github.com/eclipse-score/devcontainer/blob/main/README.md#inside-the-container).
+
+> [!NOTE]
+> If you are using Docker on Windows **without `WSL2`** in between, you have to select the alternative container `eclipse-s-core-docker-on-windows`.


### PR DESCRIPTION
The devcontainer eases setup a lot and creates a reproducible environment.

Currently some tests fail in the devcontainer, which I did not debug yet.