### PR TITLE
qnx: make mman_impl LP64-safe; use ::mmap/::mem_offset on QNX LP64 and include <sys/mman.h>, <sys/types.h>

### DIFF
--- a/score/os/qnx/mman_impl.cpp
+++ b/score/os/qnx/mman_impl.cpp
@@ -11,7 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/os/qnx/mman_impl.h"
-
+#include <sys/mman.h>
+#include <sys/types.h>
 namespace score
 {
 namespace os
@@ -21,14 +22,14 @@ namespace qnx
 
 /* KW_SUPPRESS_START:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
 score::cpp::expected<void*, Error> MmanQnxImpl::mmap(void* const addr,
-                                              const std::size_t length,
-                                              const std::int32_t protection,
-                                              const std::int32_t flags,
-                                              const std::int32_t fd,
-                                              const std::int64_t offset) const noexcept
+                                                 const std::size_t length,
+                                                 const std::int32_t protection,
+                                                 const std::int32_t flags,
+                                                 const std::int32_t fd,
+                                                 const std::int64_t offset) const noexcept
 /* KW_SUPPRESS_END:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
 {
-    void* const ret{::mmap(addr, length, protection, flags, fd, offset)};
+ void* const ret{::mmap(addr, length, protection, flags, fd, offset)};
     /* KW_SUPPRESS_START:AUTOSAR.CAST.CSTYLE:Cast is happening outside our code domain */
     /* KW_SUPPRESS_START:MISRA.USE.EXPANSION: Using library-defined macro to ensure correct operations */
     // Suppress "autosar_cpp14_m5_2_9_violation" rule finding. This rule states: "A cast shall not
@@ -53,12 +54,12 @@ score::cpp::expected<void*, Error> MmanQnxImpl::mmap64(void* addr,
                                                 const std::int32_t fd,
                                                 const std::int64_t offset) const noexcept
 {
+#if defined(__QNX__) && defined(__LP64__)
+    // On LP64 QNX, mmap already uses 64-bit offsets.
+    void* const ret{::mmap(addr, length, protection, flags, fd, offset)};
+#else
     void* const ret{::mmap64(addr, length, protection, flags, fd, offset)};
-    /* KW_SUPPRESS_START:AUTOSAR.CAST.CSTYLE:Cast is happening outside our code domain */
-    /* KW_SUPPRESS_START:MISRA.USE.EXPANSION: Using library-defined macro to ensure correct operations */
-    // Cast is happening outside our code domain
-    // coverity[autosar_cpp14_m5_2_9_violation]
-    // coverity[autosar_cpp14_a5_2_2_violation] MAP_FAILED is builtin macro
+#endif
     if (ret == MAP_FAILED)
     /* KW_SUPPRESS_END:MISRA.USE.EXPANSION: Using library-defined macro to ensure correct operations */
     /* KW_SUPPRESS_END:AUTOSAR.CAST.CSTYLE:Cast is happening outside our code domain */
@@ -202,13 +203,17 @@ score::cpp::expected_blank<Error> MmanQnxImpl::mem_offset64(const void* addr,
                                                      std::size_t* contig_len) const noexcept
 /* KW_SUPPRESS_END:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
 {
+#if defined(__QNX__) && defined(__LP64__)
+    // On LP64 QNX only mem_offset() exists; off_t is 64-bit already.
+    if (::mem_offset(addr, fd, length,offset,contig_len) == -1)
+#else
     if (::mem_offset64(addr, fd, length, offset, contig_len) == -1)
+#endif
     {
         return score::cpp::make_unexpected(Error::createFromErrno());
     }
     return {};
 }
-
 }  // namespace qnx
 }  // namespace os
 }  // namespace score


### PR DESCRIPTION
**Problem**

When building on QNX LP64 (e.g., Neutrino 8 x86_64), the 64-suffixed APIs are often not declared because the non-suffixed ones already use 64-bit off_t. Calling ::mmap64 / ::mem_offset64 unconditionally produces errors like:

'::mmap64' has not been declared

'::mem_offset64' has not been declared

**What this PR does**

Adds the missing system headers <sys/mman.h> and <sys/types.h> at the top of mman_impl.cpp.

Uses feature checks to select the correct calls:

On __QNX__ && __LP64__, mmap64() delegates to ::mmap(...) (already 64-bit).

On __QNX__ && __LP64__, mem_offset64() delegates to ::mem_offset(...) (already 64-bit).

On all other platforms, behavior is unchanged (still calls the 64-suffixed versions).

**Why this is correct**

On LP64 systems, off_t is 64-bit, so the non-suffixed calls already use wide offsets.

QNX headers may not even declare the “64” symbols on LP64 because they are redundant.