### PR TITLE
build: Add various missing headers

### DIFF
--- a/score/concurrency/clock.h
+++ b/score/concurrency/clock.h
@@ -14,6 +14,7 @@
 #define SCORE_LIB_CONCURRENCY_CLOCK_H
 
 #include <chrono>
+#include <exception>
 #include <mutex>
 
 namespace score

--- a/score/language/futurecpp/tests/member_iterator_test.cpp
+++ b/score/language/futurecpp/tests/member_iterator_test.cpp
@@ -6,6 +6,7 @@
 #include <score/member_iterator.hpp>
 #include <score/member_iterator.hpp> // check include guard
 
+#include <algorithm>
 #include <forward_list>
 #include <list>
 #include <vector>

--- a/score/language/futurecpp/tests/multi_span_test.cpp
+++ b/score/language/futurecpp/tests/multi_span_test.cpp
@@ -8,6 +8,7 @@
 
 #include <score/assert_support.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <numeric>
 #include <sstream>

--- a/score/mw/log/detail/logging_identifier.cpp
+++ b/score/mw/log/detail/logging_identifier.cpp
@@ -12,6 +12,7 @@
  ********************************************************************************/
 #include "score/mw/log/detail/logging_identifier.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace score


### PR DESCRIPTION
Those were discovered when trying to build the project using AutoSD GCC toolchain.