### PR TITLE
fix: move wait_free_stack dependency to correct location

### DIFF
--- a/score/mw/log/BUILD
+++ b/score/mw/log/BUILD
@@ -60,13 +60,13 @@ cc_library(
         "@score-baselibs//score/mw/log/detail:circular_allocator",
         "@score-baselibs//score/mw/log/detail:empty_recorder",
         "@score-baselibs//score/mw/log/detail:thread_local_guard",
-        "@score-baselibs//score/mw/log/detail/wait_free_stack",
         "@score-baselibs//score/result",
     ],
     tags = ["FFI"],
     visibility = ["//visibility:public"],
     deps = [
         ":log_stream",
+        "@score-baselibs//score/mw/log/detail/wait_free_stack",
     ],
 )
 


### PR DESCRIPTION
Promotes `@score-baselibs//score/mw/log/detail/wait_free_stack` from `implementation_deps` to `deps` in the cc_library so downstream consumers receive it transitively.

wait_free_stack was required by code reachable through public headers of the logging. Keeping it in implementation_deps blocked Bazel from exposing it transitively, forcing downstream modules to add redundant explicit dependencies or fail to build. Moving it to deps aligns with Bazel best practice: anything needed by public headers or inline code must be a regular dependency.

Background:
updating communication to latest baselibs (and logging) revealed this issue.
For com changes see:
https://github.com/etas-contrib/score_communication/tree/feature/build_from_reference_repo