### PR TITLE
Correct TestType terminology to match process

### DIFF
--- a/score/concurrency/synchronized_queue_test.cpp
+++ b/score/concurrency/synchronized_queue_test.cpp
@@ -32,7 +32,7 @@ using namespace std::literals::chrono_literals;
 TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenMaxQueueLengthReached)
 {
     RecordProperty("ASIL", "QM");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of boundary values");
     RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
     RecordProperty("Description",
@@ -66,7 +66,7 @@ TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenMaxQueueLengthReached)
 TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenQueueObjectDoesNotExist)
 {
     RecordProperty("ASIL", "QM");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of boundary values");
     RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
     RecordProperty("Description",
@@ -99,7 +99,7 @@ TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenQueueObjectDoesNotExist)
 TEST(SynchronizedQueue, CallPopForEmptyQueue)
 {
     RecordProperty("ASIL", "QM");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of boundary values");
     RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
     RecordProperty("Description",
@@ -128,7 +128,7 @@ TEST(SynchronizedQueue, CallPopForEmptyQueue)
 TEST(SynchronizedQueue, CallPushWhenPopIsWaitingForTimeout)
 {
     RecordProperty("ASIL", "QM");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of boundary values");
     RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
     RecordProperty("Description",
@@ -176,7 +176,7 @@ TEST(SynchronizedQueue, MakeStressTestForPushingFromMultipleThreads)
     const std::size_t max_queue_length = num_threads * num_values_per_thread;
 
     RecordProperty("ASIL", "QM");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of boundary values");
     RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
     RecordProperty("Description",

--- a/score/json/internal/model/any_test.cpp
+++ b/score/json/internal/model/any_test.cpp
@@ -28,7 +28,7 @@ TEST(Any, CanDefaultConstruct)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Empty-constructed json objects have null value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     // Given Any with no specific value
@@ -46,7 +46,7 @@ TEST(Any, CanConstructFromBool)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Bool-constructed json objects have bool value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "1");
 
@@ -65,7 +65,7 @@ TEST(Any, CanConstructFromFloat)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Float-constructed json objects have float value, cf. RFC-8259 section 3, 6, and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
@@ -84,7 +84,7 @@ TEST(Any, CanConstructFromFloatNumber)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Float-number-constructed json objects have float value, cf. RFC-8259 section 3, 6, and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
@@ -102,7 +102,7 @@ TEST(Any, CanConstructFromUint64)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Int64-constructed json objects have int64 value, cf. RFC-8259 section 3, 6, and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
@@ -121,7 +121,7 @@ TEST(Any, CanConstructFromIntegralNumber)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Integral-number-constructed json objects have int value, cf. RFC-8259 section 3, 6, and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
@@ -139,7 +139,7 @@ TEST(Any, CanConstructFromString)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "String-constructed json objects have string value, cf. RFC-8259 section 3, 7 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{std::string{"foo"}};
@@ -154,7 +154,7 @@ TEST(Any, CanConstructFromNull)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Null-constructed json objects have null value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{Null{}};
@@ -169,7 +169,7 @@ TEST(Any, CanConstructFromObject)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Object-constructed json objects have object value, cf. RFC-8259 section 3, 4 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{Object{}};
@@ -184,7 +184,7 @@ TEST(Any, CanConstructFromList)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "List-constructed json objects have list value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{List{}};
@@ -199,7 +199,7 @@ TEST(Any, CanAssignBool)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Bool-assigned json objects have bool value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     // Given Any with no specific value
@@ -220,7 +220,7 @@ TEST(Any, CanAssignFloat)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Float-assigned json objects have float value, cf. RFC-8259 section 3, 6 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -238,7 +238,7 @@ TEST(Any, CanAssignFloatNumber)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Float-number-assigned json objects have float value, cf. RFC-8259 section 3, 6 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -255,7 +255,7 @@ TEST(Any, CanAssignUint64)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Int64-assigned json objects have int64 value, cf. RFC-8259 section 3, 6 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -273,7 +273,7 @@ TEST(Any, CanAssignUint64Number)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Int64-number-assigned json objects have int64 value, cf. RFC-8259 section 3, 6 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -290,7 +290,7 @@ TEST(Any, CanAssignString)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "String-assigned json objects have string value, cf. RFC-8259 section 3, 7 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -307,7 +307,7 @@ TEST(Any, CanAssignNull)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Null-assigned json objects have null value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{true};
@@ -324,7 +324,7 @@ TEST(Any, CanAssignObject)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Object-assigned json objects have object value, cf. RFC-8259 section 3, 4 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -341,7 +341,7 @@ TEST(Any, CanAssignList)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "List-assigned json objects have list value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
     Any unit{};
@@ -358,7 +358,7 @@ TEST(Any, CanRetrieveNumberForBool)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Bool-constructed json objects have numerical value, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -376,7 +376,7 @@ TEST(Any, CanNotRetrieveWronglyTypedValue)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "list json object can't be converted to string, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -396,7 +396,7 @@ TEST(Any, CanNotRetrieveWronglyTypedReference)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "bool json object can't be converted to list, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -417,7 +417,7 @@ TEST(Any, CanNotRetrieveWronglyTypedValueConst)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "const list json object can't be converted to const bool object, cf. RFC-8259 section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -439,7 +439,7 @@ TEST(Any, CanNotRetrieveWronglyTypedReferenceConst)
     RecordProperty("Description",
                    "const bool json object can't be converted to const list object, cf. RFC-8259 "
                    "section 3 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -460,7 +460,7 @@ TEST(Any, CanAccessStringAsAmpStringView)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "String-constructed json objects can be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -477,7 +477,7 @@ TEST(Any, CanAccessStringAsStdStringView)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "String-constructed json objects can be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -495,7 +495,7 @@ TEST(Any, CanNotRetrieveWronglyTypedAmpStringView)
     RecordProperty(
         "Description",
         "non String-constructed json objects can not be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -517,7 +517,7 @@ TEST(Any, CanNotRetrieveWronglyTypedStdStringView)
     RecordProperty(
         "Description",
         "non String-constructed json objects can not be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -542,7 +542,7 @@ TEST(Any, CheckEqualOperator)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests the equal comparator of Any.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::Any::operator==");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
@@ -606,7 +606,7 @@ TEST(Any, CloneBool)
     RecordProperty("Verifies", "::score::json::Any::CloneByValue");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves boolean value equality");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -625,7 +625,7 @@ TEST(Any, CloneNumber)
     RecordProperty("Verifies", "::score::json::Any::CloneByValue");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves numeric value equality");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -644,7 +644,7 @@ TEST(Any, CloneNull)
     RecordProperty("Verifies", "::score::json::Any::CloneByValue");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves null value equality");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -663,7 +663,7 @@ TEST(Any, CloneString)
     RecordProperty("Verifies", "::score::json::Any::CloneByValue");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves string value equality");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "2");
 
@@ -682,7 +682,7 @@ TEST(Any, CloneObject)
     RecordProperty("Verifies", "::score::json::Any::CloneByValue");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves object value equality");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -704,7 +704,7 @@ TEST(Any, CloneList)
     RecordProperty("Verifies", "::score::json::Any::CloneByValue");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves list value equality");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 

--- a/score/json/internal/model/error_test.cpp
+++ b/score/json/internal/model/error_test.cpp
@@ -30,7 +30,7 @@ TEST(Error, CanMakeError)
     RecordProperty("Verifies", "::score::json::MakeError");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Use MakeError() to create Error instance.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -44,7 +44,7 @@ TEST(Error, CanMakeErrorWithUserMessage)
     RecordProperty("Verifies", "::score::json::MakeError");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Use MakeError() with error message to create Error instance.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -59,7 +59,7 @@ TEST(Error, CanGetMessageForWrongType)
     RecordProperty("Verifies", "::score::result::Error::Message");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from WrongType error.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -75,7 +75,7 @@ TEST(Error, CanGetMessageForKeyNotFound)
     RecordProperty("Verifies", "::score::result::Error::Message");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from KeyNotFound error.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -91,7 +91,7 @@ TEST(Error, CanGetMessageForParsingError)
     RecordProperty("Verifies", "::score::result::Error::Message");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from ParsingError error.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -107,7 +107,7 @@ TEST(Error, CanGetMessageForInvalidFilePath)
     RecordProperty("Verifies", "::score::result::Error::Message");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from InvalidFilePath error.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -123,7 +123,7 @@ TEST(Error, CanGetMessageForUnknownError)
     RecordProperty("Verifies", "::score::result::Error::Message");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from UnknownError.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -139,7 +139,7 @@ TEST(Error, CanGetMessageForUndefinedError)
     RecordProperty("Verifies", "::score::result::Error::Message");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from UndefinedError.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 

--- a/score/json/internal/model/number_test.cpp
+++ b/score/json/internal/model/number_test.cpp
@@ -87,7 +87,7 @@ TEST(Number, FromUint8ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint8 max value to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -109,7 +109,7 @@ TEST(Number, FromUint16ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint16 max value to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -131,7 +131,7 @@ TEST(Number, FromUint32ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint32 max value to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -153,7 +153,7 @@ TEST(Number, FromUint64ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint64 max value to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -232,7 +232,7 @@ TEST(Number, FromInt8ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int8 different values to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -250,7 +250,7 @@ TEST(Number, FromInt16ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int16 different values to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -268,7 +268,7 @@ TEST(Number, FromInt32ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int32 different values to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -286,7 +286,7 @@ TEST(Number, FromInt64ToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int64 different values to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -602,7 +602,7 @@ TEST(Number, FromFloatToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of float values to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -614,7 +614,7 @@ TEST(Number, FromDoubleToAnyOtherType)
     RecordProperty("Verifies", "::score::json::Number::As");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of double values to different data types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -632,7 +632,7 @@ TEST(Number, CheckEqualOperator)
     RecordProperty("Verifies", "::score::json::Number::operator==");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests the equal comparator of Number.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
     {

--- a/score/json/internal/model/object_test.cpp
+++ b/score/json/internal/model/object_test.cpp
@@ -67,7 +67,7 @@ TEST_F(AttributeGettersTest, GetBoolUsingResult)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get bool attribute using Result<> input.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -82,7 +82,7 @@ TEST_F(AttributeGettersTest, GetBoolDirectValue)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get bool attribute from direct Object reference.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -97,7 +97,7 @@ TEST_F(AttributeGettersTest, GetIntegerUsingResult)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get signed/unsigned integer attribute using Result<> input.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -115,7 +115,7 @@ TEST_F(AttributeGettersTest, GetIntegerDirectValue)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get signed/unsigned integer attribute from direct Object reference.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -133,7 +133,7 @@ TEST_F(AttributeGettersTest, GetFloatingPointUsingResult)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get float attribute using Result<>; double retrieval is forbidden.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -151,7 +151,7 @@ TEST_F(AttributeGettersTest, GetFloatingPointDirectValue)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get float attribute from direct value; double retrieval is forbidden.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -169,7 +169,7 @@ TEST_F(AttributeGettersTest, GetStringUsingResult)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get string attribute using Result<> input.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -185,7 +185,7 @@ TEST_F(AttributeGettersTest, GetStringDirectValue)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get string attribute from direct Object reference.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -201,7 +201,7 @@ TEST_F(AttributeGettersTest, GetListUsingResult)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get list attribute using Result<> input.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -216,7 +216,7 @@ TEST_F(AttributeGettersTest, GetListDirectValue)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get list attribute from direct Object reference.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -231,7 +231,7 @@ TEST_F(AttributeGettersTest, GetObjectUsingResult)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get nested object attribute using Result<> input.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -247,7 +247,7 @@ TEST_F(AttributeGettersTest, GetObjectDirectValue)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get nested object attribute from direct Object reference.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -263,7 +263,7 @@ TEST_F(AttributeGettersTest, CascadingAccessSuccessCase)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Traverse nested objects (widget/geometry/size/width) successfully.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -286,7 +286,7 @@ TEST_F(AttributeGettersTest, CascadingAccessErrorCase)
     RecordProperty("Verifies", "::score::json::GetAttribute");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Fail gracefully when traversing with invalid keys.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 

--- a/score/json/internal/parser/json_parser_test.cpp
+++ b/score/json/internal/parser/json_parser_test.cpp
@@ -53,7 +53,7 @@ TEST(JsonParserTest, FromBuffer)
     RecordProperty("Verifies", "::score::json::JsonParser::FromBuffer");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing json object using FromBuffer(), cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -70,7 +70,7 @@ TEST(JsonParserTest, ViaLiteral)
     RecordProperty("Description",
                    "Parsing json object using "
                    "_json operator, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -83,7 +83,7 @@ TEST(JsonParserTest, ViaErrorLiteral)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing invalid json object using _json operator, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 
@@ -95,7 +95,7 @@ TEST(JsonParserTest, FromFileSuceess)
     RecordProperty("Verifies", "::score::json::JsonParser::FromFile");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing json object from file path, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     RecordProperty("Priority", "3");
 
@@ -118,7 +118,7 @@ TEST(JsonParserTest, FromFileParseError)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing invalid json object from file path causes failure, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecordProperty("Priority", "3");
 

--- a/score/json/internal/parser/number_parser_test_suite.h
+++ b/score/json/internal/parser/number_parser_test_suite.h
@@ -99,7 +99,7 @@ TYPED_TEST_P(NumberTest, WhenParsingABoolStoredInAJsonThenParsingIsSuccessfulAnd
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of bool data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -123,7 +123,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint8StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint8 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -147,7 +147,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint16StoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint16 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -171,7 +171,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint32StoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint32 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -195,7 +195,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint64StoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint64 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -219,7 +219,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt8StoredInAJsonThenParsingIsSuccessfulAnd
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int8 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -243,7 +243,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt16StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int16 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -267,7 +267,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt32StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int32 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -291,7 +291,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt64StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int64 data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -314,7 +314,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAFloatStoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of float data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -338,7 +338,7 @@ TYPED_TEST_P(NumberTest, WhenParsingADoubleStoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of double data-type, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 

--- a/score/json/internal/parser/parsers_test_suite.h
+++ b/score/json/internal/parser/parsers_test_suite.h
@@ -86,7 +86,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectBool)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse boolean value from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -105,7 +105,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectString)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse string value from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -124,7 +124,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectNull)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse Null value from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -143,7 +143,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectNumber)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse uint64_t value from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -162,7 +162,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectFloatingPointNumber)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse float value from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -186,7 +186,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectInObject)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse an object from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -205,7 +205,7 @@ TYPED_TEST_P(ParserTest, CanParseListInObject)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse a list from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -227,7 +227,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectInObjectAndIterateOverKeys)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "parse an object where the keys are unknown to the program, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "1");
 
@@ -277,7 +277,7 @@ TYPED_TEST_P(ParserTest, EmitsErrorWhenParsingObjectWithValueButNoKey)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "failure in parsing an object with no keys, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
 
@@ -299,7 +299,7 @@ TYPED_TEST_P(ParserTest, EmitsErrorWhenParsingObjectWithBinaryValue)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "failure in parsing an object with binary value element, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
 
@@ -333,7 +333,7 @@ TYPED_TEST_P(ParserTest, EmitsErrorWhenParsingTooLargeNumber)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
                          "failure in parsing an object with very large value element, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
 
@@ -352,7 +352,7 @@ TYPED_TEST_P(ParserTest, FromFileFail)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Invalid file path returns error");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
     // Pass invalid file path
@@ -366,7 +366,7 @@ TYPED_TEST_P(ParserTest, ParsingFromFileWorks)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Verifies that parsing JSON from a file works correctly");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
     // Given a simple JSON File

--- a/score/json/internal/parser/vajson/number_parser_test.cpp
+++ b/score/json/internal/parser/vajson/number_parser_test.cpp
@@ -56,7 +56,7 @@ TEST(Number, Bool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of bool data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<bool>("-1", "2");
@@ -68,7 +68,7 @@ TEST(Number, Uint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint8 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::uint8_t>("-1", "256");
@@ -80,7 +80,7 @@ TEST(Number, Uint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint16 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::uint16_t>("-1", "65536");
@@ -92,7 +92,7 @@ TEST(Number, Uint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint32 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::uint32_t>("-1", "4294967296");
@@ -104,7 +104,7 @@ TEST(Number, Uint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint64 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::uint64_t>("-1", "18446744073709551616");
@@ -116,7 +116,7 @@ TEST(Number, Int8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int8 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::int8_t>("-129", "128");
@@ -128,7 +128,7 @@ TEST(Number, Int16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int16 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::int16_t>("-32769", "32768");
@@ -140,7 +140,7 @@ TEST(Number, Int32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int32 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::int32_t>("-2147483649", "2147483648");
@@ -152,7 +152,7 @@ TEST(Number, Int64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int64 data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<std::int64_t>("-9223372036854775809", "9223372036854775808");
@@ -164,7 +164,7 @@ TEST(Number, Float)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of float data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<float>("-3.402823476385288598117e+38", "3.402823476385288598117e+38");
@@ -176,7 +176,7 @@ TEST(Number, Double)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of double data-type, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     range_test<double>("-1.797693134862415708145e+308", "1.797693134862415708145e+308");
@@ -188,7 +188,7 @@ TEST(Number, WithDecimalPointWithoutFractionalPartCannotBeParsedAsInteger)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test interpreting number with decimal point as floating point only, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Tolerated behavior of vajson that interprets any number with decimal point as floating point only.
@@ -201,7 +201,7 @@ TEST(Number, WithExponentialNotationWithoutFractionalPartCannotBeParsedAsInteger
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Test interpreting number with exponent notation as floating point only, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Tolerated behavior of vajson that interprets any number with exponent notation as floating point only.
@@ -215,7 +215,7 @@ TEST(Number, FloatingPointWithoutDecimalPoint)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Number without decimal point can be treated as floating point too, cf. RFC-8259 section 9");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(ParseNumberAs<float>("-18446744073709551615").value_or(-999), -18446744073709551615.0f);

--- a/score/json/internal/parser/vajson/vajson_parser_test.cpp
+++ b/score/json/internal/parser/vajson/vajson_parser_test.cpp
@@ -29,7 +29,7 @@ TEST(VajsonParser, CanParseObjectHexadecimalNumber)
     this->RecordProperty("Verifies", "SCR-5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse hex value from json buffer, cf. RFC-8259 section 9");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string buffer_json_hex{R"(

--- a/score/json/internal/writer/json_serialize/json_serialize_test.cpp
+++ b/score/json/internal/writer/json_serialize/json_serialize_test.cpp
@@ -39,7 +39,7 @@ TEST(JsonSerializeTest, SerializeString)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with string elements and serializing it, cf. RFC-8259 section 7");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -60,7 +60,7 @@ TEST(JsonSerializeTest, SerializeStringWithSpecialChars)
     RecordProperty("Description",
                    "constructing json object with string elements and serializing it, cf. RFC-8259 section 7 "
                    "considering special characters");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string expected_json_string{R"({
@@ -80,7 +80,7 @@ TEST(JsonSerializeTest, SerializeInt8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Int8 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -106,7 +106,7 @@ TEST(JsonSerializeTest, SerializeInt16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Int16 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -132,7 +132,7 @@ TEST(JsonSerializeTest, SerializeInt32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Int32 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -158,7 +158,7 @@ TEST(JsonSerializeTest, SerializeInt64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Int64 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -184,7 +184,7 @@ TEST(JsonSerializeTest, SerializeUint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Uint8 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -207,7 +207,7 @@ TEST(JsonSerializeTest, SerializeUint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Uint16 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -230,7 +230,7 @@ TEST(JsonSerializeTest, SerializeUint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Uint32 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -253,7 +253,7 @@ TEST(JsonSerializeTest, SerializeUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Uint64 elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -276,7 +276,7 @@ TEST(JsonSerializeTest, SerializeFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with float elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::ostringstream string_stream{};
@@ -306,7 +306,7 @@ TEST(JsonSerializeTest, SerializeDouble)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with double elements and serializing it, cf. RFC-8259 section 6");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::ostringstream string_stream{};
@@ -336,7 +336,7 @@ TEST(JsonSerializeTest, SerializeBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with bool elements and serializing it, cf. RFC-8259 section 3");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -356,7 +356,7 @@ TEST(JsonSerializeTest, SerializeNull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with Null element and serializing it, cf. RFC-8259 section 3");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -374,7 +374,7 @@ TEST(JsonSerializeTest, SerializeMultipleTypes)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with multiple types elements and serializing it, cf. RFC-8259 section 3");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::ostringstream string_stream{};
@@ -403,7 +403,7 @@ TEST(JsonSerializeTest, SerializeList)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with list of elements and serializing it, cf. RFC-8259 section 5");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"([
@@ -423,7 +423,7 @@ TEST(JsonSerializeTest, SerializeEmptyList)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with empty list and serializing it, cf. RFC-8259 section 5");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"([
@@ -439,7 +439,7 @@ TEST(JsonSerializeTest, SerializeEmptyObject)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "constructing json object with empty object and serializing it, cf. RFC-8259 section 3");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"({
@@ -457,7 +457,7 @@ TEST(JsonSerializeTest, SerializeNestedObjectAndList)
     RecordProperty(
         "Description",
         "constructing json object with nested object and list and serializing it, cf. RFC-8259 section 4 and 5");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string input_json{R"([
@@ -493,7 +493,7 @@ TEST(JsonSerializeAnyTest, SerializeAny)
     RecordProperty("Verifies", "5310867");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test serializing json::Any with all type variants, cf. RFC-8259 section 3-7");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::vector<std::pair<std::string, score::json::Any>> v;

--- a/score/json/json_serializer_test.cpp
+++ b/score/json/json_serializer_test.cpp
@@ -112,7 +112,7 @@ STRUCT_VISITABLE(TypeToSerialize, integer_val, string_val, nested_val)
 
 TEST(JsonSerializerTest, TestSerialization)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::ToJsonAny");
     RecordProperty("Description", "Test the serialization of a visitable structure and all its contents");
     RecordProperty("ASIL", "QM");
@@ -166,7 +166,7 @@ TEST(JsonSerializerTest, TestSerialization)
 
 TEST(JsonSerializerTest, TestDeserialization)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description", "Test the deserialization of a visitable structure and all its contents");
     RecordProperty("ASIL", "QM");
@@ -200,7 +200,7 @@ TEST(JsonSerializerTest, TestDeserialization)
 
 TEST(JsonSerializerTest, TestFailingDeserialization)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description",
                    "Check whether the deserialization of a JSON that does not match a visitable structure fails with "
@@ -239,7 +239,7 @@ STRUCT_VISITABLE(TypeWithCustomSerializable, custom_type)
 
 TEST(JsonSerializerTest, UserProvidedDeserialization)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description",
                    "Test that the deserialization of a struct works that defines a custom deserialization scheme");
@@ -264,7 +264,7 @@ TEST(JsonSerializerTest, UserProvidedDeserialization)
 
 TEST(JsonSerializerTest, UserProvidedSerialization)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::ToJsonAny");
     RecordProperty("Description",
                    "Test that the serialization of a struct works that defines a custom serialization scheme");
@@ -298,7 +298,7 @@ STRUCT_VISITABLE(TypeWithOptionalValue, mandatory_val, never_ever_val, optional_
 
 TEST(JsonSerializerTest, DeserializeOptionalFields)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty(
         "Description",
@@ -328,7 +328,7 @@ TEST(JsonSerializerTest, DeserializeOptionalFields)
 
 TEST(JsonSerializerTest, NoErrorOnMissingOptionalFields)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty(
         "Description",
@@ -358,7 +358,7 @@ TEST(JsonSerializerTest, NoErrorOnMissingOptionalFields)
 
 TEST(JsonSerializerTest, ErrorOnMissingMandatoryFields)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty(
         "Description",
@@ -386,7 +386,7 @@ TEST(JsonSerializerTest, ErrorOnMissingMandatoryFields)
 
 TEST(JsonSerializerTest, SerializingStructWithUnusedOptionalDoesntEmitField)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::ToJsonAny");
     RecordProperty(
         "Description",
@@ -520,7 +520,7 @@ TEST(JsonSerializerTest, FailToDeserializeANonNumberTypeToAnInteger)
 
 TEST(JsonSerializerTest, FailToDeserializeToVectorIfJSONIsNotAList)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description",
                    "Verify that deserializing a vector will fail if the JSON does not contain an array as the value "
@@ -564,7 +564,7 @@ TEST(JsonSerializerTest, FailToDeserializeIntoAVectorIfJSONListHasMixedTypes)
 
 TEST(JsonSerializerTest, SucceedDeserializeListIntoVectorIfListConsistsOfSameType)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description",
                    "Verify that deserializing a vector of numbers works if the JSON list contains only integers");
@@ -585,7 +585,7 @@ TEST(JsonSerializerTest, SucceedDeserializeListIntoVectorIfListConsistsOfSameTyp
 
 TEST(JsonSerializerTest, SuceedDeserializeListIntoVectorOfAnyEvenOnMixedTypes)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description",
                    "Verify that deserializing a vector of Any works even if the JSON list contains mixed types");
@@ -612,7 +612,7 @@ TEST(JsonSerializerTest, SuceedDeserializeListIntoVectorOfAnyEvenOnMixedTypes)
 
 TEST(JsonSerializerTest, SerializeOptionalValuesIfTheyContainAValue)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::ToJsonAny");
     RecordProperty("Description", "Verify that optional values are added as JSON object keys if they contain a value");
     RecordProperty("ASIL", "QM");
@@ -636,7 +636,7 @@ TEST(JsonSerializerTest, SerializeOptionalValuesIfTheyContainAValue)
 
 TEST(JsonSerializerTest, FailToDeserializeOptionalValueIfEnclosedTypesDoNotMatch)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("Description",
                    "Verify that deserializing an optional value fails if the enclosed type does not match");
@@ -657,7 +657,7 @@ TEST(JsonSerializerTest, FailToDeserializeOptionalValueIfEnclosedTypesDoNotMatch
 
 TEST(JsonSerializerTest, SerializeConstantObjects)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::json::ToJsonAny");
     RecordProperty("Description", "Verify that constant objects can be serialized");
     RecordProperty("ASIL", "QM");
@@ -701,7 +701,7 @@ TEST(JsonSerializerTest, SerializeConstantObjects)
 
 TEST(JsonSerializerTest, UseCustomSerializationOnVisitableStruct)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "JsonSerializer");
     RecordProperty("Description",
                    "This test verifies that the custom serialization function of a struct is used, even if the struct "

--- a/score/json/json_serializer_test.cpp
+++ b/score/json/json_serializer_test.cpp
@@ -410,7 +410,7 @@ TEST(JsonSerializerTest, SerializingStructWithUnusedOptionalDoesntEmitField)
 
 TEST(JsonSerializerTest, DeserializingStructFromNonObjectFails)
 {
-    RecordProperty("TestType", "Verification of the control flow and data flow");
+    RecordProperty("TestType", "data-flow-analysis");
     RecordProperty("Description",
                    "Verify that deserializing a struct does not work if the JSON is not an object but a number");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
@@ -431,7 +431,7 @@ TEST(JsonSerializerTest, DeserializingStructFromNonObjectFails)
 
 TEST(JsonSerializerTest, FailToDeserializeWrongNumberType)
 {
-    RecordProperty("TestType", "Verification of the control flow and data flow");
+    RecordProperty("TestType", "data-flow-analysis");
     RecordProperty(
         "Description",
         "Verify that deserializing an attribute of an integer type fails if the JSON instead contains a float number");
@@ -461,7 +461,7 @@ TEST(JsonSerializerTest, FailToDeserializeWrongNumberType)
 
 TEST(JsonSerializerTest, FailToDeserializeANonBooleanTypeToBool)
 {
-    RecordProperty("TestType", "Verification of the control flow and data flow");
+    RecordProperty("TestType", "data-flow-analysis");
     RecordProperty("Description",
                    "Verify that deserializing an attribute of a bool type fails if the JSON instead contains a string");
     RecordProperty("Verifies", "::score::json::FromJsonAny");
@@ -490,7 +490,7 @@ TEST(JsonSerializerTest, FailToDeserializeANonBooleanTypeToBool)
 
 TEST(JsonSerializerTest, FailToDeserializeANonNumberTypeToAnInteger)
 {
-    RecordProperty("TestType", "Verification of the control flow and data flow");
+    RecordProperty("TestType", "data-flow-analysis");
     RecordProperty("Description",
                    "Verify that deserializing an attribute of an integer type fails if the JSON instead contains a "
                    "string");
@@ -542,7 +542,7 @@ TEST(JsonSerializerTest, FailToDeserializeToVectorIfJSONIsNotAList)
 
 TEST(JsonSerializerTest, FailToDeserializeIntoAVectorIfJSONListHasMixedTypes)
 {
-    RecordProperty("TestType", "Verification of the control flow and data flow");
+    RecordProperty("TestType", "data-flow-analysis");
     RecordProperty("Description",
                    "Verify that deserializing a vector of numbers won't work in case the JSON list contains other "
                    "entries than integers");

--- a/score/json/json_test.cpp
+++ b/score/json/json_test.cpp
@@ -20,7 +20,7 @@ TEST(JsonTest, ReadWrite)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Create Json object with different attributes, write it to a buffer, then read it successfully.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     score::json::Object json{};

--- a/score/json/json_writer_test.cpp
+++ b/score/json/json_writer_test.cpp
@@ -112,7 +112,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToBuffer)
     this->RecordProperty("Verifies", "::score::json::JsonWriter::ToBuffer");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
-    this->RecordProperty("TestType", "Interface test");
+    this->RecordProperty("TestType", "interface-test");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -128,7 +128,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToFile)
     this->RecordProperty("Verifies", "::score::json::JsonWriter::ToFile");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
-    this->RecordProperty("TestType", "Interface test");
+    this->RecordProperty("TestType", "interface-test");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -147,7 +147,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToUnsyncedFile)
     this->RecordProperty("Verifies", "::score::json::JsonWriter::ToFile");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
-    this->RecordProperty("TestType", "Interface test");
+    this->RecordProperty("TestType", "interface-test");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -165,7 +165,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToSyncedFile)
     this->RecordProperty("Verifies", "::score::json::JsonWriter::ToFile");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
-    this->RecordProperty("TestType", "Interface test");
+    this->RecordProperty("TestType", "interface-test");
     this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
     this->RecordProperty("Priority", "3");
 
@@ -184,7 +184,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToUnsyncedFileResultsInError)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Invalid file path returns error when writing unsynced file");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
 
@@ -206,7 +206,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToSyncedFileResultsInError)
     this->RecordProperty("Verifies", "5310867");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Invalid file path returns error when writing with atomic update");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
     this->RecordProperty("Priority", "3");
 

--- a/score/memory/shared/memory_resource_proxy_test.cpp
+++ b/score/memory/shared/memory_resource_proxy_test.cpp
@@ -120,7 +120,7 @@ TEST_F(MemoryResourceManagerDeathTest, ProperHandleNonExistingMemoryResource)
     RecordProperty("Verifies", "SCR-6223631");
     RecordProperty("Description",
                    "The MemoryRessourceProxy shall store its identifier in a way, that it can detect corruptions.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -184,7 +184,7 @@ TEST_F(BoundCheckedMemoryResourceManagerDeathTest, AllocationTerminatesWhenProxy
     RecordProperty("Verifies", "SCR-6223631");
     RecordProperty("Description",
                    "The MemoryRessourceProxy shall store its identifier in a way, that it can detect corruptions.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 

--- a/score/memory/shared/shared_memory_factory_test.cpp
+++ b/score/memory/shared/shared_memory_factory_test.cpp
@@ -271,7 +271,7 @@ TEST_P(SharedMemoryFactoryTest, SharedMemoryResourceIsCreatedWithCorrectPath)
     RecordProperty("Verifies", "SCR-6223575");
     RecordProperty("Description",
                    "The SharedMemoryFactory shall return the Shared Memory Resource associated with the given path.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -305,7 +305,7 @@ TEST_F(SharedMemoryFactoryTest, SharedMemoryResourceFallbackToSystemMemory)
     RecordProperty("Verifies", "SCR-6223575");
     RecordProperty("Description",
                    "The SharedMemoryFactory shall return the Shared Memory Resource associated with the given path.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -345,7 +345,7 @@ TEST_F(SharedMemoryFactoryTest, SharedMemoryResourceIsOpenedWithCorrectPath)
     RecordProperty("Verifies", "SCR-6223575");
     RecordProperty("Description",
                    "The SharedMemoryFactory shall return the Shared Memory Resource associated with the given path.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -475,7 +475,7 @@ TEST_F(SharedMemoryFactoryTest, AllowsAccessToMatchingProvidersPreventsNonMatchi
     RecordProperty("Description",
                    "Checks that SharedMemoryFactory::Open will return a nullptr if the provided of the "
                    "SharedMemoryResource to be opened is not in the passed list of allowed providers.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 

--- a/score/memory/shared/shared_memory_resource_allocate_test.cpp
+++ b/score/memory/shared/shared_memory_resource_allocate_test.cpp
@@ -45,7 +45,7 @@ TEST_F(SharedMemoryResourceAllocateTest, AssociatedMemoryResourceProxyForwardsCa
     RecordProperty("Description",
                    "The SharedMemoryResource shall return an associated proxy and allocate calls will allocate the "
                    "requested memory.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -76,7 +76,7 @@ TEST_F(SharedMemoryResourceAllocateTest, SharedMemoryResourceAllocatesAlignedMem
     RecordProperty(
         "Description",
         "SharedMemoryResource shall allocate memory in accordance to the alignment of that CPU architecture.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -112,7 +112,7 @@ TEST_F(SharedMemoryResourceAllocateTest,
     RecordProperty(
         "Description",
         "SharedMemoryResource shall allocate memory in accordance to the alignment of that CPU architecture.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -206,7 +206,7 @@ TEST_F(SharedMemoryResourceAllocateDeathTest, AllocatingBlockLargerThanAllocated
     RecordProperty("Verifies", "SCR-6240703");
     RecordProperty("Description",
                    "The process shall terminate when the SharedMemoryResource cannot allocate the requested memory.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 

--- a/score/memory/shared/shared_memory_resource_create_test.cpp
+++ b/score/memory/shared/shared_memory_resource_create_test.cpp
@@ -85,7 +85,7 @@ TEST_F(SharedMemoryResourceCreateTest, CreateSharedMemoryFreesResourcesOnDestruc
 {
     RecordProperty("Verifies", "SCR-6367126");
     RecordProperty("Description", "SharedMemoryResource shall free resources only on destruction.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -610,7 +610,7 @@ TEST_F(SharedMemoryResourceCreateDeathTest, UnableToTruncateSharedMemoryCausesTe
 {
     RecordProperty("Verifies", "SCR-6240638");
     RecordProperty("Description", "A process shall terminate, if the truncation of a shared memory segment fails.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 

--- a/score/memory/shared/shared_memory_resource_open_test.cpp
+++ b/score/memory/shared/shared_memory_resource_open_test.cpp
@@ -45,7 +45,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpensSharedMemoryReadOnlyByDefault)
     RecordProperty(
         "Description",
         "Can open shared memory segment read-only. Only opens shared memory segment provided in constructor.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -65,7 +65,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpeningSharedMemoryFreesResourcesOnDestruct
 {
     RecordProperty("Verifies", "SCR-6367126");
     RecordProperty("Description", "SharedMemoryResource shall free resources only on destruction.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -114,7 +114,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpensSharedMemoryWillWaitUntilLockFileIsGon
 {
     RecordProperty("Verifies", "SCR-5899175");
     RecordProperty("Description", "Can open shared memory segment read-only after a lock was created");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -171,7 +171,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpensSharedMemoryReadWrite)
     RecordProperty(
         "Description",
         "Can open shared memory segment read-write. Only opens shared memory segment provided in constructor.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -192,7 +192,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpeningResourceThatDoesNotExistWillReturnEr
     RecordProperty("Verifies", "SCR-32158471");
     RecordProperty("Description",
                    "Checks that Open will return an error when the underlying resource cannot be found.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -220,7 +220,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpeningResourceWithoutTheRequiredACLsWillRe
     RecordProperty("Description",
                    "Checks that Open will return an error when the process doesn't have the correct permissions to "
                    "open the underlying resource.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 

--- a/score/memory/shared/test_offset_ptr/bounds_check_test.cpp
+++ b/score/memory/shared/test_offset_ptr/bounds_check_test.cpp
@@ -182,7 +182,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, DereferencingOffsetPtrReturnsCorrectValue)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that dereferencing performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -202,7 +202,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, GettingOffsetPtr)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling get() performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -222,7 +222,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, GettingOffsetPtrWithTypedGet)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling typed get() performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -242,7 +242,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, GettingOffsetPtrWithSizedGet)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling get() that accepts size as argument performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -301,7 +301,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, DereferencingOffsetPtrTerminates)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that dereferencing performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -319,7 +319,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, OffsetPtrGetTerminates)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling get() performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -337,7 +337,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, OffsetPtrTypedGetTerminates)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling typed get() performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -355,7 +355,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, OffsetPtrSizedGetTerminates)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling get() that takes size as argument performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
@@ -386,7 +386,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, ArrowOperatorTerminates)
 {
     RecordProperty("Verifies", "SCR-5899238");
     RecordProperty("Description", "Checks that calling get() performs bounds checking");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 

--- a/score/mw/log/configuration/configuration_file_discoverer_test.cpp
+++ b/score/mw/log/configuration/configuration_file_discoverer_test.cpp
@@ -132,7 +132,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindGlobalConfiguratio
     RecordProperty("Requirement", "SCR-1634075");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the discoverer shall find the global configuration file.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -151,7 +151,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty(
         "Description",
         "Verifies that the discoverer shall find the application specific configuration file under <cwd>/etc.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -172,7 +172,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies that the discoverer shall find the application specific configuration file under <cwd>.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -193,7 +193,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty(
         "Description",
         "Verifies that the discoverer shall find the application specific configuration file under the binary path.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -216,7 +216,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty("Description",
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -237,7 +237,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty("Description",
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path. The <cwd>/etc. path should be ignored");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -259,7 +259,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty("Description",
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path. The <cwd> path should be ignored");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -281,7 +281,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty("Description",
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path. The binary path should be ignored");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When ...
@@ -301,7 +301,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallReturnEmptyIfNothingEx
     RecordProperty("Requirement", "SCR-1633294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the discoverer shall return an empty list if no config file exists.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When no file exists then ...
@@ -314,7 +314,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallReturnEmptyIfExecPathF
     RecordProperty("Requirement", "SCR-1633294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the discoverer shall return an empty list if an error occurs.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When...

--- a/score/mw/log/configuration/configuration_test.cpp
+++ b/score/mw/log/configuration/configuration_test.cpp
@@ -30,7 +30,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsBelowThresho
     RecordProperty("Requirement", "SCR-1633254");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log message shall be enabled if the log level is below the threshold.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -46,7 +46,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsEqualThresho
     RecordProperty("Requirement", "SCR-1633254");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log message shall be enabled if the log level is equal to the threshold.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -62,7 +62,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnFalseIfLogLevelIsAboveThresh
     RecordProperty("Requirement", "SCR-1633254");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log message shall be disabled if the log level is above to the threshold.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -79,7 +79,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsAboveOrEqual
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "The log message shall be enabled if the log level is equal to the default log level threshold.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -95,7 +95,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnFalseIfLogLevelIsBelowDefaul
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "The log message shall be disabled if the log level is below the default log level threshold.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -113,7 +113,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsAboveOrEqual
         "Description",
         "The log message for the console shall be enabled if the log level is equal to the default log level "
         "threshold for the console.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -130,7 +130,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnFalseIfLogLevelIsBelowDefaul
     RecordProperty("Description",
                    "The log message shall be disabled for the console if the log level is below the default log level "
                    "threshold for the console.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -145,7 +145,7 @@ TEST(ConfigurationTestSuite, AppidWithMoreThanFourCharactersShallBeTruncated)
     RecordProperty("Requirement", "SCR-1633316");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The application identifier shall be limited to four characters.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};
@@ -159,7 +159,7 @@ TEST(ConfigurationTestSuite, EcuidWithMoreThanFourCharactersShallBeTruncated)
     RecordProperty("Requirement", "SCR-1633316");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The ECU identifier shall be limited to four characters.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     Configuration config{};

--- a/score/mw/log/configuration/nvconfig_test.cpp
+++ b/score/mw/log/configuration/nvconfig_test.cpp
@@ -97,7 +97,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsExpectedValues)
     RecordProperty("Requirement", "SCR-1633147");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Logging libraries use static configuration based on .json files.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     auto result = NvConfigFactory::CreateAndInit(JSON_PATH());
     ASSERT_TRUE(result.has_value());  // Verify config was created successfully
@@ -128,7 +128,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsExpectedValuesWithOtherFile)
     RecordProperty("Requirement", "SCR-1633147");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Logging libraries use static configuration based on .json files.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(JSON_PATH_2());
@@ -164,7 +164,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorOpenWhenGivenEmptyFile)
     RecordProperty("Requirement", "SCR-1633147, SCR-7263548");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of parsing a general empty file.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(EMPTY_FILE());
@@ -177,7 +177,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorOpenWhenGivenPathToNonExistentFile)
     RecordProperty("Requirement", "SCR-1633147, SCR-7263537");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ara::log shall discard configuration files that are not found.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(WRONG_JSON_PATH());
@@ -190,7 +190,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsOkWhenGivenEmptyJsonFile)
     RecordProperty("Requirement", "SCR-1633147, SCR-7263548");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of parsing an empty JSON file.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(EMPTY_JSON());
@@ -203,7 +203,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorParseIfEmptyObject)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies the inability of parsing JSON file that has array instead of JSON object as a root node.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(EMPTY_JSON_OBJECT());
@@ -216,7 +216,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorParseIfThereIsSomethingElseInstedOf
     RecordProperty("Requirement", "SCR-1633147, SCR-7263548");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of parsing a JSON file that does not have object as value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_PARSE_1_PATH());
@@ -231,7 +231,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorContentIfCtxidValuePairDoesntExists
     RecordProperty(
         "Description",
         "Verifies the inability of parsing JSON file that misses ctxid key-value pair for one of the objects.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_1_PATH());
@@ -246,7 +246,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorContentIfAppidValuePairDoesntExists
     RecordProperty(
         "Description",
         "Verifies the inability of parsing JSON file that misses appid key-value pair for one of the objects.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_2_PATH());
@@ -260,7 +260,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorContentIfIdValuePairDoesntExistsFor
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies the inability of parsing JSON file that misses id key-value pair for one of the objects.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_3_PATH());
@@ -273,7 +273,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorIfIdDataTypeIsWrong)
     RecordProperty("Requirement", "SCR-1633147, SCR-7263548");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of parsing JSON file that has wrong id value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_WRONG_ID_VALUE());

--- a/score/mw/log/configuration/target_config_reader_test.cpp
+++ b/score/mw/log/configuration/target_config_reader_test.cpp
@@ -155,7 +155,7 @@ TEST_F(TargetConfigReaderFixture, NoConfigFilesShallFail)
     RecordProperty("Requirement", "SCR-7263537, SCR-7263552");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall return an error if no configuration files are found");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // For the case that no configuration files exist.
@@ -171,7 +171,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseEcuIdFromEcuConfig)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "TargetConfigReader shall parse the DLT ECU ID from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetEcuId(), kEcuConfigEcuId);
@@ -183,7 +183,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseAppIdFromAppConfig)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "TargetConfigReader shall parse the DLT Application ID from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetAppId(), kAppConfigAppId);
@@ -196,7 +196,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogLevelFromAppConfig)
     RecordProperty(
         "Description",
         "TargetConfigReader shall parse the DLT Application log level from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDefaultLogLevel(), kAppConfigLogLevel);
@@ -208,7 +208,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogModeFromAppConfig)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "TargetConfigReader shall parse the logging mode from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetLogMode(), kAppConfigLogMode);
@@ -220,7 +220,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseAppDescriptionFromAppCon
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "TargetConfigReader shall parse the application description from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetAppDescription(), kAppDescription);
@@ -233,7 +233,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseBufferOverwriteOnFullSta
     RecordProperty(
         "Description",
         "TargetConfigReader shall parse the overwrite ring buffer option from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_TRUE(GetReader().ReadConfig()->GetRingBufferOverwriteOnFull());
@@ -246,7 +246,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseStackBufferSizeFromEcuCo
     RecordProperty(
         "Description",
         "TargetConfigReader shall parse the stack buffer size in shared memory from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetStackBufferSize(), kEcuConfigStackBufferSize);
@@ -259,7 +259,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseRingBufferSizeFromEcuCon
     RecordProperty(
         "Description",
         "TargetConfigReader shall parse the ring buffer size in shared memory from the configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetRingBufferSize(), kEcuConfigRingBufferSize);
@@ -272,7 +272,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogLevelConsoleFromEcuCo
     RecordProperty("Description",
                    "TargetConfigReader shall parse the default log level threshold for console logging from the "
                    "configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDefaultConsoleLogLevel(), kEcuConfigLogLevelConsole);
@@ -285,7 +285,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogFilePathFromAppConfig
     RecordProperty("Description",
                    "TargetConfigReader shall parse the default log file path for console logging from the "
                    "configuration file correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetLogFilePath(), kAppConfigLogFilePath);
@@ -298,7 +298,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseContextLogLevelFromEcuAn
     RecordProperty("Description",
                    "TargetConfigReader shall parse and combine the context log levels from the "
                    "configuration files correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetContextLogLevel(), kCombinedContextLogLevel);
@@ -309,7 +309,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseNumberOfSlots)
     RecordProperty("Requirement", "SCR-1633316");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall parse the number of slots for preallocation correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetNumberOfSlots(), kNumberOfSlots);
@@ -320,7 +320,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseSlotSizeBytes)
     RecordProperty("Requirement", "SCR-1633316");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall parse the size of the slots for preallocation correctly.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetSlotSizeInBytes(), kSlotSizeBytes);
@@ -332,7 +332,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseDynamicDatarouterIdentif
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "TargetConfigReader shall parse if datarouter dyanmic identifiers flag is enabled or not.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDynamicDatarouterIdentifiers(), kDynamicDatarouterIdentifiers);
@@ -343,7 +343,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseDataRouterUid)
     RecordProperty("Requirement", "SCR-1633316");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall parse datarouter user ID.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDataRouterUid(), kDatarouterUid);
@@ -356,7 +356,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigSyntaxErrorShallFallbackToEcuConfig)
     RecordProperty(
         "Description",
         "TargetConfigReader fall back to the ECU config file if the application config files contains syntax errors.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config contains a syntax error.
@@ -373,7 +373,7 @@ TEST_F(TargetConfigReaderFixture, WrongStructureConfigFileShallCauseDefaultAppId
     RecordProperty("Description",
                    "TargetConfigReader fall back to the hard-coded default application id if the configuration file "
                    "does not contain a valid JSON structure");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config has wrong structure.
@@ -390,7 +390,7 @@ TEST_F(TargetConfigReaderFixture, WrongLogLevelValueShallFallbackToEcuConfig)
     RecordProperty("Description",
                    "TargetConfigReader fall back to the ECU config file if the if the logLevelThresholdConsole "
                    "has wrong value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config has wrong structure.
@@ -407,7 +407,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigInvalidLogLevelFallbackToEcuConfig)
     RecordProperty("Description",
                    "TargetConfigReader fall back to the valid value from the ECU configuration file if the application "
                    "config file contains an invalid log level.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config contains invalid default log level.
@@ -424,7 +424,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigInvalidLogModeFallbackToEcuConfig)
     RecordProperty("Description",
                    "TargetConfigReader fall back to the valid value from the ECU configuration file if the application "
                    "config file contains an invalid log mode.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config contains invalid log mode.
@@ -441,7 +441,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigInvalidContextConfigFallbackToEcuConf
     RecordProperty("Description",
                    "TargetConfigReader fall back to the valid value from the ECU configuration file if the application "
                    "config file contains an invalid log level for a context.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config contains invalid context log level entries.
@@ -457,7 +457,7 @@ TEST_F(TargetConfigReaderFixture, WrongEntriesToContextConfigslShallReturnEmptyC
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "TargetConfigReader shall return empty context config log level when providing wrong entries.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config contains invalid context config entries.
@@ -474,7 +474,7 @@ TEST_F(TargetConfigReaderFixture, WhenInvalidFilePathReaderShallReturnDefaultApp
     RecordProperty("Description",
                    "TargetConfigReader fall back to the hard-coded default application id if the configuration file "
                    "does not exist");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config does not exist
@@ -491,7 +491,7 @@ TEST_F(TargetConfigReaderFixture, EmptyConfigFileShallCauseDefaultAppId)
     RecordProperty("Description",
                    "TargetConfigReader fall back to the hard-coded default application id if the configuration file "
                    "does not contain any value");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // The application config does not exist
@@ -508,7 +508,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallFallBackToContextLogLevelDefa
     RecordProperty("Description",
                    "TargetConfigReader fall back to the hard-coded default context log level values if there is no "
                    "valid value in the configuration files");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     SetConfigurationFiles({kCtxLevelBrokenConfigFile()});

--- a/score/mw/log/detail/circular_allocator_test.cpp
+++ b/score/mw/log/detail/circular_allocator_test.cpp
@@ -52,7 +52,7 @@ TEST_F(CircularAllocatorFixture, WriteSingleEntryWithoutThreads)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Writing into the circular allocator shall succeed if there are multiple free slots.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a Ring-Buffer with enough space
@@ -69,7 +69,7 @@ TEST_F(CircularAllocatorFixture, WriteSingleEntryWithoutThreadsWithSingleSlotCap
     RecordProperty("Requirement", "SCR-861534, SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Writing into the circular allocator shall succeed if a single slot is free.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a Ring-Buffer with enough space
@@ -88,7 +88,7 @@ TEST_F(CircularAllocatorFixture, WriteSingleThreadedOverBufferSize)
     RecordProperty("Description",
                    "When writing more slots in the circular allocator than capacity, the write to the next slot shall "
                    "wrap around and succeed.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Overview of the expected storage layout:
@@ -120,7 +120,7 @@ TEST_F(CircularAllocatorFixture, WritingFromMultipleThreadsIsSafe)
         "When writing to the CircularAllocator from multiple threads and each thread shall occupy one slot at a time "
         "every slot allocation from every thread shall succeed if the number of threads is equal the "
         "number of slots.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a Ring-Buffer
@@ -152,7 +152,7 @@ TEST_F(CircularAllocatorFixture, WritingFromMultipleThreadsIsSafeWithInsufficien
     RecordProperty("Description",
                    "When writing to CircularAllocator with multiple threads in parallel and trying to allocate more "
                    "slots than capacity, the number of reserved slots shall be equal to the capacity.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a Ring-Buffer
@@ -192,7 +192,7 @@ TEST_F(CircularAllocatorFixture, TryAcquireWhenAllSlotsAcquired)
     RecordProperty("Requirement", "SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "When every slot is occupied acquiring another slot shall return an empty result.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a Ring-Buffer where all slots are acquired

--- a/score/mw/log/detail/dlt_argument_counter_test.cpp
+++ b/score/mw/log/detail/dlt_argument_counter_test.cpp
@@ -28,7 +28,7 @@ TEST(DltArgumentCounterShould, IncreaseCounter)
     RecordProperty("Requirement", "SCR-1633144");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DltArgumentCounter should increase counter when an argument is added");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     uint8_t counter = 0;
@@ -44,7 +44,7 @@ TEST(DltArgumentCounterShould, NotIncreaseCounterBecauseArgumentNotAdded)
     RecordProperty("Requirement", "SCR-1633144");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DltArgumentCounter should not increase counter when no argument is added");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     uint8_t counter = 0;
@@ -60,7 +60,7 @@ TEST(DltArgumentCounterShould, NotIncreaseCounterBecauseMaxCounterReached)
     RecordProperty("Requirement", "SCR-1633144");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DltArgumentCounter should not increase counter when the counter has maximum value");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     uint8_t counter = 255;
@@ -78,7 +78,7 @@ TEST(DltArgumentCounterShould, NotIncreaseCounterBecauseMaxCounterReachedAndNoAr
     RecordProperty(
         "Description",
         "DltArgumentCounter should not increase counter when the counter has maximum value and no argument is added");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     uint8_t counter = 255;

--- a/score/mw/log/detail/empty_recorder_test.cpp
+++ b/score/mw/log/detail/empty_recorder_test.cpp
@@ -36,7 +36,7 @@ TEST_F(EmptyRecorderFixture, StartRecord)
     RecordProperty("Requirement", "SCR-861534, SCR-1633144");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains StartRecord function for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.StartRecord("DFLT", LogLevel::kInfo);
@@ -47,7 +47,7 @@ TEST_F(EmptyRecorderFixture, StopRecord)
     RecordProperty("Requirement", "SCR-861534, SCR-1633144");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains StopRecord function for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.StopRecord(SlotHandle{});
@@ -58,7 +58,7 @@ TEST_F(EmptyRecorderFixture, LogBool)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log boolean for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, bool{});
@@ -69,7 +69,7 @@ TEST_F(EmptyRecorderFixture, LogUint8_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint8_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::uint8_t{});
@@ -80,7 +80,7 @@ TEST_F(EmptyRecorderFixture, LogInt8_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int8_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::int8_t{});
@@ -91,7 +91,7 @@ TEST_F(EmptyRecorderFixture, LogUint16_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint16_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::uint16_t{});
@@ -102,7 +102,7 @@ TEST_F(EmptyRecorderFixture, LogInt16_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int16_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::int16_t{});
@@ -113,7 +113,7 @@ TEST_F(EmptyRecorderFixture, LogUint32_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint32_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::uint32_t{});
@@ -124,7 +124,7 @@ TEST_F(EmptyRecorderFixture, LogInt32_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int32_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::int32_t{});
@@ -135,7 +135,7 @@ TEST_F(EmptyRecorderFixture, LogUint64_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint64_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::uint64_t{});
@@ -146,7 +146,7 @@ TEST_F(EmptyRecorderFixture, LogInt64_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int64_t for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::int64_t{});
@@ -157,7 +157,7 @@ TEST_F(EmptyRecorderFixture, LogFloat)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log float for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, float{});
@@ -168,7 +168,7 @@ TEST_F(EmptyRecorderFixture, LogDouble)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log double for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, double{});
@@ -179,7 +179,7 @@ TEST_F(EmptyRecorderFixture, LogStringView)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log string view for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, std::string_view{});
@@ -192,7 +192,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex8)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 8 bits with hex represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogHex8{});
@@ -205,7 +205,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex16)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 16 bits with hex represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogHex16{});
@@ -218,7 +218,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex32)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 32 bits with hex represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogHex32{});
@@ -231,7 +231,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex64)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 64 bits with hex represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogHex64{});
@@ -244,7 +244,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin8)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 8 bits with bin represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogBin8{});
@@ -257,7 +257,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin16)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 16 bits with bin represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogBin16{});
@@ -270,7 +270,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin32)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 32 bits with bin represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogBin32{});
@@ -283,7 +283,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin64)
     RecordProperty(
         "Description",
         "EmptyRecorder contains log function which can log 64 bits with bin represenataton for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogBin64{});
@@ -294,7 +294,7 @@ TEST_F(EmptyRecorderFixture, Log_LogRawBuffer)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log raw buffer for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogRawBuffer{nullptr, 0});
@@ -305,7 +305,7 @@ TEST_F(EmptyRecorderFixture, Log_LogSlog2Message)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "EmptyRecorder contains log function which can log LogSlog2Message for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     emptyRecorder.Log(SlotHandle{}, LogSlog2Message{11, "slog message"});
@@ -316,7 +316,7 @@ TEST_F(EmptyRecorderFixture, IsLogEnabledShallReturnValue)
     RecordProperty("Requirement", "SCR-861534, SCR-2592577");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains IsLogEnabled for testing purpose.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_FALSE(emptyRecorder.IsLogEnabled(LogLevel::kInfo, std::string_view{"DFLT"}));

--- a/score/mw/log/detail/error_test.cpp
+++ b/score/mw/log/detail/error_test.cpp
@@ -59,7 +59,7 @@ TEST_P(LogDetailErrorFixture, EachErrorShallReturnNonEmptyMessage)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of raising the error codes with a specific error message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error_code = ReturnError(GetParam());
@@ -70,7 +70,7 @@ TEST(LgDetailErrorUnknown, TestUnknownError)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of raising the error codes with a specific error message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error_code_out_of_range =

--- a/score/mw/log/detail/log_record_test.cpp
+++ b/score/mw/log/detail/log_record_test.cpp
@@ -54,7 +54,7 @@ TEST(LogRecord, LogRecordShallReturnExpectedLogEntry)
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can be constructed with max payload size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     LogRecord unit{kMaxPayloadSize};
@@ -66,7 +66,7 @@ TEST(LogRecord, LogRecordShallReturnExpectedVerbosePayload)
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide the expected verbose payload.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     LogRecord unit{kMaxPayloadSize};
@@ -78,7 +78,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallCopyAssignAndUpdateRe
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide copy assignment operator with valid state.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     LogRecord unit{kMaxPayloadSize};
@@ -95,7 +95,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallCopyConstructAndUpdat
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide copy constructor with valid state.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     score::cpp::optional<LogRecord> unit{};
@@ -112,7 +112,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallMoveAssignAndUpdateRe
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide move assigment operator with validstate.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     LogRecord unit{kMaxPayloadSize};
@@ -129,7 +129,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallMoveConstructAndUpdat
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide move constructor with valid state.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     score::cpp::optional<LogRecord> unit{};
@@ -146,7 +146,7 @@ TEST(LogRecord, SelfAssignmentShallNotModifyState)
     RecordProperty("Requirement", "SCR-861534, 1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord handles self-assignment without modifying state.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Arrange: Create a LogRecord object and set some initial state

--- a/score/mw/log/detail/logging_identifier_test.cpp
+++ b/score/mw/log/detail/logging_identifier_test.cpp
@@ -32,7 +32,7 @@ TEST(LoggingIdentifierTestSuite, CheckThatLongIdentifiersShallBeCropped)
     RecordProperty("ParentRequirement", "SCR-1633144, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "logging identifier has maximum length in which the identifier will be cropped.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     LoggingIdentifier identifier{"12345"};
@@ -44,7 +44,7 @@ TEST(LoggingIdentifierTestSuite, CheckThatHashMatchesIntHasher)
     RecordProperty("ParentRequirement", "SCR-1633144, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that hash matches int hasher.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string_view ctx{"CTX1"};
@@ -59,7 +59,7 @@ TEST(LoggingIdentifierTestSuite, EqualityOperatorShallReturnTrueForTheSameString
     RecordProperty("ParentRequirement", "SCR-1633144, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "logging identifiers with the same context name shall be equal.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::string_view ctx{"CTX1"};
@@ -73,7 +73,7 @@ TEST(LoggingIdentifierTestSuite, InequalityOperatorShallReturnTrueForDifferentSt
     RecordProperty("ParentRequirement", "SCR-1633144, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "logging identifiers with the different context name shall not be equal.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     LoggingIdentifier lhs{std::string_view{"CTX1"}};
@@ -85,7 +85,7 @@ TEST(LoggingIdentifierTestSuite, AssignOperatorShallCopyLoggingIdentifier)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the assign operator functionality.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string_view ctx{"CTX1"};

--- a/score/mw/log/detail/text_recorder/file_output_backend_test.cpp
+++ b/score/mw/log/detail/text_recorder/file_output_backend_test.cpp
@@ -72,7 +72,7 @@ TEST_F(FileOutputBackendFixture, ReserveSlotShouldTriggerFlushing)
     RecordProperty("Requirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ReserveSlot shall trigger flushing.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
@@ -96,7 +96,7 @@ TEST_F(FileOutputBackendFixture, FlushSlotShouldTriggerFlushing)
     RecordProperty("Requirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FlushSlot shall trigger flushing.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
@@ -124,7 +124,7 @@ TEST_F(FileOutputBackendFixture, DepletedAllocatorShouldCauseEmptyOptionalReturn
     RecordProperty("Requirement", "SCR-861578, SCR-1016716");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ReserveSlot will return None if all allocator's slots are reserved.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     for (std::size_t i = 0; i < pool_size_; i++)
@@ -155,7 +155,7 @@ TEST_F(FileOutputBackendFixture, GetLogRecordReturnsObjectSameAsAllocatorWould)
     RecordProperty("Requirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetLogRecord can return object same as returned from the allocator.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
@@ -181,7 +181,7 @@ TEST_F(FileOutputBackendFixture, BackendConstructionShallCallNonBlockingFileSetu
     RecordProperty("Description",
                    "File backend construction shall return non blocking file setup. The component shall set the "
                    "FD_CLOEXEC (or O_CLOEXEC) flag on all the file descriptor it owns");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     score::os::Fcntl::Open flags = score::os::Fcntl::Open::kReadWrite;
@@ -212,7 +212,7 @@ TEST_F(FileOutputBackendFixture, MissingFlagsShallSkipCallToSetupFile)
     RecordProperty("Requirement", "SCR-861578, SCR-1016724");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "File backend construction shall not do file setup if there is any missing flag.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);

--- a/score/mw/log/detail/text_recorder/non_blocking_writer_test.cpp
+++ b/score/mw/log/detail/text_recorder/non_blocking_writer_test.cpp
@@ -60,7 +60,7 @@ TEST_F(NonBlockingWriterTestFixture, NonBlockingWriterWhenFlushingTwiceMaxChunkS
     RecordProperty("ParentRequirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingWrite can flush 2 max chunks size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::array<uint8_t, 2 * max_chunk_size> payload{};
@@ -86,7 +86,7 @@ TEST_F(NonBlockingWriterTestFixture,
     RecordProperty("ParentRequirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingWrite can flush 2 different spans with different sizes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::array<uint8_t, (2 * max_chunk_size) + 3> first_payload{};
@@ -126,7 +126,7 @@ TEST_F(NonBlockingWriterTestFixture, NonBlockingWriterShallReturnFalseWhenWriteS
     RecordProperty("ParentRequirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingWrite cannot flush if the system call write fails with error EBADF.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::array<uint8_t, max_chunk_size> payload{};
@@ -150,7 +150,7 @@ TEST_F(NonBlockingWriterTestFixture,
     RecordProperty(
         "Description",
         "NonBlockingWrite can flush 2 max chunk sizes when flushing span with correct indexes to system call write");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::array<uint8_t, 2 * max_chunk_size> payload{};
@@ -177,7 +177,7 @@ TEST_F(NonBlockingWriterTestFixture,
     RecordProperty("Description",
                    "NonBlockingWrite can flush 1 k max chunk size on two different times even if the write returns "
                    "half of max chunk size");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::array<uint8_t, max_chunk_size> payload{};

--- a/score/mw/log/detail/text_recorder/slot_drainer_test.cpp
+++ b/score/mw/log/detail/text_recorder/slot_drainer_test.cpp
@@ -76,7 +76,7 @@ TEST_F(SlotDrainerFixture, TestOneWriteFileFailurePath)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Writes will fail with IO error in case of failure path.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     //  Given write file error
@@ -105,7 +105,7 @@ TEST_F(SlotDrainerFixture, IncompleteWriteFileShouldMakeFlushSpansReturnWouldBlo
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "If write not completed, the Flush API would wait till flushing is complete.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     //  Given write file error
@@ -139,7 +139,7 @@ TEST_F(SlotDrainerFixture, TestOneSlotOneSpan)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Writes shall succeed in case of proper arguments.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     //  Given one slot flushed
@@ -174,7 +174,7 @@ TEST_F(SlotDrainerFixture, TestTooManySlotsForSingleCallShallNotBeAbleToFlushAll
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Fails to flush all slots in case of exceeding the limit of slots to be processed per one call.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t kLimiNumberOfSlotsProcesssedInOneCall = 2UL;

--- a/score/mw/log/detail/text_recorder/text_format_test.cpp
+++ b/score/mw/log/detail/text_recorder/text_format_test.cpp
@@ -57,7 +57,7 @@ TYPED_TEST(UnsupportedTypesCoverage, VerifyUnsupportedTypesActionsHex)
     ::testing::Test::RecordProperty("ASIL", "B");
     ::testing::Test::RecordProperty(
         "Description", "Verifies Type-Information for integer values with hex representation can not be logged.");
-    ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
+    ::testing::Test::RecordProperty("TestingTechnique", "requirements-based");
     ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(this->payload_, this->value_, IntegerRepresentation::kHex);
@@ -70,7 +70,7 @@ TYPED_TEST(UnsupportedTypesCoverage, VerifyUnsupportedTypesActionsOctal)
     ::testing::Test::RecordProperty("ASIL", "B");
     ::testing::Test::RecordProperty(
         "Description", "Verifies Type-Information for integer values with octal representation can not be logged.");
-    ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
+    ::testing::Test::RecordProperty("TestingTechnique", "requirements-based");
     ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(this->payload_, this->value_, IntegerRepresentation::kOctal);
@@ -83,7 +83,7 @@ TYPED_TEST(UnsupportedTypesCoverage, VerifyUnsupportedTypesActionsBin)
     ::testing::Test::RecordProperty("ASIL", "B");
     ::testing::Test::RecordProperty(
         "Description", "Verifies Type-Information for integer values with binary representation can not be logged.");
-    ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
+    ::testing::Test::RecordProperty("TestingTechnique", "requirements-based");
     ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(this->payload_, this->value_, IntegerRepresentation::kBinary);
@@ -95,7 +95,7 @@ TEST_F(TextFormatFixture, DepletedBufferPassed)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies no log can be set for a zero buffer size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(depleted_payload_, std::int32_t{123U});
@@ -108,7 +108,7 @@ TEST_F(TextFormatFixture, PositiveValueForBool)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with bool in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, bool{true});
@@ -126,7 +126,7 @@ TEST_F(TextFormatFixture, NegativeValueForBool)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with bool in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, bool{false});
@@ -145,7 +145,7 @@ TEST_F(TextFormatFixture, PositiveValueOnBufferFull)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int64 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(capacity_two_payload_, std::string_view{"xxx"});
@@ -162,7 +162,7 @@ TEST_F(TextFormatFixture, PositiveValueForInt8)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int8 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::int8_t{123U});
@@ -179,7 +179,7 @@ TEST_F(TextFormatFixture, NegativeValueInt8)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int8 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::int8_t{-123});
@@ -197,7 +197,7 @@ TEST_F(TextFormatFixture, PositiveValueForInt16)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int16 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::int16_t{123U});
@@ -214,7 +214,7 @@ TEST_F(TextFormatFixture, NegativeValueInt16)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int16 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::numeric_limits<int16_t>::min());
@@ -227,7 +227,7 @@ TEST_F(TextFormatFixture, PositiveValueInt32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int32 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::numeric_limits<int32_t>::max());
@@ -240,7 +240,7 @@ TEST_F(TextFormatFixture, NegativeValueInt32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int32 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::numeric_limits<int32_t>::min());
@@ -265,7 +265,7 @@ TEST_F(TextFormatFixture, PositiveValueInt64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int64 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, int64_t{std::numeric_limits<int64_t>::max()});
@@ -279,7 +279,7 @@ TEST_F(TextFormatFixture, NegativeValueInt64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int64 size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::numeric_limits<int64_t>::min());
@@ -294,7 +294,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for positive value with uint8 representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint8_t{234U});
@@ -312,7 +312,7 @@ TEST_F(TextFormatFixture, HexFormatUint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint8 value with hex representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogHex8{234U});
@@ -329,7 +329,7 @@ TEST_F(TextFormatFixture, BinaryFormatUint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint8 value with binary representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogBin8{234U});
@@ -352,7 +352,7 @@ TEST_F(TextFormatFixture, OctalFormatUint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint8 value with octal representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint8_t{234U}, IntegerRepresentation::kOctal);
@@ -370,7 +370,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for a positive value with uint16 representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint16_t{43456U});
@@ -390,7 +390,7 @@ TEST_F(TextFormatFixture, HexFormatUint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint16 value with hex representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogHex16{123U});
@@ -407,7 +407,7 @@ TEST_F(TextFormatFixture, BinaryFormatUint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint16 value with binary representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogBin16{43456U});
@@ -422,7 +422,7 @@ TEST_F(TextFormatFixture, OctalFormatUint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint16 value with octal representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint16_t{43456U}, IntegerRepresentation::kOctal);
@@ -442,7 +442,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for positive value with uint32_t size in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint32_t{std::numeric_limits<int32_t>::max()} + 1);
@@ -456,7 +456,7 @@ TEST_F(TextFormatFixture, HexFormatUint32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for uint32 with hex representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogHex32{52345U});
@@ -475,7 +475,7 @@ TEST_F(TextFormatFixture, BinFormatUint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint32 with binary representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogBin32{52345U});
@@ -490,7 +490,7 @@ TEST_F(TextFormatFixture, OctalFormatUint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint32 with octal representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint32_t{52349U}, IntegerRepresentation::kOctal);
@@ -505,7 +505,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for positive value with uint64_t size  in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, uint64_t{std::numeric_limits<int64_t>::max()} + 1);
@@ -521,7 +521,7 @@ TEST_F(TextFormatFixture, BinaryFormat_InsufficientBuffer)
     RecordProperty("Description",
                    "Verifies Type-Information for binary representation shall be cropped in case of insufficent buffer "
                    "for its bytes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(capacity_two_payload_, std::uint8_t{234U}, IntegerRepresentation::kBinary);
@@ -539,7 +539,7 @@ TEST_F(TextFormatFixture, BinaryFormatWhenBufferFull)
     RecordProperty("Description",
                    "Verifies Type-Information for binary representation shall be cropped in case of insufficent buffer "
                    "for its bytes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     //  Make the buffer full
@@ -560,7 +560,7 @@ TEST_F(TextFormatFixture, HexFormat_InsufficientBuffer)
     RecordProperty("Description",
                    "Verifies Type-Information for hex representation shall only store bytes of data equal to the "
                    "allocated capacity.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(capacity_two_payload_, std::uint32_t{52345U}, IntegerRepresentation::kHex);
@@ -576,7 +576,7 @@ TEST_F(TextFormatFixture, HexFormatUint64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for uint64 with hex representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogHex64{12379813812177893520U});
@@ -591,7 +591,7 @@ TEST_F(TextFormatFixture, BinaryFormatUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint64 with binary representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, LogBin64{12379813812177893520U});
@@ -608,7 +608,7 @@ TEST_F(TextFormatFixture, OctalFormatUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for uint64 with octal representation is in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::uint64_t{12379813812177893520U}, IntegerRepresentation::kOctal);
@@ -622,7 +622,7 @@ TEST_F(TextFormatFixture, LogFloat)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for float in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, 1.23f);
@@ -645,7 +645,7 @@ TEST_F(TextFormatFixture, LogDouble)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for double in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, 1.23);
@@ -668,7 +668,7 @@ TEST_F(TextFormatFixture, StringValueCorrectlyTransformed)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for string in correct format.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::string_view{"Hello World"});
@@ -695,7 +695,7 @@ TEST_F(TextFormatFixture, TerminateShallPutNewLine)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that TerminateLog shall put new line in data buffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::TerminateLog(payload_);
@@ -708,7 +708,7 @@ TEST_F(TextFormatFixture, StringValueWhenBufferFull)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for string shall be intact in case of using full buffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     //  Make the buffer full
@@ -728,7 +728,7 @@ TEST_F(TextFormatFixture, EmptyString)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for empty string will not allocate memory.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     TextFormat::Log(payload_, std::string_view{""});
@@ -743,7 +743,7 @@ TEST_F(TextFormatFixture, RawValueSimpleConversionToHex)
     RecordProperty(
         "Description",
         "Verifies Type-Information for raw value will be converted to hex values nibble by nibble before storing.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::vector<char> data{{1, 2, 0x1F}};
@@ -768,7 +768,7 @@ TEST_F(TextFormatFixture, RawValueSimpleConversionToHexInsufficientBuffer)
     RecordProperty("Description",
                    "Verifies Type-Information for raw value will be converted to hex values nibble by nibble and will "
                    "be cropped in case of using insufficient buffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::vector<char> data{{1, 2, 0x1F}};
@@ -787,7 +787,7 @@ TEST_F(TextFormatFixture, RawValueZeroLengthBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies Type-Information for raw value with zero size will not allocate any memory for logging.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::vector<char> data{};
@@ -803,7 +803,7 @@ TEST_F(TextFormatFixture, RawValueZeroMaxSizeBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies raw value with zero max size buffer will not allocate any memory for logging.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ByteVector buffer{};
@@ -826,7 +826,7 @@ TEST(FormattingFunction, ShallReturnEmptyIfPayloadMaxSizeEqualToZero)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies getting empty payload in case of the max size for allocated memory is equal to zero.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ByteVector buffer{};

--- a/score/mw/log/detail/text_recorder/text_message_builder_test.cpp
+++ b/score/mw/log/detail/text_recorder/text_message_builder_test.cpp
@@ -69,7 +69,7 @@ TEST_F(TextMessageBuilderFixture, ShallDepleteAfterHeaderAndPayload)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextMessageBuilder shall deplete after getting header and payload.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     unit_.SetNextMessage(log_record_);
@@ -88,7 +88,7 @@ TEST_F(TextMessageBuilderFixture, HeaderShallHaveSpecificElements)
     RecordProperty("Description",
                    "Header of TextMessageBuilder shall have specific elements like context id, application id, ecu id, "
                    "and number of args.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     unit_.SetNextMessage(log_record_);
@@ -110,7 +110,7 @@ TEST_F(TextMessageBuilderFixture, PayloadShouldHaveSetText)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Payload of TextMessageBuilder shall have the set text.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     unit_.SetNextMessage(log_record_);
@@ -137,7 +137,7 @@ TEST_P(TextMessageBuilderFixture, HeaderShallHaveLevelPrintedForAllParams)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Header of TextMessageBuilder shall have printed level for all parameters.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto& log_entry = log_record_.getLogEntry();
@@ -156,7 +156,7 @@ TEST_F(TextMessageBuilderFixture, LogLevelToStringShouldReturnUndefinedForInvali
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogLevelToString should return 'undefined' for an invalid log level.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto& log_entry = log_record_.getLogEntry();

--- a/score/mw/log/detail/text_recorder/text_recorder_test.cpp
+++ b/score/mw/log/detail/text_recorder/text_recorder_test.cpp
@@ -67,7 +67,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, WillObtainSlotForSufficientLogLevel
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The required slots will be returned in case of insufficent log level");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto slot = recorder_->StartRecord(context_id_, kActiveLogLevel);
@@ -79,7 +79,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, WillObtainEmptySlotForInsufficentLo
     RecordProperty("Requirement", "SCR-861534, SCR-2592577");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Empty slots will be returned in case of insufficent log level");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto slot = recorder_->StartRecord(context_id_, kInActiveLogLevel);
@@ -91,7 +91,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, DisablesOrEnablesLogAccordingToLeve
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of enabling or disabling specific log level");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_TRUE(recorder_->IsLogEnabled(kActiveLogLevel, context_id_));
@@ -103,7 +103,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, WillObtainEmptySlotsWhenNoSlotsRese
     RecordProperty("Requirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Recorder shall returns zero slots if no slots were reserved.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto backend_mock = std::make_unique<BackendMock>();
@@ -156,7 +156,7 @@ TEST_F(TextRecorderFixture, TooManyArgumentsWillYieldTruncatedLog)
     RecordProperty("Requirement", "SCR-861534, SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log will be truncated in case of too many arguments");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     constexpr std::size_t byte_size_of_space_seperator = 1;
@@ -178,7 +178,7 @@ TEST_F(TextRecorderFixture, TooLargeSinglePayloadWillYieldTruncatedLog)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The logs will be truncated in case of too large single payload");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const std::size_t too_big_data_size = log_record_.getLogEntry().payload.capacity() + 1UL;
@@ -196,7 +196,7 @@ TEST_F(TextRecorderFixture, LogUint8_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint8_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::uint8_t{});
@@ -207,7 +207,7 @@ TEST_F(TextRecorderFixture, LogBool)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log boolean.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, bool{});
@@ -218,7 +218,7 @@ TEST_F(TextRecorderFixture, LogInt8_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int8_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::int8_t{});
@@ -229,7 +229,7 @@ TEST_F(TextRecorderFixture, LogUint16_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint16_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::uint16_t{});
@@ -240,7 +240,7 @@ TEST_F(TextRecorderFixture, LogInt16_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int16_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::int16_t{});
@@ -251,7 +251,7 @@ TEST_F(TextRecorderFixture, LogUint32_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint32_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::uint32_t{});
@@ -262,7 +262,7 @@ TEST_F(TextRecorderFixture, LogInt32_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int32_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::int32_t{});
@@ -273,7 +273,7 @@ TEST_F(TextRecorderFixture, LogUint64_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint64_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::uint64_t{});
@@ -284,7 +284,7 @@ TEST_F(TextRecorderFixture, LogInt64_t)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int64_t.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::int64_t{});
@@ -295,7 +295,7 @@ TEST_F(TextRecorderFixture, LogFloat)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log float.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, float{});
@@ -306,7 +306,7 @@ TEST_F(TextRecorderFixture, LogDouble)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log double.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, double{});
@@ -317,7 +317,7 @@ TEST_F(TextRecorderFixture, LogStringView)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log string view.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, std::string_view{"Hello world"});
@@ -328,7 +328,7 @@ TEST_F(TextRecorderFixture, LogHex8)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 8 bits with hex representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, LogHex8{});
@@ -339,7 +339,7 @@ TEST_F(TextRecorderFixture, LogHex16)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 16 bits with hex representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     recorder_->Log(SlotHandle{}, LogHex16{});
@@ -350,7 +350,7 @@ TEST_F(TextRecorderFixture, LogHex32)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 32 bits with hex representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
 
     recorder_->Log(SlotHandle{}, LogHex32{});
 }
@@ -360,7 +360,7 @@ TEST_F(TextRecorderFixture, LogHex64)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 64 bits with hex representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
 
     recorder_->Log(SlotHandle{}, LogHex64{});
 }
@@ -370,7 +370,7 @@ TEST_F(TextRecorderFixture, LogBin8)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 8 bits with bin representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
 
     recorder_->Log(SlotHandle{}, LogBin8{});
 }
@@ -380,7 +380,7 @@ TEST_F(TextRecorderFixture, LogBin16)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 16 bits with bin representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
 
     recorder_->Log(SlotHandle{}, LogBin16{});
 }
@@ -390,7 +390,7 @@ TEST_F(TextRecorderFixture, LogBin32)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 32 bits with bin representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
 
     recorder_->Log(SlotHandle{}, LogBin32{});
 }
@@ -400,7 +400,7 @@ TEST_F(TextRecorderFixture, LogBin64)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 64 bits with bin representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
 
     recorder_->Log(SlotHandle{}, LogBin64{});
 }
@@ -410,7 +410,7 @@ TEST_F(TextRecorderFixture, LogRawBuffer)
     RecordProperty("Requirement", "SCR-861534, SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log raw buffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     recorder_->Log(SlotHandle{}, LogRawBuffer{"raw", 3});
 }
 
@@ -418,7 +418,7 @@ TEST_F(TextRecorderFixture, LogSlog2Message)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log LogSlog2Message.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     recorder_->Log(SlotHandle{}, LogSlog2Message{11, "slog message"});
 }
 
@@ -427,7 +427,7 @@ TEST(TextRecorderTests, DefaultLogLevelShallBeUsedIfCheckForConsoleIsDisabled)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies that the default log level will be used in case of disabling the console logging.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto default_log_level = LogLevel::kDebug;
@@ -460,7 +460,7 @@ TEST(TextRecorderTests, TextRecorderShouldClearSlotOnStart)
     RecordProperty("Requirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Recorder should clean slots before reuse.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Test setup is here since we cannot reuse the fixture here because we have a specific construction use case.

--- a/score/mw/log/detail/verbose_payload_test.cpp
+++ b/score/mw/log/detail/verbose_payload_test.cpp
@@ -45,7 +45,7 @@ TEST_F(VerbosePayloadFixture, SinglePutStoresMemoryCorrect)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Put function stores data in correct order in the payload (buffer) if called once.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an empty verbose payload with enough space
@@ -70,7 +70,7 @@ TEST_F(VerbosePayloadFixture, MultiplePutStoresMemoryCorrectly)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Put function stores data in correct order in the payload (buffer) if called multiple times.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an already filled buffer with enough space
@@ -97,7 +97,7 @@ TEST_F(VerbosePayloadFixture, PutZeroSize)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Put function handles zero size data requests gracefully");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an already filled buffer with enough space
@@ -113,7 +113,7 @@ TEST_F(VerbosePayloadFixture, PutStopsAtMaximumSize)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Put function continues to fill data to maximum size and any additional data will not be filled.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an empty verbose payload with to few space
@@ -135,7 +135,7 @@ TEST_F(VerbosePayloadFixtureDeathTest, AssertForInvalidPointerKicksIn)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Put function will exit with failure in case of invalid data pointer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an empty buffer
@@ -152,7 +152,7 @@ TEST_F(VerbosePayloadFixture, EmptyBufferHasNoWrongBehavior)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Put function will not fill any data in case of empty buffer and will return successfully.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an empty verbose payload with no space
@@ -171,7 +171,7 @@ TEST_F(VerbosePayloadFixture, SizeFitsInPayload)
     RecordProperty("Requirement", "SCR-861534, SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies size fits in payload.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an empty verbose payload with enough space
@@ -187,7 +187,7 @@ TEST_F(VerbosePayloadFixture, SizeFitsNotInPayload)
     RecordProperty("Requirement", "SCR-861534");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies size does not fit in payload.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given an empty verbose payload with enough space
@@ -206,7 +206,7 @@ TEST_F(VerbosePayloadFixture, SetBufferShallRebindReference)
         "Description",
         "Verifies setting new buffer for VerbosePayload will update the pointer to the new buffer and discards "
         "the old one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given VerbosePayload is constructed with a different buffer.

--- a/score/mw/log/detail/wait_free_stack/wait_free_stack_test.cpp
+++ b/score/mw/log/detail/wait_free_stack/wait_free_stack_test.cpp
@@ -37,7 +37,7 @@ TEST(WaitFreeStack, AtomicOperationFetchAddForWriteIndex)
     RecordProperty("Requirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check atomic fetch_add function for write_index_.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     using AtomicType = std::size_t;
@@ -60,7 +60,7 @@ TEST(WaitFreeStack, AtomicShallBeLockFree)
     RecordProperty("Requirement", "SCR-861578");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check atomic lock-free.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(
@@ -76,7 +76,7 @@ TEST(WaitFreeStack, ConcurrentPushingAndReadingShouldReturnExpectedElements)
     RecordProperty("Description",
                    "Ensures that WaitFreeStack shall be capable of performing multiple "
                    "concurrent write operations without endless loops and return the correct data.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     constexpr auto stack_size = 10UL;

--- a/score/mw/log/log_stream_test.cpp
+++ b/score/mw/log/log_stream_test.cpp
@@ -46,7 +46,7 @@ TEST(LogStream, CorrectlyHandleStartStop)
     RecordProperty("ParentRequirement", "SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability to start and stop stream.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecorderMock recorder_mock_{};
     detail::Runtime::SetRecorder(&recorder_mock_);
@@ -67,7 +67,7 @@ TEST(LogStream, CanLogRecursive)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that logging recursively calls the normal recorder");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecorderMock recorder_mock_{};
     detail::Runtime::SetRecorder(&recorder_mock_);
@@ -118,7 +118,7 @@ TYPED_TEST_P(DurationTest, insertion_operator_chrono_duration)
     this->RecordProperty("ParentRequirement", "SCR-1633893, SCR-1633236");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "ara log shall be able to log chrono duration with unit suffix");
-    this->RecordProperty("TestType", "Requirements-based test");
+    this->RecordProperty("TestType", "requirements-based");
     this->RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // changing representation to double to prevent amiguity between int*, float and double types
@@ -136,7 +136,7 @@ TEST(LogStream, WhenTryToGetStreamWithEmptyStringViewShallReturnDfltStream)
     RecordProperty("ParentRequirement", "SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Getting stream with empty string view shall return the default context id.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     RecorderMock recorder_mock_{};
     detail::Runtime::SetRecorder(&recorder_mock_);
@@ -152,7 +152,7 @@ TEST(LogStream, TypeSupport)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the support for logging various types.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto ensure_that_log_stream_reports_support_for = [](auto value) {
@@ -233,7 +233,7 @@ TEST_F(LogStreamFixture, CanLogBool)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging boolean value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = true;
@@ -250,7 +250,7 @@ TEST_F(LogStreamFixture, CanLogUint8)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int8 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::uint8_t{5};
@@ -267,7 +267,7 @@ TEST_F(LogStreamFixture, CanLogInt8)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int8 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::int8_t{5};
@@ -284,7 +284,7 @@ TEST_F(LogStreamFixture, CanLogUint16)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int16 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::uint16_t{5};
@@ -306,7 +306,7 @@ TEST_F(LogStreamFixture, CanLogSlog2Message)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int16 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto value = mw::log::LogSlog2Message{0U, std::string_view{"Any string"}};
@@ -326,7 +326,7 @@ TEST_F(LogStreamFixture, CanLogInt16)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int16 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::int16_t{5};
@@ -343,7 +343,7 @@ TEST_F(LogStreamFixture, CanLogUint32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int32 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::uint32_t{5};
@@ -360,7 +360,7 @@ TEST_F(LogStreamFixture, CanLogInt32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int32 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::int32_t{5};
@@ -377,7 +377,7 @@ TEST_F(LogStreamFixture, CanLogUint64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int64 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::uint64_t{5};
@@ -394,7 +394,7 @@ TEST_F(LogStreamFixture, CanLogInt64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int64 value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = std::int64_t{5};
@@ -411,7 +411,7 @@ TEST_F(LogStreamFixture, CanLogFloat)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging float value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = float{5.2F};
@@ -428,7 +428,7 @@ TEST_F(LogStreamFixture, CanLogDouble)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging double value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto constexpr value = double{5.2};
@@ -445,7 +445,7 @@ TEST_F(LogStreamFixture, CanLogAmpStringView)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging std::string_view value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto value = std::string_view{"Foo"};
@@ -462,7 +462,7 @@ TEST_F(LogStreamFixture, CanLogStdStringView)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging std::string_view value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto value = std::string_view{"Foo"};
@@ -479,7 +479,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyAmpStringViewShallNotLog)
     RecordProperty("ParentRequirement", "SCR-1633236, SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that in case of empty std::string_view we shall expect no logs.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto value = std::string_view{};
@@ -496,7 +496,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyStdStringViewShallNotLog)
     RecordProperty("ParentRequirement", "SCR-1633236, SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that in case of empty std::string_view we shall expect no logs.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     auto value = std::string_view{};
@@ -513,7 +513,7 @@ TEST_F(LogStreamFixture, CanLogConstStringReference)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging const string reference.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     const auto value = std::string{"Foo"};
@@ -530,7 +530,7 @@ TEST_F(LogStreamFixture, CanLogStdArrayOfChar)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging std::array<char> value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Expecting that the expected value will be transferred to the correct log call
@@ -547,7 +547,7 @@ TEST_F(LogStreamFixture, CanLogCharArrayLiteral)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging char[] literal value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Expecting that the expected value will be transferred to the correct log call
@@ -562,7 +562,7 @@ TEST_F(LogStreamFixture, CanLogPtrToNonConstChar)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging pointer to non-const char.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     std::array<char, 4> value{'F', 'o', 'o', '\0'};
@@ -579,7 +579,7 @@ TEST_F(LogStreamFixture, CanLogStringLiteral)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging string literal value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     LogString::CharPtr value = "Foo";
@@ -596,7 +596,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyStringLiteralShallNotLog)
     RecordProperty("ParentRequirement", "SCR-1633236, SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that in case of empty string literal we shall expect no logs.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Given a value we want to log
     LogString::CharPtr value = nullptr;
@@ -613,7 +613,7 @@ TEST_F(LogStreamFixture, LogStreamMoveConstructorShallDetachMovedFromInstance)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of log value using a moved LogStream instance.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // When logging the value
@@ -635,7 +635,7 @@ TEST_F(LogStreamFixture, CanLogHex8)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int8 in hexdecimal representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -653,7 +653,7 @@ TEST_F(LogStreamFixture, CanLogHex16)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int16 in hexdecimal representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -671,7 +671,7 @@ TEST_F(LogStreamFixture, CanLogHex32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int32 in hexdecimal representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -689,7 +689,7 @@ TEST_F(LogStreamFixture, CanLogHex64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int64 in hexdecimal representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -707,7 +707,7 @@ TEST_F(LogStreamFixture, CanLogBin8)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int8 in binary representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -725,7 +725,7 @@ TEST_F(LogStreamFixture, CanLogBin16)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int16 in binary representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -743,7 +743,7 @@ TEST_F(LogStreamFixture, CanLogBin32)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int32 in binary representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -760,7 +760,7 @@ TEST_F(LogStreamFixture, CanLogBin64)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int64 in binary representation.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -777,7 +777,7 @@ TEST_F(LogStreamFixture, CanLogRawBuffer)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging LogRawBuffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -796,7 +796,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyRawBufferShallNotLog)
     RecordProperty("ParentRequirement", "SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Logging empty LogRawBuffer shall not log.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -814,7 +814,7 @@ TEST_F(LogStreamFixture, CanLogACustomType)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging custom type (struct).");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ::testing::InSequence in_sequence{};
@@ -845,7 +845,7 @@ TEST(LogStreamFlush, WhenFlushingLogStreamAfterLogUint8ShallBeAbleToLogBoolAgain
     RecordProperty("Description",
                    "Verifies teh ability of flushing LogStream used to log unsigned int8 and then use it again to log "
                    "boolean value.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -880,7 +880,7 @@ TEST(LogStreamFlush, AvoidFormattingCallsWhenSlotIsNotAvailable)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of logging formatting functions if no slots are reserved.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -917,7 +917,7 @@ TEST(LogStreamFlush, WhenEmptyAppIdStringProvidedExpectDefaultOneReturned)
     RecordProperty("ParentRequirement", "SCR-1633236");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "When empty app id is provided the default context id shall be returned.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a value we want to log
@@ -984,7 +984,7 @@ TEST_F(LogStreamFixture, UsesFallbackRecorderWithinOtherRecorder)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the fallback recorder is used, if another recorder also uses logging");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto local_stream_ = Unit();

--- a/score/mw/log/log_types_test.cpp
+++ b/score/mw/log/log_types_test.cpp
@@ -35,7 +35,7 @@ TEST(LogStringTest, ConstructFromCharArray)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the detection of null-/non-null-terminated char array");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // When constructing our LogString type from an empty char[] literal
@@ -85,7 +85,7 @@ TEST(LogStringTest, CanImplicitlyConvertFromStringLikeTypes)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating our LogString type view from string-like types");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto kExpected = "MyString";
@@ -129,7 +129,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromInteger)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from integer");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t value{15};
@@ -147,7 +147,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromIntegerStdArray)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from array of integers.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::array<std::int32_t, 2> values{15, 16};
@@ -165,7 +165,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromSpan)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from score::cpp::span.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t values[]{15, 16};
@@ -184,7 +184,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromVector)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from vector of integers");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::vector<std::int32_t> values{15, 16};

--- a/score/mw/log/logger_container_test.cpp
+++ b/score/mw/log/logger_container_test.cpp
@@ -42,7 +42,7 @@ TEST(LoggerContainerTests, WhenRequestingNonExistingNewLoggerItShallBeInsertedAn
     RecordProperty(
         "Description",
         "Verifies the ability of requesting non-existing new logger shall be inserted and returned to the caller.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     LoggerContainer unit;
     EXPECT_EQ(unit.GetLogger(kContext1).GetContext(), kContext1);
@@ -53,7 +53,7 @@ TEST(LoggerContainerTests, WhenGetingDefaultLoggerShallGetDLFTContextID)
     RecordProperty("ParentRequirement", "SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that when getting a default logger it shall get DFLT context id.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     LoggerContainer unit;
     EXPECT_EQ(unit.GetDefaultLogger().GetContext(), kDefaultContext);
@@ -66,7 +66,7 @@ TEST(LoggerContainerTests, WhenRequestingAlreadyExistingLoggerShallBeReturnedWit
     RecordProperty(
         "Description",
         "Verifies that when requesting already existing logger shall be returned without inserting new logger.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     LoggerContainer unit;
     EXPECT_EQ(unit.GetLogger(kContext1).GetContext(), kContext1);
@@ -80,7 +80,7 @@ TEST(LoggerContainerTests, WhenLoggerContainerIsFullShallGetDefaultContextWhenNe
     RecordProperty(
         "Description",
         "Verifies that when logger container is full shall get default context when new logger is requested.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // Expecting a log record of level verbose
     LoggerContainer unit;
@@ -119,7 +119,7 @@ TEST(LoggerContainerTests, WhenTwoThreadsRequestSameLoggerShallBeOnlyOneExisting
     RecordProperty(
         "Description",
         "Verifies that when two threads request the same logger it shall be only one existing in logger container.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     LoggerContainer unit;
 

--- a/score/mw/log/logger_test.cpp
+++ b/score/mw/log/logger_test.cpp
@@ -61,7 +61,7 @@ TEST_F(LoggerFixture, CanLogVerboseWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging verbose message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -77,7 +77,7 @@ TEST_F(LoggerFixture, CanLogDebugWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging debug message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -93,7 +93,7 @@ TEST_F(LoggerFixture, CanLogInfoWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging info message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -109,7 +109,7 @@ TEST_F(LoggerFixture, CanLogWarnWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging warning message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -125,7 +125,7 @@ TEST_F(LoggerFixture, CanLogErrorWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging error message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -141,7 +141,7 @@ TEST_F(LoggerFixture, CanLogFatalWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging fatal message.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -157,7 +157,7 @@ TEST_F(LoggerFixture, CheckThatWithLevelSetsCorrectLogLevel)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging warn message using WithLevel API.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -173,7 +173,7 @@ TEST_F(BasicLoggerFixture, CheckThatIsLogEnabledReturnsCorrectValue)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify that IsLogEnabled API is returning the correct log level.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -189,7 +189,7 @@ TEST(CreateLoggerGetContext, CreateLoggerWithNeededContext)
     RecordProperty("ParentRequirement", "SCR-1016719");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that GetContext shall return the right context.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     Logger unit = CreateLogger(CONTEXT);
     EXPECT_EQ(unit.GetContext(), CONTEXT);
@@ -201,7 +201,7 @@ TEST(CreateLoggerGetContext, WhenCreateLoggerWIthEmptyContextShallReturnDefaultL
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verifies that creating a logger with empty context it shall return the default logger.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     Logger unit = CreateLogger(std::string_view{});
     EXPECT_EQ(unit.GetContext(), kDefaultContext);
@@ -214,7 +214,7 @@ TEST(CreateLoggerGetContext, CreateLoggerPassingTwoArgs)
     RecordProperty("Description",
                    "Verifies that GetContext shall return the right context when instantiating the CreateLogger with "
                    "two arguments.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     Logger unit = CreateLogger(CONTEXT, CONTEXT_DESCRIPTION);
     EXPECT_EQ(unit.GetContext(), CONTEXT);

--- a/score/mw/log/logging_test.cpp
+++ b/score/mw/log/logging_test.cpp
@@ -38,7 +38,7 @@ TEST(Logging, CanSetAndRetrieveDefaultRecorder)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of retrieving the default logger.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SetLogRecorder");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -68,7 +68,7 @@ TEST_F(LoggingFixture, CanLogVerboseWithoutContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging verbose message without context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogVerbose");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -85,7 +85,7 @@ TEST_F(LoggingFixture, CanLogDebugWithoutContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging debug message without context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogDebug");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -101,7 +101,7 @@ TEST_F(LoggingFixture, CanLogInfoWithoutContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging info message without context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogInfo");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -117,7 +117,7 @@ TEST_F(LoggingFixture, CanLogWarnWithoutContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging warning message without context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogWarn");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -133,7 +133,7 @@ TEST_F(LoggingFixture, CanLogErrorWithoutContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging error message without context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogError");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -149,7 +149,7 @@ TEST_F(LoggingFixture, CanLogFatalWithoutContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging fatal message without context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogFatal");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -165,7 +165,7 @@ TEST_F(LoggingFixture, CanLogVerboseWitContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging verbose message with context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogVerbose");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -181,7 +181,7 @@ TEST_F(LoggingFixture, CanLogDebugWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging debug message with context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogDebug");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -197,7 +197,7 @@ TEST_F(LoggingFixture, CanLogInfoWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging info message with context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogInfo");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -213,7 +213,7 @@ TEST_F(LoggingFixture, CanLogWarnWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging warning message with context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogWarn");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -229,7 +229,7 @@ TEST_F(LoggingFixture, CanLogErrorWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging error message with context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogError");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -245,7 +245,7 @@ TEST_F(LoggingFixture, CanLogFatalWithContext)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of logging fatal message with context provided.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::LogFatal");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 

--- a/score/mw/log/runtime_test.cpp
+++ b/score/mw/log/runtime_test.cpp
@@ -48,7 +48,7 @@ TEST_F(RuntimeFixture, CanSetALoggingBackend)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability to set backend logging without exception.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given an empty process
@@ -63,7 +63,7 @@ TEST_F(RuntimeFixture, CanRetrieveSetRecorder)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability to get the recorder properly.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given the recorder was already set
@@ -78,7 +78,7 @@ TEST_F(RuntimeFixture, CanRetrieveFallbackRecorder)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability to get a fallback recorder.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given the runtime was initialized
@@ -95,7 +95,7 @@ TEST_F(RuntimeFixture, DefaultRecorderShallBeReturned)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verify the ability of returning the default recorder in case of null recorder is set.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given the unset recorder:
@@ -116,7 +116,7 @@ TEST_F(RuntimeFixture, WithLoggerContainerHasFreeCapacityExpectedThatNewLoggerCo
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Verify if logger container has capacity will create this logger if it's not available.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::string_view context{"ctx"};
@@ -129,7 +129,7 @@ TEST(RuntimeTest, RuntimeInitializationWithPointer)
     RecordProperty("Description",
                    "This suite only exists to test the second branch of the runtime initialization. Since this is "
                    "static state we need a separate binary for this.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // This suite only exists to test the second branch of the runtime initialization.

--- a/score/mw/log/runtime_test_instance_fallback.cpp
+++ b/score/mw/log/runtime_test_instance_fallback.cpp
@@ -48,7 +48,7 @@ TEST(RuntimeTest, RuntimeInitializationWithoutPointer)
     RecordProperty("Description",
                    "This suite only exists to test the first branch of the runtime initialization. Since this is "
                    "static state we need a separate binary for this.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Runtime::SetRecorder(nullptr, nullptr);

--- a/score/mw/log/runtime_test_without_pointer_initialization.cpp
+++ b/score/mw/log/runtime_test_without_pointer_initialization.cpp
@@ -34,7 +34,7 @@ TEST(RuntimeTest, RuntimeInitializationWithoutPointer)
     RecordProperty("Description",
                    "This suite only exists to test the first branch of the runtime initialization. Since this is "
                    "static state we need a separate binary for this.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Do not add additional tests here, but in runtime_test.cpp.

--- a/score/mw/log/slot_handle_test.cpp
+++ b/score/mw/log/slot_handle_test.cpp
@@ -40,7 +40,7 @@ TEST(SlotHandle, SlotHandleShallDefaultInitializeToZero)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the default initialization of SlotHandle instance.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -54,7 +54,7 @@ TEST(SlotHandle, GetSlotOfSelectedRecorderShallReturnCorrectSlot)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Set/Get slot method.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -68,7 +68,7 @@ TEST(SlotHandle, GetSlotShallReturnCorrectValue)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check getting the slot whose Set via constructor.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -81,7 +81,7 @@ TEST(SlotHandle, GetSlotShallReturnZeroOnIncorrectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "Check the in-ability of getting the slot in case of invalid recorder identifier value.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -93,7 +93,7 @@ TEST(SlotHandle, SetSlotShallSetCorrectValue)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the ability of seting slot properly.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -106,7 +106,7 @@ TEST(SlotHandle, SetSlotShallDiscardInvalidRecorder)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the in-ability of setting invalid recorder identifier value.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -119,7 +119,7 @@ TEST(SlotHandle, SetSelectedRecorderShallReturnCorrectValue)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of setting selected recorder.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -132,7 +132,7 @@ TEST(SlotHandle, SetSelectedRecorderShallIgnoreInvalidValue)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of SetSelectedRecorder to ignore invalid recorder.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -146,7 +146,7 @@ TEST(SlotHandle, GetSlotAvailableShallReturnTrueOnAssigned)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of checking the availability of specific slot.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -158,7 +158,7 @@ TEST(SlotHandle, GetSlotAvailableShallReturnFalseOnInvalidRecorder)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of checking the availability of specific slot.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -170,7 +170,7 @@ TEST(SlotHandle, ShallBeEqualIffSelectedRecorderAndSlotsAreEqual)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the equality of SlotHandle instances.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -192,7 +192,7 @@ TEST(SlotHandle, ShallBeUnequalIfSelectedRecorderUnequal)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the inequality of SlotHandle instances.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -208,7 +208,7 @@ TEST(SlotHandle, ShallBeUnequalIfAnySlotUnequal)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the inequality of SlotHandle instances.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
@@ -224,7 +224,7 @@ TEST(SlotHandle, ShallBeUnequalIfAnySlotUnequalAssigned)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the inequality of SlotHandle instances.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 

--- a/score/network/sock_async/sock_async_test.cpp
+++ b/score/network/sock_async/sock_async_test.cpp
@@ -98,7 +98,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZero)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
@@ -153,7 +153,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroRaw)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful on RAW socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
@@ -208,7 +208,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroTCP)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful on TCP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
@@ -263,7 +263,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroDefaultSocket)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
@@ -319,7 +319,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroMMsg)
     RecordProperty("Priority", "3");
     RecordProperty("Description",
                    "Verifies that async read of multiple messages operation is successful on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmmsg(_, _, _, _, _))
@@ -380,7 +380,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroMMsgWithEndPoint)
     RecordProperty("Description",
                    "Verifies that async read of multiple messages operation is successful on UDP socket type "
                    "when endpoint is provided");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmmsg(_, _, _, _, _))
@@ -443,7 +443,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataEqualZero)
     RecordProperty("Description",
                    "Verifies that async read of multiple messages operation is successful on UDP socket type "
                    "empty data is provided ");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -478,7 +478,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroReadFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read will fail on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([this](struct pollfd* in_pollfd, nfds_t, int) {
@@ -533,7 +533,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroWithEndpoint)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read will succeed on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([this](struct pollfd* in_pollfd, nfds_t, int) {
@@ -590,7 +590,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytes)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -632,7 +632,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesRaw)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on RAW socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -674,7 +674,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesTCP)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on TCP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -716,7 +716,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesWithEndPoint)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on UDP socket type with endpoint");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -760,7 +760,7 @@ TEST_F(SocketAsyncTest, WriteAsyncWithDataGreaterThanZeroWriteFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will fail on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -802,7 +802,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesNoData)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write with empty data on UDP socket type");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {

--- a/score/network/sock_async_raw/socket_raw_test.cpp
+++ b/score/network/sock_async_raw/socket_raw_test.cpp
@@ -66,7 +66,7 @@ TEST_F(SocketRAWTest, CreationSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of RAW async socket is successful");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     factory = new SocketFactory();
@@ -80,7 +80,7 @@ TEST_F(SocketRAWTest, CreationFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of RAW async socket fails");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _))
         .Times(Exactly(1))
@@ -97,7 +97,7 @@ TEST_F(SocketRAWTest, ConnectFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that connection on RAW async socket fails");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     factory = new SocketFactory();

--- a/score/network/sock_async_tcp/socket_tcp_test.cpp
+++ b/score/network/sock_async_tcp/socket_tcp_test.cpp
@@ -78,7 +78,7 @@ TEST_F(SocketTCPTest, ConnectSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that connection on TCP async socket is successful");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -109,7 +109,7 @@ TEST_F(SocketTCPTest, CreationSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of TCP async socket is successful");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -128,7 +128,7 @@ TEST_F(SocketTCPTest, CreationFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of TCP async socket fails");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _))
         .Times(Exactly(1))

--- a/score/network/sock_async_udp/socket_udp_test.cpp
+++ b/score/network/sock_async_udp/socket_udp_test.cpp
@@ -72,7 +72,7 @@ TEST_F(SocketUDPTest, CreationSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of UDP async socket is successful");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
@@ -91,7 +91,7 @@ TEST_F(SocketUDPTest, CreationFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of UDP async socket fails");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _))
         .Times(Exactly(1))
@@ -112,7 +112,7 @@ TEST_F(SocketUDPTest, ConnectFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that connection on UDP async socket fails");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {

--- a/score/os/test/ObjectSeam_test.cpp
+++ b/score/os/test/ObjectSeam_test.cpp
@@ -48,7 +48,7 @@ TEST(ObjectSeamTest, CopyConstructor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ObjectSeamTest Copy Constructor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MockObject mock("Testing Copy");
@@ -65,7 +65,7 @@ TEST(ObjectSeamTest, MoveConstructor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ObjectSeamTest Move Constructor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MockObject mock("Testing Move");

--- a/score/os/test/acl_test.cpp
+++ b/score/os/test/acl_test.cpp
@@ -59,7 +59,7 @@ TEST_F(AclTestFixture, CanAddGroupEntries)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer adding group entries");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kGroup).has_value());
@@ -119,7 +119,7 @@ TEST_F(AclTestFixture, SettingTagTokOwningGroup)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer adding tags to onwing group");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kOwningGroup).has_value());
@@ -132,7 +132,7 @@ TEST_F(AclTestFixture, SettingTagTokMaximumAllowedPermissions)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer setting of maximum permission");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kMaximumAllowedPermissions).has_value());
@@ -145,7 +145,7 @@ TEST_F(AclTestFixture, SettingTagTokOther)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer set tag type to kOther");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kOther).has_value());
@@ -158,7 +158,7 @@ TEST_F(AclTestFixture, SettingTagTokOwningUser)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer set tag to kOwningUser");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kOwningUser).has_value());
@@ -171,7 +171,7 @@ TEST_F(AclTestFixture, GettingTagaclgroup)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer set tag to kGroup");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kGroup).has_value());
@@ -184,7 +184,7 @@ TEST_F(AclTestFixture, GetQualifierReturnErrorIfPassInvalidEntry)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error to get qualifier with default value");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto val = unit_.acl_get_qualifier(entry_);
@@ -198,7 +198,7 @@ TEST_F(AclTestFixture, SetQualifierReturnErrorIfPassInvalidQualifier)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid qualifier");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto val = unit_.acl_set_qualifier(entry_, nullptr);
@@ -212,7 +212,7 @@ TEST_F(AclTestFixture, AclValidToReturnErrorIfPassInvalidAcl)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid ACL");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto val = unit_.acl_valid(acl_);
@@ -225,7 +225,7 @@ TEST_F(AclTestFixture, AclToTextToReturnOkIfPassValidAcl)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid ACL");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto* result = ::acl_get_file(file_name, ACL_TYPE_ACCESS);
@@ -242,7 +242,7 @@ TEST_F(AclTestFixture, AclToTextToReturnErrorIfPassInvalidAcl)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid ACL");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto* result = ::acl_get_file("", ACL_TYPE_ACCESS);
@@ -259,7 +259,7 @@ TEST_F(AclTestFixture, AclSetFdToReturnErrorIfPassInvalidParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid param");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto val = unit_.acl_set_fd(file_descriptor_, acl_);
@@ -273,7 +273,7 @@ TEST_F(AclTestFixture, AclGetEntryToReturnErrorIfPassInvalidIndex)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid index");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
 #if defined(__QNX__)
@@ -290,7 +290,7 @@ TEST_F(AclTestFixture, AclGetPermissionTest)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description",
                    "ACL shall true when the permission is present in the permissions set; false otherwise.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kGroup).has_value());
@@ -322,7 +322,7 @@ TEST_F(AclTestFixture, AclGetFilePositiveTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return correct acl for given filename if the file exists.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto acl_result = unit_.acl_get_file(file_name);
@@ -336,7 +336,7 @@ TEST_F(AclTestFixture, AclGetFileNegativeTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if provided path is empty.");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const std::string filepath{""};

--- a/score/os/test/dirent_test.cpp
+++ b/score/os/test/dirent_test.cpp
@@ -44,7 +44,7 @@ TEST_F(DirentTest, ScanPositiveTest)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Scan shall return success for scan dir");
@@ -64,7 +64,7 @@ TEST_F(DirentTest, ScanNegativeTest)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Scan shall return error for invalid path");
@@ -78,7 +78,7 @@ TEST_F(DirentTest, OpenDirSuccess)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Open dir shall return success for valid dir");
@@ -94,7 +94,7 @@ TEST_F(DirentTest, OpenDirFailure)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Open dir shall return error for invalid dir");
@@ -107,7 +107,7 @@ TEST_F(DirentTest, ReadDirSuccess)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Read dir shall return success for valid dir");
@@ -141,7 +141,7 @@ TEST_F(DirentTest, ReadDirEnd)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Read dir shall return success for valid dir");
@@ -163,7 +163,7 @@ TEST_F(DirentTest, CloseDirSuccess)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Close dir shall return success for valid dir");
@@ -179,7 +179,7 @@ TEST(Dirent, get_instance)
 {
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description", "Dirent shall provide instance functionality");

--- a/score/os/test/errno_test.cpp
+++ b/score/os/test/errno_test.cpp
@@ -50,7 +50,7 @@ TEST_F(OsErrorViaLogStreamFixture, CanStreamViaRValueStream)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OsErrorViaLogStreamFixture Can Stream Via RValue Stream");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given a constructed error
@@ -70,7 +70,7 @@ TEST_F(OsErrorViaLogStreamFixture, StreamIntoMwLogStream2)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OsErrorViaLogStreamFixture Stream Into Mw Log Stream2");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given a constructed error
@@ -91,7 +91,7 @@ TEST(Error, CreationFromErrno)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Creation From Errno");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Error error{Error::createFromErrno(EPERM)};
@@ -103,7 +103,7 @@ TEST(Error, EqualityCompare)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Equality Compare");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
@@ -116,7 +116,7 @@ TEST(Error, InequalityCompare)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Inequality Compare");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
@@ -129,7 +129,7 @@ TEST(Error, InequalityCompareToErrorCode)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Inequality Compare To Error Code");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
@@ -141,7 +141,7 @@ TEST(Error, CreateUnspecifiedError)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create Unspecified Error");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createUnspecifiedError()};
@@ -153,7 +153,7 @@ TEST(Error, StreamingOut)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Streaming Out");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::stringstream ss;
@@ -166,7 +166,7 @@ TEST(Error, SetErrno)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Set Errno");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     seterrno(EPERM);
@@ -178,7 +178,7 @@ TEST(Error, ToString)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error To String");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
@@ -190,7 +190,7 @@ TEST(Error, GetOsDependentErrorCode)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Get Os Dependent Error Code");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
@@ -202,7 +202,7 @@ TEST(Error, CreateFromGlobErrorNoSpace)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create From Glob Error No Space");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromGlobError(GLOB_NOSPACE)};
@@ -214,7 +214,7 @@ TEST(Error, CreateFromGlobErrorNotImplemented)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create From Glob Error Not Implemented");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromGlobError(GLOB_NOSYS)};
@@ -226,7 +226,7 @@ TEST(Error, CreateFromErrnoFlockSpecificOperationNotSupported)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create From Errno Flock Specific Operation Not Supported");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto error1{Error::createFromErrnoFlockSpecific(EOPNOTSUPP)};
@@ -238,7 +238,7 @@ TEST(Error, ErrorCodeConversion)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Error Code Conversion");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::map<const std::int32_t, const Error::Code> error_code_map = {

--- a/score/os/test/fcntl_impl_test.cpp
+++ b/score/os/test/fcntl_impl_test.cpp
@@ -74,7 +74,7 @@ TEST_F(FcntlImplTest, KFileSetStatusFlagsFailsWithWrongCommand)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest KFile Set Status Flags Fails With Wrong Command");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto command{Fcntl::Command::kFileGetStatusFlags};
@@ -89,7 +89,7 @@ TEST_F(FcntlImplTest, CommandKFileSetStatusFlagsSetsFlags)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Set Status Flags Sets Flags");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const Fcntl::Command command{Fcntl::Command::kFileSetStatusFlags};
@@ -107,7 +107,7 @@ TEST_F(FcntlImplTest, CommandKFileSetStatusFlagsFailsWithInvalidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Set Status Flags Fails With Invalid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::close(file_descriptor_);
@@ -124,7 +124,7 @@ TEST_F(FcntlImplTest, KFileGetStatusFlagsFailsWithWrongCommand)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest KFile Get Status Flags Fails With Wrong Command");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto command{Fcntl::Command::kFileSetStatusFlags};
@@ -138,7 +138,7 @@ TEST_F(FcntlImplTest, CommandKFileSetStatusFlagsGetsFlags)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Set Status Flags Gets Flags");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto command{Fcntl::Command::kFileGetStatusFlags};
@@ -155,7 +155,7 @@ TEST_F(FcntlImplTest, CommandKFileGetStatusFlagsFailsWithInvalidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Get Status Flags Fails With Invalid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::close(file_descriptor_);
@@ -171,7 +171,7 @@ TEST_F(FcntlImplTest, OpenSucceeds)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open Succeeds");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly};
@@ -187,7 +187,7 @@ TEST_F(FcntlImplTest, OpenFailsWithInvalidPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open Fails With Invalid Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly};
@@ -202,7 +202,7 @@ TEST_F(FcntlImplTest, OpenWithModeSucceeds)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open With Mode Succeeds");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly | Fcntl::Open::kCreate | Fcntl::Open::kExclusive};
@@ -221,7 +221,7 @@ TEST_F(FcntlImplTest, OpenWithModeFailsWithInvalidPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open With Mode Fails With Invalid Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly | Fcntl::Open::kCreate | Fcntl::Open::kExclusive};
@@ -236,7 +236,7 @@ TEST_F(FcntlImplTest, PosixFallocateSucceedsWithValidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Posix Fallocate Succeeds With Valid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const off_t offset{0};
@@ -253,7 +253,7 @@ TEST_F(FcntlImplTest, PosixFallocateFailsWithInvalidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Posix Fallocate Fails With Invalid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::close(file_descriptor_);
@@ -269,7 +269,7 @@ TEST_F(FcntlImplTest, FlockFailsWithInvalidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails With Invalid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::close(file_descriptor_);
@@ -283,7 +283,7 @@ TEST_F(FcntlImplTest, FlockFailsWithKUnLock)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails With KUn Lock");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::close(file_descriptor_);
@@ -297,7 +297,7 @@ TEST_F(FcntlImplTest, FlockSucceedsWithValidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Succeeds With Valid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = score::os::Fcntl::instance().flock(file_descriptor_, Fcntl::Operation::kLockShared);
@@ -310,7 +310,7 @@ TEST_F(FcntlImplTest, FlockSucceedsWithValidFileDescriptorAndWithExclusiveUnLock
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "FcntlImplTest Flock Succeeds With Valid File Descriptor And With Exclusive Un Lock Combination");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = score::os::Fcntl::instance().flock(file_descriptor_,
@@ -323,7 +323,7 @@ TEST_F(FcntlImplTest, FlockFailsWhenTryToObtainExclusiveLockTwice)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails When Try To Obtain Exclusive Lock Twice");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto ret = fork();
@@ -361,7 +361,7 @@ TEST_F(FcntlImplTest, FlockFailsWhenTryToObtainExclusiveLockAndSharedLock)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails When Try To Obtain Exclusive Lock And Shared Lock");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto ret = fork();
@@ -399,7 +399,7 @@ TEST_F(FcntlImplTest, FlockSucceedsWhenTryToObtainSharedLockTwice)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Succeeds When Try To Obtain Shared Lock Twice");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto ret = fork();

--- a/score/os/test/fcntl_test.cpp
+++ b/score/os/test/fcntl_test.cpp
@@ -32,7 +32,7 @@ TEST(CommandToInteger, kFileGetStatusFlags)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CommandToInteger k File Get Status Flags");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::CommandToInteger(Fcntl::Command::kFileGetStatusFlags);
@@ -45,7 +45,7 @@ TEST(CommandToInteger, kFileSetStatusFlags)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CommandToInteger k File Set Status Flags");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::CommandToInteger(Fcntl::Command::kFileSetStatusFlags);
@@ -58,7 +58,7 @@ TEST(CommandToInteger, kInvalid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CommandToInteger k Invalid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::CommandToInteger(Fcntl::Command::kInvalid);
@@ -71,7 +71,7 @@ TEST(IntegerToOpenFlag, Translate_O_RDONLY)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_RDONLY");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_RDONLY);
@@ -83,7 +83,7 @@ TEST(IntegerToOpenFlag, Translate_O_WRONLY)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_WRONLY");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_WRONLY);
@@ -95,7 +95,7 @@ TEST(IntegerToOpenFlag, Translate_O_RDWR)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_RDWR");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_RDWR);
@@ -107,7 +107,7 @@ TEST(IntegerToOpenFlag, Translate_O_CREAT)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_CREAT");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_CREAT);
@@ -120,7 +120,7 @@ TEST(IntegerToOpenFlag, Translate_O_CLOEXEC)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_CLOEXEC");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_CLOEXEC);
@@ -133,7 +133,7 @@ TEST(IntegerToOpenFlag, Translate_O_NONBLOCK)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_NONBLOCK");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_NONBLOCK);
@@ -146,7 +146,7 @@ TEST(IntegerToOpenFlag, Translate_O_EXCL)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_EXCL");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_EXCL);
@@ -159,7 +159,7 @@ TEST(IntegerToOpenFlag, Translate_O_TRUNC)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_TRUNC");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_TRUNC);
@@ -172,7 +172,7 @@ TEST(IntegerToOpenFlag, Translate_O_DIRECTORY)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_DIRECTORY");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_DIRECTORY);
@@ -193,7 +193,7 @@ TEST(IntegerToOpenFlag, Translate_O_SYNC)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_SYNC");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_SYNC);
@@ -207,7 +207,7 @@ TEST(IntegerToOpenFlag, TranslateMultiple)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate Multiple");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_RDWR | O_CREAT);
@@ -220,7 +220,7 @@ TEST(OpenFlagToInteger, TranslateKReadOnly)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KRead Only");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kReadOnly);
@@ -232,7 +232,7 @@ TEST(OpenFlagToInteger, TranslateKWriteOnly)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KWrite Only");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kWriteOnly);
@@ -244,7 +244,7 @@ TEST(OpenFlagToInteger, TranslateKReadWrite)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KRead Write");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kReadWrite);
@@ -256,7 +256,7 @@ TEST(OpenFlagToInteger, TranslateKCreate)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KCreate");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kCreate);
@@ -268,7 +268,7 @@ TEST(OpenFlagToInteger, TranslateKCloseOnExec)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KClose On Exec");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kCloseOnExec);
@@ -280,7 +280,7 @@ TEST(OpenFlagToInteger, TranslateKNonBlocking)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KNon Blocking");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kNonBlocking);
@@ -292,7 +292,7 @@ TEST(OpenFlagToInteger, TranslateKExclusive)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KExclusive");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kExclusive);
@@ -304,7 +304,7 @@ TEST(OpenFlagToInteger, TranslateKTruncate)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KTruncate");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kTruncate);
@@ -316,7 +316,7 @@ TEST(OpenFlagToInteger, TranslateKDirectory)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KDirectory");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kDirectory);
@@ -335,7 +335,7 @@ TEST(OpenFlagToInteger, TranslateKSynchronized)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KSynchronized");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kSynchronized);
@@ -348,7 +348,7 @@ TEST(fcntl, DefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "fcntl Default Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto default_instance = score::os::Fcntl::Default();
@@ -361,7 +361,7 @@ TEST(fcntl, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "fcntl PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
@@ -375,7 +375,7 @@ TEST(fcntl, CanGetInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "fcntl Can Get Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_NO_FATAL_FAILURE(Fcntl::instance());

--- a/score/os/test/ftw_test.cpp
+++ b/score/os/test/ftw_test.cpp
@@ -39,7 +39,7 @@ TEST_F(FtwMockTest, ftw)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FtwMockTest ftw");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(ftwmock, ftw);
@@ -58,7 +58,7 @@ TEST(FtwTest, ftw_walk)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FtwTest ftw_walk");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::unique_ptr<score::os::Ftw> ftw_object = std::make_unique<score::os::FtwPosix>();
@@ -73,7 +73,7 @@ TEST(FtwTest, ftw_fail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FtwTest ftw_fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::unique_ptr<score::os::Ftw> ftw_object = std::make_unique<score::os::FtwPosix>();

--- a/score/os/test/getopt_test.cpp
+++ b/score/os/test/getopt_test.cpp
@@ -26,7 +26,7 @@ TEST(GetOptTest, GetoptTestSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getopt Test Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     optind = 1;
@@ -51,7 +51,7 @@ TEST(GetOptTest, GetOptLong)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Get Opt Long");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     optind = 1;
@@ -95,7 +95,7 @@ TEST(GetOptTest, GetoptTestFailureUnknownOption)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getopt Test Failure Unknown Option");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     optind = 1;
@@ -117,7 +117,7 @@ TEST(GetOptTest, GetoptindTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getoptind Test");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     optind = 4;
@@ -129,7 +129,7 @@ TEST(GetOptTest, GetopterrTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getopterr Test");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     opterr = 5;
@@ -141,7 +141,7 @@ TEST(GetOptTest, GetoptoptTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getoptopt Test");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     optopt = 3;

--- a/score/os/test/glob_impl_test.cpp
+++ b/score/os/test/glob_impl_test.cpp
@@ -76,7 +76,7 @@ TEST_F(GlobImplTest, MatchExistingFiles)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match Existing Files");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = glob_instance_->Match("testfile*.txt", Glob::Flag::kNoSort);
@@ -92,7 +92,7 @@ TEST_F(GlobImplTest, MatchTerminatesOnErrorWithGlobErrFlag)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match Terminates On Error With Glob Err Flag");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = glob_instance_->Match("restricted_dir/*", Glob::Flag::kErr);
@@ -105,7 +105,7 @@ TEST_F(GlobImplTest, MatchCombiningAppendAndSortFlags)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match Combining Append And Sort Flags");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto first_result = glob_instance_->Match("*.txt", Glob::Flag::kNoSort);
@@ -126,7 +126,7 @@ TEST_F(GlobImplTest, MatchNoMatchFound)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match No Match Found");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = glob_instance_->Match("nonexistentfilepattern.*", Glob::Flag::kNoSort);
@@ -139,7 +139,7 @@ TEST_F(GlobImplTest, MoveAssignmentFreesCurrentData)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Move Assignment Frees Current Data");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GlobImpl glob1{};
@@ -177,7 +177,7 @@ TEST_F(GlobImplTest, MoveAssignmentToNewInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Move Assignment To New Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GlobImpl glob1{};
@@ -210,7 +210,7 @@ TEST_F(GlobImplTest, MoveConstructor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Move Constructor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GlobImpl glob1{};
@@ -250,7 +250,7 @@ TEST_F(GlobImplTest, DefaultWithMemoryResource)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Default With Memory Resource");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto glob = Glob::Default(score::cpp::pmr::get_default_resource());

--- a/score/os/test/glob_test.cpp
+++ b/score/os/test/glob_test.cpp
@@ -34,7 +34,7 @@ TEST_P(FlagToIntegerTests, ConvertFlag)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FlagToIntegerTests Convert Flag");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto flag = std::get<0>(GetParam());
@@ -76,7 +76,7 @@ TEST(FlagToIntegerTests, MultipleFlagsConversion)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FlagToIntegerTests Multiple Flags Conversion");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto combinedFlags = Glob::Flag::kAppend | Glob::Flag::kNoCheck | Glob::Flag::kPeriod;

--- a/score/os/test/grp_test.cpp
+++ b/score/os/test/grp_test.cpp
@@ -26,7 +26,7 @@ TEST(GetGrNam, ReturnsCorrectBuffer)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Returns Correct Buffer");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto group_name{"root"};
@@ -41,7 +41,7 @@ TEST(GetGrNam, SecondCallDoesNotOverwriteBuffer)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Second Call Does Not Overwrite Buffer");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto group_name_root{"root"};
@@ -74,7 +74,7 @@ TEST(GetGrNam, ReturnsErrorWhenGroupUnknown)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Returns Error When Group Unknown");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto group_name{"invalid"};
@@ -88,7 +88,7 @@ TEST(GetGrNam, ReturnsErrorWhenGroupNameSizeBiggerThanSupported)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Returns Error When Group Name Size Bigger Than Supported");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto group_name{"VeryVeryVeryVeryGroup"};

--- a/score/os/test/inotify_test.cpp
+++ b/score/os/test/inotify_test.cpp
@@ -51,7 +51,7 @@ TEST_F(InotifyTest, AddWatchSuccessfull)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Successfull");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto wd = score::os::Inotify::instance().inotify_add_watch(
@@ -64,7 +64,7 @@ TEST_F(InotifyTest, AddWatchFailsIfDirectoryDoesNotExist)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Fails If Directory Does Not Exist");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto wd =
@@ -78,7 +78,7 @@ TEST_F(InotifyTest, AddWatchFailsWithoutInit)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Fails Without Init");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto wd =
@@ -92,7 +92,7 @@ TEST_F(InotifyTest, AddWatchFailsWithEBADF)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Fails With EBADF");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto wd =
@@ -106,7 +106,7 @@ TEST_F(InotifyTest, RemoveWatchSuccessfull)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Successfull");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto wd = score::os::Inotify::instance().inotify_add_watch(
@@ -121,7 +121,7 @@ TEST_F(InotifyTest, RemoveWatchFailsWithoutInit)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Fails Without Init");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto ret = score::os::Inotify::instance().inotify_rm_watch(1, 1);
@@ -134,7 +134,7 @@ TEST_F(InotifyTest, RemoveWatchFailsWithEBADF)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Fails With EBADF");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto ret = score::os::Inotify::instance().inotify_rm_watch(-1, 0);
@@ -147,7 +147,7 @@ TEST_F(InotifyTest, RemoveWatchFailsWithInvalidArguments)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Fails With Invalid Arguments");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto ret = score::os::Inotify::instance().inotify_rm_watch(0, 0);

--- a/score/os/test/ioctl_test.cpp
+++ b/score/os/test/ioctl_test.cpp
@@ -32,7 +32,7 @@ TEST(IoctlTest, ReadNumberOfCharactorsWaitingToBeRead)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -53,7 +53,7 @@ TEST(IoctlTest, InvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl for invalid file descriptor");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     const auto invalid_fd = -1;
@@ -77,7 +77,7 @@ TEST_F(IoctlMockTest, NoAdditionalArgument)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_CALL(ioctlmock, ioctl(1, 2, An<void*>()));
@@ -89,7 +89,7 @@ TEST_F(IoctlMockTest, Integer)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto value{0};
@@ -102,7 +102,7 @@ TEST_F(IoctlMockTest, Pointer)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
-    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_CALL(ioctlmock, ioctl(1, 2, An<void*>()))

--- a/score/os/test/libgen_test.cpp
+++ b/score/os/test/libgen_test.cpp
@@ -21,7 +21,7 @@ TEST(LibgenImplTest, GetBaseName)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LibgenImplTest Get Base Name");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char input1[] = "usr";
@@ -39,7 +39,7 @@ TEST(LibgenImplTest, GetDirName)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LibgenImplTest Get Dir Name");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char input1[] = "/foo/bar";
@@ -62,7 +62,7 @@ TEST(LibgenTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LibgenTest PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/mmanTest.cpp
+++ b/score/os/test/mmanTest.cpp
@@ -29,7 +29,7 @@ TEST(mmap, MapAndUnmap)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Map And Unmap");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"mmap_file"};
@@ -62,7 +62,7 @@ TEST(mmap, MapFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Map Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto offset{0};
@@ -84,7 +84,7 @@ TEST(mmap, UnmapFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Unmap Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     void* invalid_address = reinterpret_cast<void*>(0xDEADBEEF);
@@ -99,7 +99,7 @@ TEST(mmap, OpenAndCloseSharedMemory)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Open And Close Shared Memory");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "/test_mmap";
@@ -118,7 +118,7 @@ TEST(mmap, ShmOpenNonExistingFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Shm Open Non Existing File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "";
@@ -134,7 +134,7 @@ TEST(mmap, UnlinkNonExistentSharedMemory)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Unlink Non Existent Shared Memory");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = score::os::Mman::instance().shm_unlink("");
@@ -148,7 +148,7 @@ TEST(mmap, OpenInvalidTypedMemory)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Open Invalid Typed Memory");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "";
@@ -167,7 +167,7 @@ TEST(mmap, GetInfoInvalidFD)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Get Info Invalid FD");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t invalid_fd = -1;
@@ -184,7 +184,7 @@ TEST(mmap, OpenTypedMemory)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Open Typed Memory");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "/memory";
@@ -208,7 +208,7 @@ TEST(mmap, InfoTypedMemory)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Info Typed Memory");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "/memory";
@@ -232,7 +232,7 @@ TEST(mmap, DefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Default Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto default_instance = score::os::Mman::Default();
@@ -245,7 +245,7 @@ TEST(MmanTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MmanTest PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/mount_test.cpp
+++ b/score/os/test/mount_test.cpp
@@ -26,7 +26,7 @@ TEST(MountTest, MountTestMountFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MountTest Mount Test Mount Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::mkdir("/mnt/home", S_IRWXU | S_IRWXG | S_IRWXO);
@@ -41,7 +41,7 @@ TEST(MountTest, MountTestUmountFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MountTest Mount Test Umount Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* dir = "/mnt/home";
@@ -54,7 +54,7 @@ TEST(MountTest, MountTestConvertFlag)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MountTest Mount Test Convert Flag");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::mkdir("/mnt/home", S_IWUSR | S_IWGRP | S_IWOTH);

--- a/score/os/test/mqueue_test.cpp
+++ b/score/os/test/mqueue_test.cpp
@@ -45,7 +45,7 @@ TEST_F(MqueueTest, mq_open_succeeds)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_open_succeeds");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Mqueue::OpenFlag flags{Mqueue::OpenFlag::kCreate};
@@ -65,7 +65,7 @@ TEST_F(MqueueTest, mq_open_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_open_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Mqueue::OpenFlag flags{Mqueue::OpenFlag::kExclusive};
@@ -78,7 +78,7 @@ TEST_F(MqueueTest, mq_open_failure_without_create_flag)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_open_failure_without_create_flag");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Mqueue::OpenFlag flags{Mqueue::OpenFlag::kReadOnly};
@@ -90,7 +90,7 @@ TEST_F(MqueueTest, mq_unlink_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_unlink_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(mqueue_.mq_unlink(m_name_.c_str()).has_value());
@@ -101,7 +101,7 @@ TEST_F(MqueueTest, mq_send_and_timedreceive_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_send_and_timedreceive_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string message = "Test Message";
@@ -155,7 +155,7 @@ TEST_F(MqueueTest, mq_send_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_send_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string message = "Test Message";
@@ -185,7 +185,7 @@ TEST_F(MqueueTest, mq_timedsend_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_timedsend_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string message = "Test Message";
@@ -217,7 +217,7 @@ TEST_F(MqueueTest, mq_timedreceive_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_timedreceive_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     mq_attr attr;
@@ -247,7 +247,7 @@ TEST_F(MqueueTest, mq_timedsend_and_mq_receive_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_timedsend_and_mq_receive_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string message = "Test Message";
@@ -304,7 +304,7 @@ TEST_F(MqueueTest, mq_receive_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_receive_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char buffer[100];
@@ -319,7 +319,7 @@ TEST_F(MqueueTest, mq_close_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_close_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto mqd =
@@ -338,7 +338,7 @@ TEST_F(MqueueTest, mq_close_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_close_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = mqueue_.mq_close(kInvalidMqd);
@@ -350,7 +350,7 @@ TEST_F(MqueueTest, mq_getattr_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_getattr_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     mq_attr attr;
@@ -373,7 +373,7 @@ TEST_F(MqueueTest, mq_getattr_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_getattr_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     mq_attr attr;
@@ -386,7 +386,7 @@ TEST_F(MqueueTest, modeflag_to_nativeflag)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest modeflag_to_nativeflag");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     using OpenFlag = Mqueue::OpenFlag;
@@ -404,7 +404,7 @@ TEST(SchedTest, get_instance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedTest get_instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_NO_FATAL_FAILURE(Mqueue::instance());

--- a/score/os/test/pthread_test.cpp
+++ b/score/os/test/pthread_test.cpp
@@ -106,7 +106,7 @@ TEST_F(PthreadNameTest, GetCpuClockIdFails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadNameTest Get Cpu Clock Id Fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_t thread;
@@ -183,7 +183,7 @@ TEST(PthreadTestingInstanceTest, RestoresOriginalAfterSettingTestingInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadTestingInstanceTest Restores Original After Setting Testing Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const Pthread* instance = &Pthread::instance();
@@ -221,7 +221,7 @@ TEST_F(PthreadMockTest, SetNameCallsPOSIXAPI)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMockTest Set Name Calls POSIXAPI");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(mock_pthread, setname_np);
@@ -233,7 +233,7 @@ TEST_F(PthreadMockTest, GetNameCallsPOSIXAPI)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMockTest Get Name Calls POSIXAPI");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(mock_pthread, getname_np);
@@ -245,7 +245,7 @@ TEST(PthreadCondAttrTest, Init)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Init");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_condattr_t attr{};
@@ -258,7 +258,7 @@ TEST(PthreadCondAttrTest, SetPSharedSetsNewAttribute)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Set PShared Sets New Attribute");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_condattr_t attr{};
@@ -276,7 +276,7 @@ TEST(PthreadCondAttrTest, SetPSharedFailsWhenNewAttributeUnknown)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Set PShared Fails When New Attribute Unknown");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_condattr_t attr{};
@@ -291,7 +291,7 @@ TEST(PthreadCondAttrTest, Destroy)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Destroy");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_condattr_t attr{};
@@ -304,7 +304,7 @@ TEST(PthreadCondTest, Init)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondTest Init");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_cond_t cond{};
@@ -318,7 +318,7 @@ TEST(PthreadCondTest, Destroy)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondTest Destroy");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_cond_t cond{};
@@ -331,7 +331,7 @@ TEST(PthreadMutexAttrTest, Init)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Init");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_mutexattr_t attr{};
@@ -344,7 +344,7 @@ TEST(PthreadMutexAttrTest, SetPSharedSetsNewAttribute)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Set PShared Sets New Attribute");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_mutexattr_t attr{};
@@ -362,7 +362,7 @@ TEST(PthreadMutexAttrTest, SetPSharedFailsWhenNewAttributeUnknown)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Set PShared Fails When New Attribute Unknown");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_mutexattr_t attr{};
@@ -377,7 +377,7 @@ TEST(PthreadMutexAttrTest, Destroy)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Destroy");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_mutexattr_t attr{};
@@ -390,7 +390,7 @@ TEST(PthreadMutexTest, Init)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexTest Init");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_mutex_t mutex{};
@@ -404,7 +404,7 @@ TEST(PthreadMutexTest, Destroy)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexTest Destroy");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pthread_mutex_t mutex{};
@@ -417,7 +417,7 @@ TEST(PthreadMutexTest, DestroyFailsIfMutexLockedByOtherThread)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexTest Destroy Fails If Mutex Locked By Other Thread");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // TSAN is rightly complaining that we try to destroy a locked mutex. But this behavior is the core of the test.
@@ -457,7 +457,7 @@ TEST(PthreadSchedParamTest, SetSchedParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Set Sched Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<pthread_t> thread_id_promise{};
@@ -489,7 +489,7 @@ TEST(PthreadSchedParamTest, SetSchedParamFailsWithInvalidThread)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Set Sched Param Fails With Invalid Thread");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<pthread_t> thread_id_promise{};
@@ -516,7 +516,7 @@ TEST(PthreadSchedParamTest, GetSchedParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Get Sched Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<pthread_t> thread_id_promise{};
@@ -556,7 +556,7 @@ TEST(PthreadSchedParamTest, GetSchedParamFailsWithJoinedThread)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Get Sched Param Fails With Joined Thread");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<pthread_t> thread_id_promise{};

--- a/score/os/test/qnx/channel_impl_test.cpp
+++ b/score/os/test/qnx/channel_impl_test.cpp
@@ -82,7 +82,7 @@ TEST_F(ChannelImplFixture, MsgReceiveReturnsErrorIfInvalidChId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receive returns Error If Invalid Ch Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = unit_->MsgReceive(kInvalidId, kNoMsg, kNoBytes, kNoInfo);
@@ -94,7 +94,7 @@ TEST_F(ChannelImplFixture, MsgReceivevReturnsErrorIfInvalidChId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receivev returns Error If Invalid Ch Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto riov_size = 8;
@@ -110,7 +110,7 @@ TEST_F(ChannelImplFixture, MsgReceivePulseReturnsErrorIfInvalidChId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receive Pulse returns Error If Invalid Ch Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = unit_->MsgReceivePulse(kInvalidId, kNoMsg, kNoBytes, kNoInfo);
@@ -122,7 +122,7 @@ TEST_F(ChannelImplFixture, MsgReplyReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message reply returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto buff_size = 255;
@@ -138,7 +138,7 @@ TEST_F(ChannelImplFixture, MsgReplyvReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message reply returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto riov_size = 8;
@@ -154,7 +154,7 @@ TEST_F(ChannelImplFixture, MsgErrorReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Error returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t error = EOK;
@@ -167,7 +167,7 @@ TEST_F(ChannelImplFixture, MsgSendReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MessageData data{};
@@ -180,7 +180,7 @@ TEST_F(ChannelImplFixture, MsgSendvReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Sendv returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto iov_size = 8;
@@ -197,7 +197,7 @@ TEST_F(ChannelImplFixture, SetIovFillsPredefinedMsgData)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Set Iov Fills Predefined Msg Data");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iov_t msg{};
@@ -215,7 +215,7 @@ TEST_F(ChannelImplFixture, SetIovConstFillsPredefinedMsgData)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Set Iov Const Fills Predefined Msg Data");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iov_t msg{};
@@ -233,7 +233,7 @@ TEST_F(ChannelImplFixture, MsgSendPulseReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t calling_thread_priority{-1};
@@ -250,7 +250,7 @@ TEST_F(ChannelImplFixture, MsgSendPulsePtrReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse Ptr returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t calling_thread_priority{-1};
@@ -267,7 +267,7 @@ TEST_F(ChannelImplFixture, MsgDeliverEventReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Deliver Event returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr sigevent* no_event{nullptr};
@@ -280,7 +280,7 @@ TEST_F(ChannelImplFixture, ConnectClientInfoReturnsErrorIfNonExistingCoid)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Client Info returns Error If Non Existing Coid");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr int32_t non_existing_coid{std::numeric_limits<int32_t>::min()};
@@ -297,7 +297,7 @@ TEST_F(ChannelImplFixture, ConnectAttachReturnsErrorIfInvalidInput)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach returns Error If Invalid Input");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = unit_->ConnectAttach(kAttachId, kInvalidPid, kInvalidId, kAttachIndex, kAttachFlags);
@@ -309,7 +309,7 @@ TEST_F(ChannelImplFixture, ConnectDetachReturnsErrorIfInvalidRcvId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Detach returns Error If Invalid Rcv Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = unit_->ConnectDetach(kInvalidId);
@@ -321,7 +321,7 @@ TEST_F(ChannelImplFixture, ConnectAttachAndDetatchFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach And Detatch Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto chid = ChannelCreate(kOpenFlags);
@@ -336,7 +336,7 @@ TEST_F(ChannelImplFixture, ConnectAttachAndMsgRegisterEventFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach And Msg Register Event Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto chid = ChannelCreate(kOpenFlags);
@@ -355,7 +355,7 @@ TEST_F(ChannelImplFixture, MsgRegisterEventReturnsError)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MsgRegisterEvent returns error if called with invalid connection id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr sigevent* no_event{nullptr};
@@ -368,7 +368,7 @@ TEST_F(ChannelImplFixture, MsgDeliverEventFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Deliver Event Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // This test sends MsgDeliverEvent from main thread to client.
@@ -453,7 +453,7 @@ TEST_F(ChannelImplFixture, MessageFlow_SendReceiveReply)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Flow: Send receive Reply");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     /*

--- a/score/os/test/qnx/channel_test.cpp
+++ b/score/os/test/qnx/channel_test.cpp
@@ -71,7 +71,7 @@ TEST_F(ChannelMockTest, MsgReceive)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Receive");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgReceive);
@@ -83,7 +83,7 @@ TEST_F(ChannelMockTest, MsgReceivePulse)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receive Pulse");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgReceivePulse);
@@ -95,7 +95,7 @@ TEST_F(ChannelMockTest, MsgReply)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Reply");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgReply);
@@ -107,7 +107,7 @@ TEST_F(ChannelMockTest, MsgError)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Error");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgError);
@@ -119,7 +119,7 @@ TEST_F(ChannelMockTest, MsgSend)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Send");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgSend);
@@ -131,7 +131,7 @@ TEST_F(ChannelMockTest, MsgSendPulse)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgSendPulse);
@@ -143,7 +143,7 @@ TEST_F(ChannelMockTest, MsgSendPulsePtr)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse Ptr");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgSendPulsePtr);
@@ -155,7 +155,7 @@ TEST_F(ChannelMockTest, MsgDeliverEvent)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Deliver Event");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgDeliverEvent);
@@ -167,7 +167,7 @@ TEST_F(ChannelMockTest, ConnectClientInfo)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Client Info");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, ConnectClientInfo);
@@ -179,7 +179,7 @@ TEST_F(ChannelMockTest, ConnectAttach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, ConnectAttach);
@@ -191,7 +191,7 @@ TEST_F(ChannelMockTest, ConnectDetach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Detach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, ConnectDetach);
@@ -203,7 +203,7 @@ TEST_F(ChannelMockTest, MsgRegisterEvent)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Msg Register Event");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(channelmock, MsgRegisterEvent);
@@ -217,7 +217,7 @@ TEST(ChannelTest, CoverUnhappyPaths)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Cover Unhappy Paths");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& channel = score::os::Channel::instance();
@@ -375,7 +375,7 @@ TEST(ChannelTest, CheckHappyFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Happy Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& channel = score::os::Channel::instance();
@@ -428,7 +428,7 @@ TEST(ChannelCreateInstance, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/qnx/devctl_test.cpp
+++ b/score/os/test/qnx/devctl_test.cpp
@@ -45,7 +45,7 @@ TEST_F(DevctlTestMock, TestFunction_Devctl)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function Devctl");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::array<std::uint8_t, 3> dev_data{1, 2, 3};
@@ -75,7 +75,7 @@ TEST_F(DevctlTestMock, TestFunction_Devctlv)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function Devctlv");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::array<std::uint8_t, 3> vec_data_1{1, 2, 3};
@@ -124,7 +124,7 @@ TEST_F(DevctlTestQnx, TestDevctl_GetFlags_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Get Flags Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
@@ -148,7 +148,7 @@ TEST_F(DevctlTestQnx, TestDevctlv_GetFlags_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl:v Get Flags Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
@@ -180,7 +180,7 @@ TEST_F(DevctlTestQnx, TestDevctl_SetGetFlags_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Set Get Flags Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
@@ -208,7 +208,7 @@ TEST_F(DevctlTestQnx, TestDevctl_SetFlagsWrongFd_Fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Set Flags Wrong Fd Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t set_flags{O_APPEND | O_LARGEFILE};
@@ -221,7 +221,7 @@ TEST_F(DevctlTestQnx, TestDevctlv_SetFlagsWrongFd_Fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl:v Set Flags Wrong Fd Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto res_devctl = score::os::Devctl::instance().devctlv(-1, DCMD_ALL_SETFLAGS, 0, 0, nullptr, nullptr, nullptr);
@@ -233,7 +233,7 @@ TEST_F(DevctlTestQnx, TestDevctl_GetFlagsNullptr_Fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Get Flags Nullptr Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};

--- a/score/os/test/qnx/dispatch_impl_test.cpp
+++ b/score/os/test/qnx/dispatch_impl_test.cpp
@@ -39,7 +39,7 @@ TEST_F(DispatchImplFixture, NameOpenCloseFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Open Close Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* const path = "tmp";
@@ -61,7 +61,7 @@ TEST_F(DispatchImplFixture, dispatch_unblock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Unblock");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -90,7 +90,7 @@ TEST_F(DispatchImplFixture, resmgr_detachReturnsErrorIfPassInvalidId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Detach returns Error If Pass Invalid Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -108,7 +108,7 @@ TEST_F(DispatchImplFixture, thread_pool_create_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Thread Pool Create Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     thread_pool_attr_t pool_attr{};
@@ -121,7 +121,7 @@ TEST_F(DispatchImplFixture, select_attach_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Attach Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -145,7 +145,7 @@ TEST_F(DispatchImplFixture, select_attach_frozen_context_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Attach Frozen Context Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t no_chid{-1};
@@ -176,7 +176,7 @@ TEST_F(DispatchImplFixture, select_detach_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Detach Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -202,7 +202,7 @@ TEST_F(DispatchImplFixture, select_detach_not_attached_fd_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Detach Not Attached Fd Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -222,7 +222,7 @@ TEST_F(DispatchImplFixture, pulse_attach_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Attach Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -246,7 +246,7 @@ TEST_F(DispatchImplFixture, pulse_attach_frozen_context_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Attach Frozen Context Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t no_chid{-1};
@@ -281,7 +281,7 @@ TEST_F(DispatchImplFixture, pulse_detach_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Detach Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -307,7 +307,7 @@ TEST_F(DispatchImplFixture, pulse_detach_not_attached_code_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Detach Not Attached Code Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = unit_->dispatch_create();
@@ -328,7 +328,7 @@ TEST_F(DispatchImplFixture, thread_pool_start_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Thread Pool Start Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     thread_pool_attr_t pool_attr{};

--- a/score/os/test/qnx/dispatch_test.cpp
+++ b/score/os/test/qnx/dispatch_test.cpp
@@ -73,7 +73,7 @@ TEST_F(DispatchMockTest, name_attach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Attach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, name_attach);
@@ -85,7 +85,7 @@ TEST_F(DispatchMockTest, name_detach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Detach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, name_detach);
@@ -97,7 +97,7 @@ TEST_F(DispatchMockTest, name_open)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Open");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, name_open);
@@ -109,7 +109,7 @@ TEST_F(DispatchMockTest, name_close)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Close");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, name_close);
@@ -121,7 +121,7 @@ TEST_F(DispatchMockTest, dispatch_create)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Create");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_create);
@@ -133,7 +133,7 @@ TEST_F(DispatchMockTest, dispatch_create_channel)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Create Channel");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_create_channel);
@@ -145,7 +145,7 @@ TEST_F(DispatchMockTest, dispatch_destroy)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Destroy");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_destroy);
@@ -157,7 +157,7 @@ TEST_F(DispatchMockTest, dispatch_context_alloc)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Context Alloc");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_context_alloc);
@@ -169,7 +169,7 @@ TEST_F(DispatchMockTest, dispatch_context_free)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Context Free");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_context_free);
@@ -181,7 +181,7 @@ TEST_F(DispatchMockTest, dispatch_block)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Block");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_block);
@@ -193,7 +193,7 @@ TEST_F(DispatchMockTest, dispatch_unblock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Unblock");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_unblock);
@@ -205,7 +205,7 @@ TEST_F(DispatchMockTest, dispatch_handler)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Handler");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, dispatch_handler);
@@ -217,7 +217,7 @@ TEST_F(DispatchMockTest, resmgr_attach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Attach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, resmgr_attach);
@@ -230,7 +230,7 @@ TEST_F(DispatchMockTest, resmgr_detach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Detach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, resmgr_detach);
@@ -242,7 +242,7 @@ TEST_F(DispatchMockTest, resmgr_msgget)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Msgget");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, resmgr_msgget);
@@ -254,7 +254,7 @@ TEST_F(DispatchMockTest, message_connect)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Connect");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(dispatchmock, message_connect);
@@ -266,7 +266,7 @@ TEST_F(DispatchMockTest, message_attach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Attach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t (*const noHandler)(
@@ -283,7 +283,7 @@ TEST(DispatchTest, name_attach_to_invalid_path_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Attach To Invalid Path Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -296,7 +296,7 @@ TEST(DispatchTest, name_detach_from_invalid_id_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Detach From Invalid Id Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -313,7 +313,7 @@ TEST(DispatchTest, name_open_invalid_path_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Open Invalid Path Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -326,7 +326,7 @@ TEST(DispatchTest, name_close_invalid_id_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Close Invalid Id Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -339,7 +339,7 @@ TEST(DispatchTest, dispatch_handler_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Handler Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -354,7 +354,7 @@ TEST(DispatchTest, CheckServerHappyFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Server Happy Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -621,7 +621,7 @@ TEST_F(DispatchResourceManagerTest, CheckResourceManagerHappyFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Resource Manager Happy Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto& dispatch = score::os::Dispatch::instance();
@@ -907,7 +907,7 @@ TEST_F(DispatchClientTest, DispatchClientHappyFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Client Happy Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // prepare the client setup
@@ -938,7 +938,7 @@ TEST(DispatchTestFinal, resmgr_attach_without_privileges_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Attach Without Privileges Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto dpp = score::os::Dispatch::instance().dispatch_create();
@@ -958,7 +958,7 @@ TEST(DispatchCreateInstance, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/qnx/fs_crypto_impl_test.cpp
+++ b/score/os/test/qnx/fs_crypto_impl_test.cpp
@@ -50,7 +50,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_add_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_add Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -68,7 +68,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_set_domain_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_file_set_domain Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent/test";
@@ -84,7 +84,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_add_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_add Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t bytes_length = 64;
@@ -103,7 +103,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_query_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_query Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -119,7 +119,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_query_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_query Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent/test";
@@ -135,7 +135,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_unlock_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_unlock Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -151,7 +151,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_unlock_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_unlock Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent/test";
@@ -168,7 +168,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_set_domain_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_file_set_domain Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent/test";
@@ -184,7 +184,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_remove_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_remove Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent/test";
@@ -200,7 +200,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_remove_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_remove Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";

--- a/score/os/test/qnx/fs_crypto_test.cpp
+++ b/score/os/test/qnx/fs_crypto_test.cpp
@@ -30,7 +30,7 @@ TEST(FsCrypto, CreateObjectSuccessful)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Create Object Successful");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto fscrypto = score::os::qnx::FsCrypto::createFsCryptoInstance();
@@ -64,7 +64,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_remove_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_remove Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -82,7 +82,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_remove_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_remove Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -100,7 +100,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_add_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_add Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t bytes_length = 512;
@@ -122,7 +122,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_add_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_add Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t bytes_length = 1;
@@ -144,7 +144,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_query_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_query Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -162,7 +162,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_query_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_query Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -180,7 +180,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_unlock_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_unlock Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -200,7 +200,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_unlock_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_unlock Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -220,7 +220,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_file_set_domain_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_file_set_domain Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";
@@ -238,7 +238,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_file_set_domain_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_file_set_domain Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* path = "/persistent";

--- a/score/os/test/qnx/inout_test.cpp
+++ b/score/os/test/qnx/inout_test.cpp
@@ -39,7 +39,7 @@ TEST_F(InoutTestFixture, in8TestToReturnNoErrorIfpassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "In Test To Return No Error Ifpass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->in8(address_);
@@ -51,7 +51,7 @@ TEST_F(InoutTestFixture, in16ReturnsNoErrorIfPassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "In returns No Error If Pass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->in16(address_);
@@ -63,7 +63,7 @@ TEST_F(InoutTestFixture, in32ReturnNoErrorIfPassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "In Return No Error If Pass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->in32(address_);
@@ -75,7 +75,7 @@ TEST_F(InoutTestFixture, out8ReturnNoErrorIfPassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Out Return No Error If Pass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->out8(address_, 0xAA);
@@ -87,7 +87,7 @@ TEST_F(InoutTestFixture, out16ReturnNoErrorIfPassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Out Return No Error If Pass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->out16(address_, 0xAA);
@@ -99,7 +99,7 @@ TEST_F(InoutTestFixture, out32ReturnNoErrorIfPassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Out Return No Error If Pass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->out32(address_, 0xAA);

--- a/score/os/test/qnx/iofunc_test.cpp
+++ b/score/os/test/qnx/iofunc_test.cpp
@@ -54,7 +54,7 @@ TEST(IoFuncTest, InstanceCall)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Instance Call");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // check whether instance() returns injection
@@ -86,7 +86,7 @@ TEST_F(IoFuncMockTest, iofunc_attr_init)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Init");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_attr_init);
@@ -98,7 +98,7 @@ TEST_F(IoFuncMockTest, iofunc_func_init)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Func Init");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_func_init);
@@ -110,7 +110,7 @@ TEST_F(IoFuncMockTest, iofunc_mount_init)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Mount Init");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_mount_init);
@@ -122,7 +122,7 @@ TEST_F(IoFuncMockTest, iofunc_close_ocb_default)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Close Ocb Default");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_close_ocb_default);
@@ -134,7 +134,7 @@ TEST_F(IoFuncMockTest, iofunc_devctl_default)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_devctl_default);
@@ -146,7 +146,7 @@ TEST_F(IoFuncMockTest, iofunc_write_verify)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Write Verify");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_write_verify);
@@ -158,7 +158,7 @@ TEST_F(IoFuncMockTest, iofunc_read_verify)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Read Verify");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_read_verify);
@@ -170,7 +170,7 @@ TEST_F(IoFuncMockTest, iofunc_lseek_default)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Lseek Default");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(iofuncmock, iofunc_lseek_default);
@@ -198,7 +198,7 @@ TEST_F(IoFuncFixture, iofunc_close_ocb_default_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Close Ocb Default Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -214,7 +214,7 @@ TEST_F(IoFuncFixture, iofunc_mount_init_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Mount Init Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iofunc_mount_t mount_point{};
@@ -231,7 +231,7 @@ TEST_F(IoFuncFixture, iofunc_mount_init_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Mount Init Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iofunc_mount_t mount_point{};
@@ -245,7 +245,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_return_resmgr_default_with_un
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Return Resmgr Default With Unknown Dmcd");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -261,7 +261,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_return_data_with_dcmd_all_get
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Return Data With Dcmd All Getflags");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -278,7 +278,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_fail_with_dcmd_all_setflags_i
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Fail With Dcmd All Setflags Incomplete Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -298,7 +298,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_succeed_with_dcmd_all_setflag
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Succeed With Dcmd All Setflags Complete Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -318,7 +318,7 @@ TEST_F(IoFuncFixture, iofunc_write_verifyReturnsErrorIfInvalidCtp)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Write Verify returns Error If Invalid Ctp");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -335,7 +335,7 @@ TEST_F(IoFuncFixture, iofunc_read_verifyReturnsErrorIfInvalidCtp)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Read Verify returns Error If Invalid Ctp");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -352,7 +352,7 @@ TEST_F(IoFuncFixture, iofunc_lseek_defaultReturnsErrorIfInvalidMsg)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Lseek Default returns Error If Invalid Msg");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -368,7 +368,7 @@ TEST(IoFuncTest, iofunc_write_verify_fails_for_empty_parameters)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Write Verify Fails For Empty Parameters");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -386,7 +386,7 @@ TEST(IoFuncCreateInstance, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
@@ -400,7 +400,7 @@ TEST(IoFuncTest, iofunc_client_info_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Client Info Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -417,7 +417,7 @@ TEST(IoFuncTest, iofunc_client_info_free_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc client_info_free success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct _client_info* pinfo{nullptr};
@@ -433,7 +433,7 @@ TEST(IoFuncTest, iofunc_check_access_failure_client_info_nullptr)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Check Access Failure Client Info Nullptr");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -451,7 +451,7 @@ TEST(IoFuncTest, iofunc_check_access_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Check Access Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -472,7 +472,7 @@ TEST(IoFuncTest, iofunc_attr_lock_failure_invalid_mutex)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Lock Failure Invalid Mutex");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iofunc_attr_t attr{};
@@ -491,7 +491,7 @@ TEST(IoFuncTest, iofunc_attr_unlock_failure_invalid_mutex)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Unlock Failure Invalid Mutex");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iofunc_attr_t attr{};
@@ -510,7 +510,7 @@ TEST(IoFuncTest, iofunc_attr_lock_unlock_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Lock Unlock Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     iofunc_attr_t attr{};
@@ -528,7 +528,7 @@ TEST(IoFuncTest, iofunc_open_failure_both_attr_nullptr)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Open Failure Both Attr Nullptr");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -547,7 +547,7 @@ TEST(IoFuncTest, iofunc_open_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Open Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};
@@ -568,7 +568,7 @@ TEST(IoFuncTest, iofunc_ocb_attach_failure_invalid_ctp)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Ocb Attach Failure Invalid Ctp");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     resmgr_context_t ctp{};

--- a/score/os/test/qnx/mman_test.cpp
+++ b/score/os/test/qnx/mman_test.cpp
@@ -36,7 +36,7 @@ TEST_F(MmanTestFixture, MmapMunmapDeviceIOReturnNoErrorIfPassValidAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Munmap Device Io Return No Error If Pass Valid Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->mmap_device_io(1, address_);
@@ -53,7 +53,7 @@ TEST_F(MmanTestFixture, ShmCtlFailsWithInvalidPhysicalAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Ctl Fails With Invalid Physical Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto shm_open_result = ::shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, 0000);
@@ -72,7 +72,7 @@ TEST_F(MmanTestFixture, ShmCtlSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Ctl Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "/memory";
@@ -95,7 +95,7 @@ TEST_F(MmanTestFixture, MemOffsetFailsWhenPassInvalidVirtualAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Fails When Pass Invalid Virtual Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     off_t physical_addr{};
@@ -110,7 +110,7 @@ TEST_F(MmanTestFixture, MemOffsetSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "/memory";
@@ -132,7 +132,7 @@ TEST_F(MmanTestFixture, MemOffset64FailsWhenPassInvalidVirtualAddress)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Fails When Pass Invalid Virtual Address");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     off_t physical_addr{};
@@ -147,7 +147,7 @@ TEST_F(MmanTestFixture, MemOffset64Succeeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* name = "/memory";
@@ -169,7 +169,7 @@ TEST_F(MmanTestFixture, ShmOpenSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t oflag = O_CREAT | O_RDWR;
@@ -186,7 +186,7 @@ TEST_F(MmanTestFixture, ShmOpenFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t oflag = O_RDWR;
@@ -202,7 +202,7 @@ TEST_F(MmanTestFixture, ShmOpenHandleSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Handle Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t fd = ::shm_open(shm_name, O_CREAT | O_RDWR, 0666);
@@ -226,7 +226,7 @@ TEST_F(MmanTestFixture, ShmOpenHandleFailsWithInvalidHandle)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Handle Fails With Invalid Handle");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     shm_handle_t invalid_handle = -1;
@@ -243,7 +243,7 @@ TEST_F(MmanTestFixture, ShmCreateHandleSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Create Handle Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
@@ -265,7 +265,7 @@ TEST_F(MmanTestFixture, ShmCreateHandleFailsWithBadFileDescritor)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Create Handle Fails With Bad File Descritor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t invalid_fd = -1;
@@ -285,7 +285,7 @@ TEST_F(MmanTestFixture, MmapSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t length = 4096;
@@ -305,7 +305,7 @@ TEST_F(MmanTestFixture, MmapFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t length = 0;
@@ -325,7 +325,7 @@ TEST_F(MmanTestFixture, Mmap64Succeeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t length = 4096;
@@ -345,7 +345,7 @@ TEST_F(MmanTestFixture, Mmap64Fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t length = 0;
@@ -365,7 +365,7 @@ TEST_F(MmanTestFixture, MunmapSucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Munmap Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t length = 4096;
@@ -387,7 +387,7 @@ TEST_F(MmanTestFixture, MunmapFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Munmap Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t invalid_length = 0;

--- a/score/os/test/qnx/neutrino_impl_test.cpp
+++ b/score/os/test/qnx/neutrino_impl_test.cpp
@@ -29,7 +29,7 @@ TEST_F(NeutrinoImplFixture, ThreadCtlTestReturnsError)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Thread Ctl Test returns Error");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t cmd = 0xFFFFFFFF;
@@ -45,7 +45,7 @@ TEST_F(NeutrinoImplFixture, ThreadCtlGetThreadNme)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Thread Ctl Get Thread Nme");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t valid_cmd{_NTO_TCTL_NAME};
@@ -67,7 +67,7 @@ TEST_F(NeutrinoImplFixture, InterruptAttachAndDetachTest)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Attach And Detach Test");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::uint64_t timeout{0U};
@@ -97,7 +97,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateDeprecatedSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Deprecated Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::uint32_t valid_flags{0U};
@@ -111,7 +111,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateDeprecatedFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Deprecated Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto invalid_flags{std::numeric_limits<std::uint32_t>::max()};
@@ -126,7 +126,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = neutrino_.ChannelCreate(Neutrino::ChannelFlag::kDisconnect);
@@ -138,7 +138,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result =
@@ -152,7 +152,7 @@ TEST_F(NeutrinoImplFixture, ChannelDestroySuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Destroy Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto channel_id = neutrino_.ChannelCreate(Neutrino::ChannelFlag::kDisconnect);
@@ -167,7 +167,7 @@ TEST_F(NeutrinoImplFixture, ChannelDestroyFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Destroy Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t failed_channel_id = 0;
@@ -180,7 +180,7 @@ TEST_F(NeutrinoImplFixture, ClockAdjustSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Adjust Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     clockid_t clockid{CLOCK_REALTIME};
@@ -202,7 +202,7 @@ TEST_F(NeutrinoImplFixture, ClockAdjust_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Adjust Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     clockid_t invalid_clockid{-1};
@@ -219,7 +219,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutDeprecatedSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Deprecated Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     clockid_t clockid{CLOCK_REALTIME};
@@ -254,7 +254,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutDeprecatedFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Deprecated Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     clockid_t clockid{-1};
@@ -279,7 +279,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::unique_ptr<score::os::SigEvent> signal_event1 = std::make_unique<score::os::SigEventQnxImpl>();
@@ -321,7 +321,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test TimerTimeout Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::unique_ptr<score::os::SigEvent> signal_event = nullptr;
@@ -342,7 +342,7 @@ TEST_F(NeutrinoImplFixture, ClockCyclesMonotonicity)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Cycles Monotonicity");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto start = neutrino_.ClockCycles();
@@ -355,7 +355,7 @@ TEST_F(NeutrinoImplFixture, ClockCyclesElapsedTime)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Cycles Elapsed Time");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto start = neutrino_.ClockCycles();
@@ -370,7 +370,7 @@ TEST_F(NeutrinoImplFixture, ClockIdSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
     pid_t pid = ::getpid();
     int32_t tid = ::gettid();

--- a/score/os/test/qnx/neutrino_showcase_test.cpp
+++ b/score/os/test/qnx/neutrino_showcase_test.cpp
@@ -258,7 +258,7 @@ TEST_F(NeutrinoTest, TimerTimeoutCalledOnMessageSend)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Called On Message Send");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -336,7 +336,7 @@ TEST_F(NeutrinoTest, TimerTimeoutCalledOnMessageSend_1)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Called On Message Send");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -483,7 +483,7 @@ TEST_F(NeutrinoTest, TimerTimeoutCalledOnMessageReply)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Called On Message Reply");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -569,7 +569,7 @@ TEST_F(NeutrinoTest, TimerTimeoutOnMessageReceive)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout On Message Receive");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto create_server = CreateNamedServer();
@@ -598,7 +598,7 @@ TEST_F(NeutrinoTest, TimerTimeoutNeverCalledWrongFlag)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Never Called Wrong Flag");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -682,7 +682,7 @@ TEST_F(NeutrinoTest, TimerTimeoutNeverCalledChannelUnblockFlag)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Never Called Channel Unblock Flag");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -776,7 +776,7 @@ TEST_F(NeutrinoTest, TestServerPulseOnClientShutdown)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Test Server Pulse On Client Shutdown");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -883,7 +883,7 @@ TEST_F(NeutrinoTest, TestSendErrorOnServerDeath)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Test send Error On Server Death");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;
@@ -948,7 +948,7 @@ TEST_F(NeutrinoTest, TestClientPulseOnServerDeath)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Test Client Pulse On Server Death");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::mutex client_server_sync_mutex;

--- a/score/os/test/qnx/neutrino_test.cpp
+++ b/score/os/test/qnx/neutrino_test.cpp
@@ -52,7 +52,7 @@ TEST_F(NeutrinoMockTest, TimerTimeoutRawSigevent)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigevent raw_signal_event;
@@ -65,7 +65,7 @@ TEST_F(NeutrinoMockTest, TimerTimeout)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::unique_ptr<score::os::SigEvent> signal_event{std::make_unique<score::os::SigEventQnxImpl>()};
@@ -80,7 +80,7 @@ TEST_F(NeutrinoMockTest, ClockAdjust)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Adjust");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     _clockadjust adjustment{0, 0};
@@ -94,7 +94,7 @@ TEST_F(NeutrinoMockTest, ThreadCtl)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Thread Ctl");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t cmd = _NTO_TCTL_IO;
@@ -108,7 +108,7 @@ TEST_F(NeutrinoMockTest, InterruptWait_r)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Wait R");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t flags = 0;
@@ -122,7 +122,7 @@ TEST_F(NeutrinoMockTest, InterruptAttachEvent)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Attach Event");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t intr = _NTO_INTR_CLASS_EXTERNAL;
@@ -137,7 +137,7 @@ TEST_F(NeutrinoMockTest, InterruptDetach)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Detach");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t id = 0;
@@ -151,7 +151,7 @@ TEST_F(NeutrinoMockTest, InterruptUnmask)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Unmask");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t intr = _NTO_INTR_CLASS_EXTERNAL;
@@ -166,7 +166,7 @@ TEST_F(NeutrinoMockTest, ChannelCreate)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto flags{Neutrino::ChannelFlag::kConnectionIdDisconnect};
@@ -180,7 +180,7 @@ TEST_F(NeutrinoMockTest, ChannelDestroy)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Destroy");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
     const auto dummy_channel_id = 0;
     EXPECT_CALL(*neutrino_mock_ptr, ChannelDestroy(dummy_channel_id));

--- a/score/os/test/qnx/pcap_test.cpp
+++ b/score/os/test/qnx/pcap_test.cpp
@@ -77,7 +77,7 @@ TEST_F(PcapFixture, PcapOpenLiveSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Open Live Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -88,7 +88,7 @@ TEST_F(PcapFixture, PcapOpenLiveFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Open Live Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = pcap_->pcap_open_live("invalid_device", kSnapLenTooLarge, 1, kPacketBufferDelay, errbuf_.data());
@@ -100,7 +100,7 @@ TEST_F(PcapFixture, PcapOpenDeadSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Open Dead Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = pcap_->pcap_open_dead(DLT_EN10MB, kSnapLenSmall);
@@ -113,7 +113,7 @@ TEST_F(PcapFixture, PcapLoopSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Loop Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -126,7 +126,7 @@ TEST_F(PcapFixture, PcapBreakloopSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Breakloop Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -139,7 +139,7 @@ TEST_F(PcapFixture, PcapCloseSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Close Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -153,7 +153,7 @@ TEST_F(PcapFixture, PcapGeterrSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Geterr Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -166,7 +166,7 @@ TEST_F(PcapFixture, PcapBreakloopFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Breakloop Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = pcap_->pcap_breakloop(nullptr);
@@ -178,7 +178,7 @@ TEST_F(PcapFixture, PcapCloseFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Close Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = pcap_->pcap_close(nullptr);
@@ -190,7 +190,7 @@ TEST_F(PcapFixture, PcapGeterrWithNullPcap)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Geterr With Null Pcap");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = pcap_->pcap_geterr(nullptr);
@@ -202,7 +202,7 @@ TEST_F(PcapFixture, PcapLoopFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Loop Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -217,7 +217,7 @@ TEST_F(PcapFixture, PcapCompileSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -233,7 +233,7 @@ TEST_F(PcapFixture, PcapCompileFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -249,7 +249,7 @@ TEST_F(PcapFixture, PcapCompileFailure2)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -264,7 +264,7 @@ TEST_F(PcapFixture, PcapCompileFailure3)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -279,7 +279,7 @@ TEST_F(PcapFixture, PcapSetFilterSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Set Filter Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -297,7 +297,7 @@ TEST_F(PcapFixture, PcapSetFilterFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Set Filter Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -311,7 +311,7 @@ TEST_F(PcapFixture, PcapSetFilterFailure2)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Set Filter Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -324,7 +324,7 @@ TEST_F(PcapFixture, PcapFreeCodeSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Free Code Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -343,7 +343,7 @@ TEST_F(PcapFixture, PcapFreeCodeFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Free Code Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -356,7 +356,7 @@ TEST_F(PcapFixture, PcapDumpOpenSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -370,7 +370,7 @@ TEST_F(PcapFixture, PcapDumpOpenFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -384,7 +384,7 @@ TEST_F(PcapFixture, PcapDumpOpenFailure2)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -397,7 +397,7 @@ TEST_F(PcapFixture, PcapDumpOpenFailure3)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -411,7 +411,7 @@ TEST_F(PcapFixture, PcapDumpSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -441,7 +441,7 @@ TEST_F(PcapFixture, PcapDumpFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -466,7 +466,7 @@ TEST_F(PcapFixture, PcapDumpFailure2)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -487,7 +487,7 @@ TEST_F(PcapFixture, PcapDumpFailure3)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -507,7 +507,7 @@ TEST_F(PcapFixture, PcapDumpCloseSuccess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Close Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();
@@ -522,7 +522,7 @@ TEST_F(PcapFixture, PcapDumpCloseFailure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Close Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     GetMeADevice();

--- a/score/os/test/qnx/pci_safety_test.cpp
+++ b/score/os/test/qnx/pci_safety_test.cpp
@@ -33,7 +33,7 @@ TEST_F(PciSafetylTest, pci_device_cfg_rd32_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Cfg Rd Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -49,7 +49,7 @@ TEST_F(PciSafetylTest, pci_device_read_did_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Did Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -64,7 +64,7 @@ TEST_F(PciSafetylTest, pci_device_read_vid_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Vid Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;

--- a/score/os/test/qnx/pci_test.cpp
+++ b/score/os/test/qnx/pci_test.cpp
@@ -38,7 +38,7 @@ TEST_F(PciTest, pci_device_read_cmd_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Cmd Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -53,7 +53,7 @@ TEST_F(PciTest, pci_device_read_cmd_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Cmd Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_cmd_t cmd;
@@ -67,7 +67,7 @@ TEST_F(PciTest, pci_device_attach_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Attach Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -81,7 +81,7 @@ TEST_F(PciTest, pci_device_read_ba_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Ba Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_devhdl_t hdl;
@@ -95,7 +95,7 @@ TEST_F(PciTest, pci_device_read_ba_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Ba Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
@@ -117,7 +117,7 @@ TEST_F(PciTest, pci_device_cfg_rd32_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Cfg Rd Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -133,7 +133,7 @@ TEST_F(PciTest, pci_device_cfg_rd32_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Cfg Rd Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::uint16_t offset{64U};
@@ -149,7 +149,7 @@ TEST_F(PciTest, pci_device_read_did_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Did Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -164,7 +164,7 @@ TEST_F(PciTest, pci_device_read_did_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Did Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_did_t did;
@@ -178,7 +178,7 @@ TEST_F(PciTest, pci_device_read_vid_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Vid Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf;
@@ -193,7 +193,7 @@ TEST_F(PciTest, pci_device_read_vid_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Vid Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_vid_t vid;
@@ -207,7 +207,7 @@ TEST_F(PciTest, pci_device_detach_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Detach Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
@@ -223,7 +223,7 @@ TEST_F(PciTest, pci_device_detach_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Detach Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_devhdl_t hdl = static_cast<pci_devhdl_t>(0);  // Invalid handle
@@ -235,7 +235,7 @@ TEST_F(PciTest, pci_device_find_succeed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Find Succeed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_vid_t vid = 0xFFFF;
@@ -249,7 +249,7 @@ TEST_F(PciTest, pci_device_find_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Find Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pci_vid_t vid = 0x1234;

--- a/score/os/test/qnx/procmgr_test.cpp
+++ b/score/os/test/qnx/procmgr_test.cpp
@@ -42,7 +42,7 @@ TEST_F(ProcMgrMockTest, procmgr_ability)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Ability");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(procmgrmock, procmgr_ability(kCurrentPid, PROCMGR_AID_EOL));
@@ -54,7 +54,7 @@ TEST(ProcMgrTest, procmgr_subrange_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Subrange Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_FALSE(score::os::ProcMgr::instance().procmgr_ability(kCurrentPid, PROCMGR_AID_EOL | PROCMGR_AOP_SUBRANGE));
@@ -65,7 +65,7 @@ TEST(ProcMgrTest, procmgr_generic_invalid_pid_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Generic Invalid Pid Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_FALSE(score::os::ProcMgr::instance().procmgr_ability(kInvalidPid, PROCMGR_AID_EOL));
@@ -76,7 +76,7 @@ TEST(ProcMgrTest, procmgr_invalid_ability_fails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Invalid Ability Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_FALSE(score::os::ProcMgr::instance().procmgr_ability(
@@ -88,7 +88,7 @@ TEST(ProcMgrTest, procmgr_generic_succeeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Generic Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_TRUE(score::os::ProcMgr::instance().procmgr_ability(kCurrentPid,
@@ -100,7 +100,7 @@ TEST(ProcMgrTest, procmgr_specific_succeeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Specific Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_TRUE(score::os::ProcMgr::instance().procmgr_ability(
@@ -112,7 +112,7 @@ TEST(ProcMgrTest, procmgr_ability_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Ability Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = score::os::ProcMgr::instance().procmgr_ability(
@@ -130,7 +130,7 @@ TEST(ProcMgrTest, procmgr_ability_failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Ability Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result =
@@ -144,7 +144,7 @@ TEST(ProcMgrTest, procmgr_daemon_success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Daemon Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = score::os::ProcMgr::instance().procmgr_daemon(

--- a/score/os/test/qnx/pthread_test.cpp
+++ b/score/os/test/qnx/pthread_test.cpp
@@ -41,7 +41,7 @@ TEST(QnxPthreadTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/qnx/resmgr_test.cpp
+++ b/score/os/test/qnx/resmgr_test.cpp
@@ -22,7 +22,7 @@ TEST(ResMgrTest, ResMgrMsgWriteFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Res Mgr Msg Write Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::ResMgrImpl resmgr;

--- a/score/os/test/qnx/secpol_test.cpp
+++ b/score/os/test/qnx/secpol_test.cpp
@@ -28,7 +28,7 @@ TEST(SecpolTest, InstanceCall)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Instance Call");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // check whether instance() returns injection
@@ -60,7 +60,7 @@ TEST_F(SecpolFixture, secpol_openOpenNullPath)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Open Open Null Path");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* const path{nullptr};
@@ -76,7 +76,7 @@ TEST_F(SecpolFixture, secpol_openOpenDoubleCallFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Open Open Double Call Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* const path{nullptr};
@@ -95,7 +95,7 @@ TEST_F(SecpolFixture, secpol_posix_spawnattr_settypeid)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Posix Spawnattr Settypeid");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr{};
@@ -112,7 +112,7 @@ TEST_F(SecpolFixture, secpol_transition_type)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Transition Type");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     secpol_file_t* handle{nullptr};

--- a/score/os/test/qnx/sigevent_qnx_test.cpp
+++ b/score/os/test/qnx/sigevent_qnx_test.cpp
@@ -43,7 +43,7 @@ TEST_F(SigEventQnxTest, SetUnblock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set unblock");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     signal_event_qnx_->SetUnblock();
@@ -57,7 +57,7 @@ TEST_F(SigEventQnxTest, SetPulse)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set pulse");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     signal_event_qnx_->SetPulse(kConnectionId, kPriority, kCode, kSignalEventValue);
@@ -75,7 +75,7 @@ TEST_F(SigEventQnxTest, SetSignalThread)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set signal thread");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     signal_event_qnx_->SetSignalThread(kSignalNumber, kSignalEventValue, kThreadId);
@@ -91,7 +91,7 @@ TEST_F(SigEventQnxTest, SetSignalCode)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set signal code");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     signal_event_qnx_->SetSignalCode(kSignalNumber, kSignalEventValue, kSignalCode);
@@ -108,7 +108,7 @@ TEST_F(SigEventQnxTest, SetMemory)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set memory");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     volatile std::uint32_t dummy_mem = 0;
@@ -126,7 +126,7 @@ TEST_F(SigEventQnxTest, SetInterrupt)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set interrupt");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     signal_event_qnx_->SetInterrupt();
@@ -140,7 +140,7 @@ TEST_F(SigEventQnxTest, SetSignalEventValue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set signal event value");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SigEventErrorCodeDomain errorDomain;
@@ -175,7 +175,7 @@ TEST_F(SigEventQnxTest, Reset)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest reset sigevent");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = signal_event_qnx_->SetNotificationType(SigEvent::NotificationType::kThread);
@@ -206,7 +206,7 @@ TEST_F(SigEventQnxTest, Getter)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest getters sigevent");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto&& const_ref = signal_event_qnx_->GetSigevent();
@@ -219,7 +219,7 @@ TEST_F(SigEventQnxTest, ModifySigevent)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest modify sigevent");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     signal_event_qnx_->ModifySigevent([](sigevent& raw_sigevent) {

--- a/score/os/test/qnx/slog2_test.cpp
+++ b/score/os/test/qnx/slog2_test.cpp
@@ -36,7 +36,7 @@ TEST_F(Slog2ImplFixture, slog2_registerReturnsErrorIfSetNumBuffersToZero)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog Register returns Error If Set Num Buffers To Zero");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     slog2_buffer_set_config_t buffer_config{};
@@ -61,7 +61,7 @@ TEST_F(Slog2ImplFixture, slog2SetVerbosityFailsWhenInvalidVerbosity)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog Set Verbosity Fails When Invalid Verbosity");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr uint8_t invalid_level = INT8_MAX;
@@ -75,7 +75,7 @@ TEST_F(Slog2ImplFixture, slog2cReturnsErrorIfNotRegisteredSlog2)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog C returns Error If Not Registered Slog");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     slog2_buffer_t buffer_handle[1]{};
@@ -87,7 +87,7 @@ TEST_F(Slog2ImplFixture, slog2fReturnsErrorIfNotRegisteredSlog2)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog F returns Error If Not Registered Slog");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     slog2_buffer_t buffer_handle[1]{};
@@ -99,7 +99,7 @@ TEST_F(Slog2ImplFixture, RegisterAndLogFlow)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Register And Log Flow");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     /*
@@ -151,7 +151,7 @@ TEST(Slog2Test, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/qnx/sysctl_test.cpp
+++ b/score/os/test/qnx/sysctl_test.cpp
@@ -49,7 +49,7 @@ TEST_F(SysctlTestMock, TestFunction_sysctl)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctl");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t RETURN_LENGTH = 100;
@@ -89,7 +89,7 @@ TEST_F(SysctlTestMock, TestFunction_sysctlbyname)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctlbyname");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::size_t RETURN_LENGTH = 100;
@@ -126,7 +126,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctl_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctl Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::array<std::int32_t, 2> sys_name = {
@@ -146,7 +146,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctl_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctl Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::array<std::int32_t, 6> sys_name = {1, 2, 3, 4, 5, 6};
@@ -161,7 +161,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlbyname_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctlbyname Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::size_t sys_len{};
@@ -180,7 +180,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlbyname_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctlbyname Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto res = instance_.sysctlbyname("", nullptr, nullptr, nullptr, 0);
@@ -192,7 +192,7 @@ TEST_F(SysctlTestMock, TestFunction_sysctlnametomib)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "Test Function sysctlnametomib");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* sys_name = "some.dummy.parameter";
@@ -222,7 +222,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlnametomib_Success)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "Test Function sysctlnametomib Success");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     int mib[4] = {0};
@@ -238,7 +238,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlnametomib_Failure)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "Test Function sysctlnametomib Failure");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     int mib[4] = {0};

--- a/score/os/test/qnx/thread_ctl_test.cpp
+++ b/score/os/test/qnx/thread_ctl_test.cpp
@@ -40,7 +40,7 @@ TEST_F(ThreadCtlTest, succeed_reading_current_thread_name)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Succeed Reading Current Thread Name");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const pid_t pid{0};
@@ -58,7 +58,7 @@ TEST_F(ThreadCtlTest, fails_on_invalid_pid_tid_combination)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Fails On Invalid Pid Tid Combination");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const pid_t pid{1};

--- a/score/os/test/qnx/timer_test.cpp
+++ b/score/os/test/qnx/timer_test.cpp
@@ -46,7 +46,7 @@ TEST_F(TimerTest, timer_create_succeed_for_realtime_clock_nullptr_event)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Create Succeed For Realtime Clock Nullptr Event");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = timer_->TimerCreate(CLOCK_REALTIME, nullptr);
@@ -58,7 +58,7 @@ TEST_F(TimerTest, timer_create_succeed_for_realtime_clock_real_struct_event)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Create Succeed For Realtime Clock Real Struct Event");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = timer_->TimerCreate(CLOCK_REALTIME, &event_);
@@ -70,7 +70,7 @@ TEST_F(TimerTest, timer_create_fail_for_invalid_clock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Create Fail For Invalid Clock");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = timer_->TimerCreate(kInvalidId, &event_);
@@ -84,7 +84,7 @@ TEST_F(TimerTest, timer_settime_succeed_for_realtime_clock_nullptr_event)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Settime Succeed For Realtime Clock Nullptr Event");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto timer_id = timer_->TimerCreate(CLOCK_REALTIME, nullptr);
@@ -99,7 +99,7 @@ TEST_F(TimerTest, timer_settime_fail_for_invalid_clock_id)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Settime Fail For Invalid Clock Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = timer_->TimerSettime(kInvalidId, TIMER_ABSTIME, &expiration_time_, nullptr);
@@ -113,7 +113,7 @@ TEST_F(TimerTest, timer_destroy_succeed_for_created_monotonic_clock_timer)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Destroy Succeed For Created Monotonic Clock Timer");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto timer_id = timer_->TimerCreate(CLOCK_MONOTONIC, nullptr);
@@ -128,7 +128,7 @@ TEST_F(TimerTest, timer_destroy_fail_for_invalid_clock_id)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Destroy Fail For Invalid Clock Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = timer_->TimerDestroy(kInvalidId);
@@ -142,7 +142,7 @@ TEST_F(TimerTest, timer_settime_fail_after_timer_destroy)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Settime Fail After Timer Destroy");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto timer_id = timer_->TimerCreate(CLOCK_REALTIME, nullptr);

--- a/score/os/test/qnx/unistd_test.cpp
+++ b/score/os/test/qnx/unistd_test.cpp
@@ -69,7 +69,7 @@ TEST_F(QnxUnistdImplFixture, SetgroupspidReturnsErrorIfPassInvalidParams)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set groups pid returns Error If Pass Invalid Params");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->setgroupspid(-1, nullptr, 0);
@@ -81,7 +81,7 @@ TEST_F(QnxUnistdImplFixture, SetgroupspidNewGroupAdded)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set groups pid New Group Added");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ForkAndExpectTrue([]() noexcept {
@@ -135,7 +135,7 @@ TEST_F(QnxUnistdFixture, SetuidChangesUidIfPassValidId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set uid Changes Uid If Pass Valid Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_EQ(::getuid(), 0);
@@ -154,7 +154,7 @@ TEST_F(QnxUnistdFixture, SetGidSetsGidIfPassValidId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set Gid Sets Gid If Pass Valid Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_EQ(::getuid(), 0);

--- a/score/os/test/sched_test.cpp
+++ b/score/os/test/sched_test.cpp
@@ -38,7 +38,7 @@ TEST_F(SchedImplTest, sched_setparam_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setparam_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param set_params;
@@ -55,7 +55,7 @@ TEST_F(SchedImplTest, sched_getparam_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getparam_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param set_params;
@@ -72,7 +72,7 @@ TEST_F(SchedImplTest, sched_getparam_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getparam_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(sched_.sched_getparam(kInvalidPid, nullptr).has_value());
@@ -83,7 +83,7 @@ TEST_F(SchedImplTest, sched_setscheduler_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setscheduler_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param param;
@@ -97,7 +97,7 @@ TEST_F(SchedImplTest, sched_setscheduler_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setscheduler_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param params;
@@ -114,7 +114,7 @@ TEST_F(SchedImplTest, sched_getscheduler_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getscheduler_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param params;
@@ -131,7 +131,7 @@ TEST_F(SchedImplTest, sched_getscheduler_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getscheduler_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(sched_.sched_getscheduler(kInvalidPid).has_value());
@@ -142,7 +142,7 @@ TEST_F(SchedImplTest, sched_setparam_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setparam_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(sched_.sched_setparam(kInvalidPid, nullptr).has_value());
@@ -153,7 +153,7 @@ TEST_F(SchedImplTest, sched_yield_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_yield_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_TRUE(sched_.sched_yield().has_value());
@@ -164,7 +164,7 @@ TEST_F(SchedImplTest, sched_rr_get_interval_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_rr_get_interval_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec ts;
@@ -179,7 +179,7 @@ TEST_F(SchedImplTest, sched_rr_get_interval_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_rr_get_interval_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(sched_.sched_rr_get_interval(kInvalidPid, nullptr).has_value());
@@ -190,7 +190,7 @@ TEST_F(SchedImplTest, sched_get_priority_max_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_max_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto prio_max = sched_.sched_get_priority_max(kPolicy);
@@ -207,7 +207,7 @@ TEST_F(SchedImplTest, sched_get_priority_min_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_min_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto prio_min = sched_.sched_get_priority_min(kPolicy);
@@ -224,7 +224,7 @@ TEST_F(SchedImplTest, sched_get_priority_min_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_min_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(sched_.sched_get_priority_min(kInvalidPolicy).has_value());
@@ -235,7 +235,7 @@ TEST_F(SchedImplTest, sched_get_priority_max_fails)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_max_fails");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(sched_.sched_get_priority_max(kInvalidPolicy).has_value());
@@ -246,7 +246,7 @@ TEST(SchedTest, CanGetInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedTest Can Get Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_NO_FATAL_FAILURE(Sched::instance());
@@ -258,7 +258,7 @@ TEST_F(SchedImplTest, sched_get_priority_adjust_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_adjust_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t priority = 3;

--- a/score/os/test/select_test.cpp
+++ b/score/os/test/select_test.cpp
@@ -31,7 +31,7 @@ TEST(SelectTest, selectPass)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SelectTest select Pass");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::SelectImpl select;
@@ -50,7 +50,7 @@ TEST(SelectTest, selectPassInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SelectTest select Pass Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Select& select = score::os::Select::instance();

--- a/score/os/test/semaphore_test.cpp
+++ b/score/os/test/semaphore_test.cpp
@@ -45,7 +45,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemOpen)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Open");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto ret_open_create = unit_.sem_open(m_name_.c_str(),
@@ -68,7 +68,7 @@ TEST_F(SemaphoreTestFixture, FailureSemOpen)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Failure Sem Open");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* invalid_path = "/invalid_path";
@@ -82,7 +82,7 @@ TEST_F(SemaphoreTestFixture, FailureSemOpenWithoutCreateFlag)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Failure Sem Open Without Create Flag");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* invalid_path = "/invalid_path";
@@ -96,7 +96,7 @@ TEST_F(SemaphoreTestFixture, SuccessGetValue)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Get Value");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t sval;
@@ -117,7 +117,7 @@ TEST_F(SemaphoreTestFixture, FailureSemPost)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Failure Sem Post");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto valid_sem =
@@ -138,7 +138,7 @@ TEST_F(SemaphoreTestFixture, SuccessTimedWait)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Timed Wait");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     timespec abs_time{};
@@ -157,7 +157,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemOpenAllModes)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Open All Modes");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::vector<score::os::Semaphore::ModeFlag> mode_vector = {Semaphore::ModeFlag::kReadUser,
@@ -186,7 +186,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemWait)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Wait");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto sem = ::sem_open(m_name_.c_str(), O_CREAT, S_IRUSR, value_);
@@ -211,7 +211,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemPost)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Post");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto sem = ::sem_open(m_name_.c_str(), O_CREAT, S_IRUSR, value_);
@@ -236,7 +236,7 @@ TEST_F(SemaphoreTestFixture, SuccessTimedWaitFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Timed Wait Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     timespec abs_time{0, -1};
@@ -252,7 +252,7 @@ TEST(Semaphore, get_instance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Semaphore get_instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_NO_FATAL_FAILURE(Semaphore::instance());

--- a/score/os/test/sigevent_test.cpp
+++ b/score/os/test/sigevent_test.cpp
@@ -34,7 +34,7 @@ TEST_F(SigEventTest, SetNotificationType)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set notification types");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto none_notification = signal_event_->SetNotificationType(SigEvent::NotificationType::kNone);
@@ -65,7 +65,7 @@ TEST_F(SigEventTest, SetSignalNumber)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set signal number");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SigEventErrorCodeDomain errorDomain;
@@ -92,7 +92,7 @@ TEST_F(SigEventTest, SetSignalEventValue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set signal event value");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SigEventErrorCodeDomain errorDomain;
@@ -132,7 +132,7 @@ TEST_F(SigEventTest, SetThreadCallback)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set thread callback");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SigEventErrorCodeDomain errorDomain;
@@ -166,7 +166,7 @@ TEST_F(SigEventTest, SetThreadAttributes)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set thread attributes");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SigEventErrorCodeDomain errorDomain;
@@ -193,7 +193,7 @@ TEST_F(SigEventTest, Reset)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest reset sigevent");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto result = signal_event_->SetNotificationType(SigEvent::NotificationType::kThread);
@@ -224,7 +224,7 @@ TEST_F(SigEventTest, ModifySigevent)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest modify sigevent positive and negative scenarios");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t kTestSignalValue = 42;
@@ -246,7 +246,7 @@ TEST_F(SigEventTest, Getter)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest getter sigevent");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto&& const_ref = signal_event_->GetSigevent();
@@ -259,7 +259,7 @@ TEST_F(SigEventTest, DefaultError)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest default error sigevent");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SigEventErrorCodeDomain errorDomain;

--- a/score/os/test/spawn_test.cpp
+++ b/score/os/test/spawn_test.cpp
@@ -46,7 +46,7 @@ TEST_F(SpawnTest, posix_spawnattr_setflags_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setflags_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int16_t set_flags{POSIX_SPAWN_SETSIGDEF};
@@ -65,7 +65,7 @@ TEST_F(SpawnTest, posix_spawnattr_getflags_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getflags_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int16_t set_flags{POSIX_SPAWN_SETSIGDEF};
@@ -83,7 +83,7 @@ TEST(SpawnImpl, posix_spawnattr_getflags_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getflags_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int16_t set_flags{POSIX_SPAWN_SETSIGDEF};
@@ -104,7 +104,7 @@ TEST_F(SpawnTest, posix_spawnattr_setflags_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setflags_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto invalid_flag{-1};
@@ -121,7 +121,7 @@ TEST_F(SpawnTest, posix_spawnattr_sigsetdefault_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_sigsetdefault_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -143,7 +143,7 @@ TEST_F(SpawnTest, posix_spawnattr_getsigdefault_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getsigdefault_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -164,7 +164,7 @@ TEST(SpawnImpl, posix_spawnattr_setsigdefault_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setsigdefault_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -184,7 +184,7 @@ TEST(SpawnImpl, posix_spawnattr_getsigdefault_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getsigdefault_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -208,7 +208,7 @@ TEST_F(SpawnTest, posix_spawnattr_setsigmask_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setsigmask_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -230,7 +230,7 @@ TEST_F(SpawnTest, posix_spawnattr_getsigmask_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getsigmask_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -251,7 +251,7 @@ TEST(SpawnImpl, posix_spawnattr_setsigmask_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setsigmask_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -271,7 +271,7 @@ TEST(SpawnImpl, posix_spawnattr_getsigmask_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getsigmask_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -295,7 +295,7 @@ TEST_F(SpawnTest, posix_spawnattr_setpgroup_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setpgroup_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{4};
@@ -315,7 +315,7 @@ TEST_F(SpawnTest, posix_spawnattr_getpgroup_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getpgroup_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{4};
@@ -334,7 +334,7 @@ TEST(SpawnImpl, posix_spawnattr_setpgroup_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setpgroup_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{4};
@@ -351,7 +351,7 @@ TEST(SpawnImpl, posix_spawnattr_getpgroup_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getpgroup_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -368,7 +368,7 @@ TEST_F(SpawnTest, posix_spawnattr_setschedparam_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setschedparam_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param set_param;
@@ -387,7 +387,7 @@ TEST_F(SpawnTest, posix_spawnattr_getschedparam_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getschedparam_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct sched_param set_param;
@@ -406,7 +406,7 @@ TEST(SpawnImpl, posix_spawnattr_setschedparam_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setschedparam_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -424,7 +424,7 @@ TEST(SpawnImpl, posix_spawnattr_getschedparam_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getschedparam_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -441,7 +441,7 @@ TEST_F(SpawnTest, posix_spawnattr_setschedpolicy_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setschedpolicy_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t set_policy{1};
@@ -461,7 +461,7 @@ TEST_F(SpawnTest, posix_spawnattr_getschedpolicy_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getschedpolicy_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t set_policy{1};
@@ -480,7 +480,7 @@ TEST(SpawnImpl, posix_spawnattr_getschedpolicy_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getschedpolicy_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t set_policy{1};
@@ -501,7 +501,7 @@ TEST_F(SpawnTest, posix_spawnattr_setschedpolicy_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setschedpolicy_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t get_policy{};
@@ -518,7 +518,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_init_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_init_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -534,7 +534,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_destroy_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_destroy_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -550,7 +550,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addclose_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addclose_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -564,7 +564,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addopen_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addopen_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -586,7 +586,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addclose_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addclose_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -605,7 +605,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addopen_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addopen_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -622,7 +622,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_adddup2_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_adddup2_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -644,7 +644,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_adddup2_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_adddup2_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawn_file_actions_t file_actions;
@@ -659,7 +659,7 @@ TEST_F(SpawnTest, Spawn_succcess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawn_succcess");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{0};
@@ -684,7 +684,7 @@ TEST_F(SpawnTest, Spawn_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawn_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{-1};
@@ -703,7 +703,7 @@ TEST_F(SpawnTest, Spawnp_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawnp_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{0};
@@ -728,7 +728,7 @@ TEST_F(SpawnTest, Spawnp_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawnp_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     pid_t pid{-1};
@@ -748,7 +748,7 @@ TEST_F(SpawnTest, posix_spawnattr_setxflags_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setxflags_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_flags{POSIX_SPAWN_SETSIGMASK};
@@ -766,7 +766,7 @@ TEST_F(SpawnTest, posix_spawnattr_getxflags_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getxflags_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_flags{POSIX_SPAWN_SETSIGMASK};
@@ -784,7 +784,7 @@ TEST(SpawnImpl, posix_spawnattr_setxflags_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setxflags_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_flags{POSIX_SPAWN_SETSIGMASK};
@@ -802,7 +802,7 @@ TEST(SpawnImpl, posix_spawnattr_getxflags_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getxflags_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -819,7 +819,7 @@ TEST_F(SpawnTest, posix_spawnattr_getrunmask_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getrunmask_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_runmask{1};
@@ -837,7 +837,7 @@ TEST_F(SpawnTest, posix_spawnattr_setrunmask_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setrunmask_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_runmask{1};
@@ -855,7 +855,7 @@ TEST(SpawnImpl, posix_spawnattr_setrunmask_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setrunmask_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_runmask{1};
@@ -873,7 +873,7 @@ TEST(SpawnImpl, posix_spawnattr_getrunmask_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getrunmask_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -890,7 +890,7 @@ TEST_F(SpawnTest, posix_spawnattr_setsigignore_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setsigignore_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -915,7 +915,7 @@ TEST_F(SpawnTest, posix_spawnattr_getsigignore_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getsigignore_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t set_sigset;
@@ -939,7 +939,7 @@ TEST(SpawnImpl, posix_spawnattr_setsigignore_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setsigignore_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -958,7 +958,7 @@ TEST(SpawnImpl, posix_spawnattr_getsigignore_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getsigignore_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -976,7 +976,7 @@ TEST_F(SpawnTest, posix_spawnattr_setstackmax_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setstackmax_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_size{1};
@@ -994,7 +994,7 @@ TEST_F(SpawnTest, posix_spawnattr_getstackmax_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getstackmax_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_size{1};
@@ -1012,7 +1012,7 @@ TEST(SpawnImpl, posix_spawnattr_setstackmax_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setstackmax_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1029,7 +1029,7 @@ TEST(SpawnImpl, posix_spawnattr_getstackmax_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getstackmax_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1048,7 +1048,7 @@ TEST_F(SpawnTest, posix_spawnattr_setnode_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setnode_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_node{1};
@@ -1066,7 +1066,7 @@ TEST_F(SpawnTest, posix_spawnattr_getnode_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getnode_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_node{1};
@@ -1084,7 +1084,7 @@ TEST(SpawnImpl, posix_spawnattr_setnode_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setnode_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1101,7 +1101,7 @@ TEST(SpawnImpl, posix_spawnattr_getnode_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getnode_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1118,7 +1118,7 @@ TEST_F(SpawnTest, posix_spawnattr_setcred_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setcred_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const uid_t set_uid{1};
@@ -1139,7 +1139,7 @@ TEST_F(SpawnTest, posix_spawnattr_getcred_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getcred_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const uid_t set_uid{1};
@@ -1160,7 +1160,7 @@ TEST(SpawnImpl, posix_spawnattr_setcred_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setcred_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1178,7 +1178,7 @@ TEST(SpawnImpl, posix_spawnattr_getcred_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getcred_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1201,7 +1201,7 @@ TEST_F(SpawnTest, posix_spawnattr_settypeid_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_settypeid_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_type_id{1};
@@ -1219,7 +1219,7 @@ TEST_F(SpawnTest, posix_spawnattr_gettypeid_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_gettypeid_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_type_id{1};
@@ -1237,7 +1237,7 @@ TEST(SpawnImpl, posix_spawnattr_settypeid_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_settypeid_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1254,7 +1254,7 @@ TEST(SpawnImpl, posix_spawnattr_gettypeid_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_gettypeid_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1274,7 +1274,7 @@ TEST_F(SpawnTest, posix_spawnattr_setasid_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setasid_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t set_asid{1};
@@ -1288,7 +1288,7 @@ TEST(SpawnImpl, posix_spawnattr_setasid_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setasid_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1305,7 +1305,7 @@ TEST_F(SpawnTest, posix_spawnattr_setaslr_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setaslr_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const posix_spawnattr_aslr_t set_aslr = {};
@@ -1323,7 +1323,7 @@ TEST_F(SpawnTest, posix_spawnattr_getaslr_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getaslr_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const posix_spawnattr_aslr_t set_aslr = {};
@@ -1341,7 +1341,7 @@ TEST(SpawnImpl, posix_spawnattr_setaslr_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setaslr_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1358,7 +1358,7 @@ TEST(SpawnImpl, posix_spawnattr_getaslr_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getaslr_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1377,7 +1377,7 @@ TEST_F(SpawnTest, posix_spawnattr_setcwd_np_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setcwd_np_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::int32_t dirfd{1};
@@ -1391,7 +1391,7 @@ TEST(SpawnImpl, posix_spawnattr_setcwd_np_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setcwd_np_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     posix_spawnattr_t attr;
@@ -1408,7 +1408,7 @@ TEST_F(SpawnTest, spawn_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawn_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t fd_count{0};
@@ -1431,7 +1431,7 @@ TEST_F(SpawnTest, spawn_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawn_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char path[] = "/nonexistent/executable";
@@ -1450,7 +1450,7 @@ TEST_F(SpawnTest, spawnp_success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawnp_success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t fd_count{0};
@@ -1473,7 +1473,7 @@ TEST_F(SpawnTest, spawnp_failure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawnp_failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char file[] = "/nonexistent/executable";

--- a/score/os/test/stat_test.cpp
+++ b/score/os/test/stat_test.cpp
@@ -28,7 +28,7 @@ TEST(StatImpl, StatRegularFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Stat Regular File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"stat_file"};
@@ -49,7 +49,7 @@ TEST(StatImpl, StatSymbolicLink)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Stat Symbolic Link");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"stat_file"};
@@ -69,7 +69,7 @@ TEST(StatImpl, StatNonExistentFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Stat Non Existent File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* non_existent_file = "nonexistent/file";
@@ -87,7 +87,7 @@ TEST(StatImpl, fstatSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl fstat Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"stat_file"};
@@ -105,7 +105,7 @@ TEST(StatImpl, fstatFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl fstat Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto fd = -1;
@@ -118,7 +118,7 @@ TEST(StatImpl, MkdirFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Mkdir Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* directory = "/hd/src";
@@ -137,7 +137,7 @@ TEST(StatImpl, MkdirSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Mkdir Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* directory = "directory";
@@ -157,7 +157,7 @@ TEST(StatImpl, ChmodSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Chmod Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"stat_test_file"};
@@ -179,7 +179,7 @@ TEST(StatImpl, ChmodFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Chmod Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{""};
@@ -194,7 +194,7 @@ TEST(StatImpl, FchmodSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmod Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"stat_test_file"};
@@ -216,7 +216,7 @@ TEST(StatImpl, FchmodFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmod Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto fd = -1;
@@ -230,7 +230,7 @@ TEST(StatImpl, FchmodatSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmodat Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* file_name = "my_directory";
@@ -249,7 +249,7 @@ TEST(StatImpl, FchmodatErrorNoFollowSymlinks)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmodat Error No Follow Symlinks");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto filename{"stat_test_file"};
@@ -268,7 +268,7 @@ TEST(StatImpl, DefaultObjectAllocationIsNotNull)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Default Object Allocation Is Not Null");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = score::os::Stat::Default();
@@ -280,7 +280,7 @@ TEST(StatImpl, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/statvfs_test.cpp
+++ b/score/os/test/statvfs_test.cpp
@@ -28,7 +28,7 @@ TEST(StatvfsTest, StatvfsSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatvfsTest Statvfs Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char tmp_dir_template[] = "statvfs_test.XXXXXX";
@@ -59,7 +59,7 @@ TEST(StatvfsTest, StatvfsFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatvfsTest Statvfs Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct statvfs buf;

--- a/score/os/test/stdio_test.cpp
+++ b/score/os/test/stdio_test.cpp
@@ -27,7 +27,7 @@ TEST(FOpenTest, ReturnsValidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FOpenTest Returns Valid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"test"};
@@ -42,7 +42,7 @@ TEST(FOpenTest, ReturnsErrorWithWrongMode)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FOpenTest Returns Error With Wrong Mode");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"test"};
@@ -57,7 +57,7 @@ TEST(FCloseTest, ReturnsBlankValueIfSuccessful)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FCloseTest Returns Blank Value If Successful");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"test"};
@@ -74,7 +74,7 @@ TEST(FCloseTest, ReturnsErrorWithInvalidFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FCloseTest Returns Error With Invalid File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
 #if defined(GTEST_OS_LINUX)
@@ -92,7 +92,7 @@ TEST(RemoveTest, ReturnsBlankValueIfSuccessful)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RemoveTest Returns Blank Value If Successful");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"test"};
@@ -112,7 +112,7 @@ TEST(RemoveTest, ReturnsErrorIfFileDoesNotExist)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RemoveTest Returns Error If File Does Not Exist");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"test-invalid-file"};
@@ -126,7 +126,7 @@ TEST(RenameTest, ReturnsBlankValueIfSuccessful)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RenameTest Returns Blank Value If Successful");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"test"};
@@ -150,7 +150,7 @@ TEST(RenameTest, ReturnsErrorIfNameInvalid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RenameTest Returns Error If Name Invalid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto filename{"invalid-test"};
@@ -165,7 +165,7 @@ TEST(POpenTest, ReturnsValidPipe)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "POpenTest Returns Valid Pipe");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto cmd{"echo 1"};
@@ -187,7 +187,7 @@ TEST(POpenTest, ReturnsErrorWithInvalidMode)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "POpenTest Returns Error With Invalid Mode");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto cmd{"echo 1"};
@@ -202,7 +202,7 @@ TEST(PCloseTest, ProvidesReturnCodeOfPipeCommand)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PCloseTest Provides Return Code Of Pipe Command");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto cmd{"exit 1"};
@@ -222,7 +222,7 @@ TEST(FileNoTest, CanTranslateFileDescriptorOfStream)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FileNoTest Can Translate File Descriptor Of Stream");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = score::os::Stdio::instance().fileno(stdin);
@@ -235,7 +235,7 @@ TEST(FileNoTest, ReturnsErrorForInvalidFileStream)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FileNoTest Returns Error For Invalid File Stream");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
 #if defined(GTEST_OS_LINUX)

--- a/score/os/test/stdlib_impl_test.cpp
+++ b/score/os/test/stdlib_impl_test.cpp
@@ -30,7 +30,7 @@ TEST(StdlibImpl, system_call)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl system_call");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result = score::os::Stdlib::instance().system_call("ls /tmp");
@@ -42,7 +42,7 @@ TEST(StdlibImpl, system_callFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl system_call Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto result1 = score::os::Stdlib::Default()->system_call("d");
@@ -54,7 +54,7 @@ TEST(StdlibImpl, getenv)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl getenv");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(setenv("TEST_ENV", "TEST_VALUE", 0), 0);
@@ -68,7 +68,7 @@ TEST(StdlibImpl, realpath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl realpath");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char resolved_path[PATH_MAX];
@@ -83,7 +83,7 @@ TEST(StdlibImpl, realpath)
 
 TEST(StdlibImpl, calloc_fail)
 {
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("DerivationTechnique", "Analysis of requirements");
@@ -110,7 +110,7 @@ TEST(StdlibImpl, calloc)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl calloc");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto size = 2;
@@ -131,7 +131,7 @@ TEST(StdlibImpl, free)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl free");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto size = 1;
@@ -146,7 +146,7 @@ TEST(StdlibImpl, mkstemp)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemp");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char path[] = "/tmp/fileXXXXXX";
@@ -160,7 +160,7 @@ TEST(StdlibImpl, mkstempFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemp Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char path[] = "/tmp/fileXXXX";
@@ -173,7 +173,7 @@ TEST(StdlibImpl, mkstemps)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemps");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char path[] = "/tmp/fileXXXXXXsuffix";
@@ -187,7 +187,7 @@ TEST(StdlibImpl, mkstempsFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemps Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char path[] = "/tmp/fileXXXXXX";
@@ -200,7 +200,7 @@ TEST(StdlibTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibTest PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/string_impl_test.cpp
+++ b/score/os/test/string_impl_test.cpp
@@ -28,7 +28,7 @@ TEST(StringImplTest, StrMemcpy)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringImplTest Str Memcpy");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     StringImpl str;
@@ -43,7 +43,7 @@ TEST(StringImplTest, StrStderr)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringImplTest Str Stderr");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     StringImpl str;
@@ -55,7 +55,7 @@ TEST(StringImplTest, StrMemset)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringImplTest Str Memset");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     StringImpl str;

--- a/score/os/test/string_test.cpp
+++ b/score/os/test/string_test.cpp
@@ -26,7 +26,7 @@ TEST(StringTest, StringMemcpy)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringTest String Memcpy");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char src[] = "ABCDEFGHIJ";
@@ -45,7 +45,7 @@ TEST(StringTest, StringMemset)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringTest String Memset");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char dest[11];
@@ -59,7 +59,7 @@ TEST(StringTest, StringStrError)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringTest String Str Error");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     for (int i = 0; i < 10; ++i)

--- a/score/os/test/sys_poll_test.cpp
+++ b/score/os/test/sys_poll_test.cpp
@@ -43,7 +43,7 @@ TEST_F(SysPollImplTest, PollSucceeds)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysPollImplTest Poll Succeeds");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct pollfd fds[1];
@@ -63,7 +63,7 @@ TEST_F(SysPollImplTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysPollImplTest PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/sys_uio_test.cpp
+++ b/score/os/test/sys_uio_test.cpp
@@ -43,7 +43,7 @@ TEST_F(SysUioImplTest, WritevFailsBadFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysUioImplTest Writev Fails Bad Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr std::int32_t kInvalidFd{-1};
@@ -66,7 +66,7 @@ TEST_F(SysUioImplTest, WritevSucceeds)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysUioImplTest Writev Succeeds");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::array<iovec, 2UL> io{};
@@ -92,7 +92,7 @@ TEST_F(SysUioImplTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysUioImplTest PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/test/sys_wait_impl_test.cpp
+++ b/score/os/test/sys_wait_impl_test.cpp
@@ -51,7 +51,7 @@ TEST(SysWaitImplTest, Wait)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Wait");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::SysWaitImpl syswait;
@@ -72,7 +72,7 @@ TEST(SysWaitImplTest, WaitFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Wait Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::SysWait& syswait = score::os::SysWait::instance();
@@ -86,7 +86,7 @@ TEST(SysWaitImplTest, Waitpid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Waitpid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::SysWait& syswait = score::os::SysWait::instance();
@@ -107,7 +107,7 @@ TEST(SysWaitImplTest, WaitpidFail)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Waitpid Fail");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::SysWaitImpl syswait;

--- a/score/os/test/time_test.cpp
+++ b/score/os/test/time_test.cpp
@@ -30,7 +30,7 @@ TEST(TimeImplTest, ClockSettimeFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Settime Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec new_time;
@@ -54,7 +54,7 @@ TEST(TimeImplTest, ClockGetTimeSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Get Time Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec get_time{};
@@ -73,7 +73,7 @@ TEST(TimeImplTest, GettimeFailsWithInvalidClockId)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Gettime Fails With Invalid Clock Id");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec get_time{};
@@ -88,7 +88,7 @@ TEST(TimeImplTest, ClockSettimeSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Settime Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec new_time;
@@ -114,7 +114,7 @@ TEST(TimeImplTest, ClockGetResSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Get Res Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec get_res{};
@@ -133,7 +133,7 @@ TEST(TimeImplTest, ClockGetResFailsWithInvalidClockId)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Get Res Fails With Invalid Clock Id");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     struct timespec get_res{};
@@ -148,7 +148,7 @@ TEST(TimeImplTest, LocaltimeRSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Localtime RSuccess");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto current_time = std::chrono::system_clock::now();

--- a/score/os/test/uname_test.cpp
+++ b/score/os/test/uname_test.cpp
@@ -40,7 +40,7 @@ TEST_F(UnameTest, GetUnameSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnameTest Get Uname Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(unameMock, UnameWrapper(::testing::_)).WillOnce([](struct utsname* info) {
@@ -56,7 +56,7 @@ TEST_F(UnameTest, GetUnameFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnameTest Get Uname Failure");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(unameMock, UnameWrapper(::testing::_)).WillOnce([](struct utsname* info) {
@@ -72,7 +72,7 @@ TEST(UnameWrapperTest, Success)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnameWrapperTest Success");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Prepare the expected behavior

--- a/score/os/test/unistdTest.cpp
+++ b/score/os/test/unistdTest.cpp
@@ -131,7 +131,7 @@ TEST_F(UnistdFixture, CloseFileDescriptor)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Close File Descriptor");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some file
@@ -154,7 +154,7 @@ TEST_F(UnistdFixture, UnlinkRemovesFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unlink Removes File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some file without a reference count
@@ -176,7 +176,7 @@ TEST_F(UnistdFixture, UnlinkReturnsErrorIfNonExistingPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unlink Returns Error If Non Existing Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some non-existing file
@@ -193,7 +193,7 @@ TEST_F(UnistdFixture, PipeOpensWithoutError)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Pipe Opens Without Error");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     int32_t fds[2] = {};
@@ -211,7 +211,7 @@ TEST_F(UnistdFixture, DupReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->dup(kInvalidFd);
@@ -223,7 +223,7 @@ TEST_F(UnistdFixture, DupReturnsNoErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup Returns No Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t fds = 1;
@@ -237,7 +237,7 @@ TEST_F(UnistdFixture, Dup2ReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup2Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->dup2(kInvalidFd, kInvalidFd);
@@ -249,7 +249,7 @@ TEST_F(UnistdFixture, ReadReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr size_t buf_size = 32;
@@ -264,7 +264,7 @@ TEST_F(UnistdFixture, PReadReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PRead Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr size_t buf_size = 32;
@@ -279,7 +279,7 @@ TEST_F(UnistdFixture, PReadReturnsNonErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PRead Returns Non Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr size_t buf_size = 32;
@@ -299,7 +299,7 @@ TEST_F(UnistdFixture, WriteReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Write Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr size_t buf_size = 32;
@@ -314,7 +314,7 @@ TEST_F(UnistdFixture, PWriteReturnsNonErrorIfPassPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PWrite Returns Non Error If Pass Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr size_t buf_size = 32;
@@ -334,7 +334,7 @@ TEST_F(UnistdFixture, PWriteReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PWrite Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr size_t buf_size = 32;
@@ -349,7 +349,7 @@ TEST_F(UnistdFixture, LSeekReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture LSeek Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->lseek(kInvalidFd, 0, 0);
@@ -361,7 +361,7 @@ TEST_F(UnistdFixture, LSeekReturnsNonErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture LSeek Returns Non Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "lseek_test_file";
@@ -379,7 +379,7 @@ TEST_F(UnistdFixture, FTruncateReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FTruncate Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->ftruncate(-1, 0);
@@ -391,7 +391,7 @@ TEST_F(UnistdFixture, FTruncateNonErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FTruncate Non Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "ftruncate_test_file";
@@ -408,7 +408,7 @@ TEST_F(UnistdFixture, GetUiIdMatchSystemGetuid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Ui Id Match System Getuid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(unit_->getuid(), ::getuid());
@@ -419,7 +419,7 @@ TEST_F(UnistdFixture, GetGidMatchSystemGetGid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Gid Match System Get Gid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(unit_->getgid(), ::getgid());
@@ -430,7 +430,7 @@ TEST_F(UnistdFixture, GetPidMatchSystemGetPid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Pid Match System Get Pid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(unit_->getpid(), ::getpid());
@@ -441,7 +441,7 @@ TEST_F(UnistdFixture, GetPpidMatchSystemGetPpid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Ppid Match System Get Ppid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(unit_->getppid(), ::getppid());
@@ -452,7 +452,7 @@ TEST_F(UnistdFixture, SetuidNotChangesUidIfPassInvalidId)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Setuid Not Changes Uid If Pass Invalid Id");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ForkAndExpectTrue([this]() noexcept {
@@ -470,7 +470,7 @@ TEST_F(UnistdFixture, SetGidNotChangesGidIfPassInvalidId)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Set Gid Not Changes Gid If Pass Invalid Id");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ForkAndExpectTrue([this]() noexcept {
@@ -490,7 +490,7 @@ TEST_F(UnistdFixture, ReadLinkReturnsErrorIfPassEmptyPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Link Returns Error If Pass Empty Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char buf[4096] = {};
@@ -505,7 +505,7 @@ TEST_F(UnistdFixture, ReadLinkReturnsNoErrorIfPassValidPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Link Returns No Error If Pass Valid Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* target = "/etc/passwd";
@@ -535,7 +535,7 @@ TEST_F(UnistdFixture, FSyncReturnsErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FSync Returns Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->fsync(-1);
@@ -547,7 +547,7 @@ TEST_F(UnistdFixture, FSyncReturnsNonErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FSync Returns Non Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "fsync_test_file";
@@ -564,7 +564,7 @@ TEST_F(UnistdFixture, FDataSyncReturnsNonErrorIfPassInvalidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FData Sync Returns Non Error If Pass Invalid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->fdatasync(-1);
@@ -576,7 +576,7 @@ TEST_F(UnistdFixture, FDataSyncReturnsNonErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FData Sync Returns Non Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "fdata_sync_test_file";
@@ -593,7 +593,7 @@ TEST_F(UnistdFixture, NanosleepReturnsNonErrorIfPassValidSleepParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Nanosleep Returns Non Error If Pass Valid Sleep Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     timespec req{0, 10};
@@ -607,7 +607,7 @@ TEST_F(UnistdFixture, NanosleepReturnsErrorIfPassInvalidSleepParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Nanosleep Returns Error If Pass Invalid Sleep Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     timespec req{0, -10};
@@ -620,7 +620,7 @@ TEST_F(UnistdFixture, SysconfReturnsErrorIfPassInvalidParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Sysconf Returns Error If Pass Invalid Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->sysconf(kInvalidFd);
@@ -632,7 +632,7 @@ TEST_F(UnistdFixture, SysconfReturnsNonErrorIfPassValidParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Sysconf Returns Non Error If Pass Valid Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->sysconf(_SC_ARG_MAX);
@@ -644,7 +644,7 @@ TEST_F(UnistdFixture, LinkReturnsErrorIfPassEmptyPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Link Returns Error If Pass Empty Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->link("", "");
@@ -656,7 +656,7 @@ TEST_F(UnistdFixture, LinkReturnsNonErrorIfPassValidPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Link Returns Non Error If Pass Valid Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "link_test_file";
@@ -674,7 +674,7 @@ TEST_F(UnistdFixture, SymlinkReturnsErrorIfPassEmptyPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Symlink Returns Error If Pass Empty Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->symlink("", "");
@@ -686,7 +686,7 @@ TEST_F(UnistdFixture, SymlinkReturnsNonErrorIfPassValidPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Symlink Returns Non Error If Pass Valid Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path_link = "symlink_test_file_link";
@@ -704,7 +704,7 @@ TEST_F(UnistdFixture, ChdirReturnsErrorIfPassEmptyPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chdir Returns Error If Pass Empty Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->chdir("");
@@ -716,7 +716,7 @@ TEST_F(UnistdFixture, ChdirReturnsNonErrorIfPassValidPath)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chdir Returns Non Error If Pass Valid Path");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->chdir(".");
@@ -728,7 +728,7 @@ TEST_F(UnistdFixture, ChownReturnsErrorIfPassInvalidParams)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chown Returns Error If Pass Invalid Params");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->chown("", 0, 0);
@@ -740,7 +740,7 @@ TEST_F(UnistdFixture, ChownReturnsNonErrorIfPassValidParams)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chown Returns Non Error If Pass Valid Params");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const OpenFileGuard file_guard{"chown_test_file", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR};
@@ -758,7 +758,7 @@ TEST_F(UnistdFixture, GetcwdReturnsErrorIfPassNullBuffer)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Getcwd Returns Error If Pass Null Buffer");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char buffer{};
@@ -771,7 +771,7 @@ TEST_F(UnistdFixture, GetcwdReturnsNonErrorIfPassAllocatedBuffer)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Getcwd Returns Non Error If Pass Allocated Buffer");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     char buf[4096] = {};
@@ -784,7 +784,7 @@ TEST_F(UnistdFixture, AccessMatchesReadWriteAccessForExistingFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Access Matches Read Write Access For Existing File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some file
@@ -812,7 +812,7 @@ TEST_F(UnistdFixture, AccessReturnsErrorIfPassNonExistingFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Access Returns Error If Pass Non Existing File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some non existing file
@@ -836,7 +836,7 @@ TEST_F(UnistdFixture, AccessReturnsNonErrorForExistingFileWithReadWriteAccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Access Returns Non Error For Existing File With Read Write Access");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some file
@@ -864,7 +864,7 @@ TEST_F(UnistdFixture, UnistdAccessReturnsErrorIfPassNonExistingFile)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Access Returns Error If Pass Non Existing File");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // Given some non existing file
@@ -888,7 +888,7 @@ TEST_F(UnistdFixture, UnistdGettidReturnsPositiveTid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Gettid Returns Positive Tid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_GT(unit_->gettid(), 0);
@@ -899,7 +899,7 @@ TEST_F(UnistdFixture, UnistdAlarmSetsAndReportsPendingAlarm)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Alarm Sets And Reports Pending Alarm");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t seconds = 10;
@@ -914,7 +914,7 @@ TEST_F(UnistdFixture, UnistdAlarmTriggersInExpectedTime)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Alarm Triggers In Expected Time");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const std::uint32_t seconds = 1;
@@ -936,7 +936,7 @@ TEST(Unistd, DefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Unistd Default Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto default_instance = score::os::Unistd::Default();
@@ -949,7 +949,7 @@ TEST_F(UnistdFixture, CloseReturnsErrIfPassInvalidParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Close Returns Err If Pass Invalid Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto val = unit_->close(kInvalidFd);
@@ -962,7 +962,7 @@ TEST_F(UnistdFixture, Dup2ReturnsNoErrorIfPassValidParam)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup2Returns No Error If Pass Valid Param");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t fds[2] = {1, 2};
@@ -982,7 +982,7 @@ TEST_F(UnistdFixture, ReadReturnsNoErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Returns No Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     // first write something to the file
@@ -1021,7 +1021,7 @@ TEST_F(UnistdFixture, WriteReturnNoErrorIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Write Return No Error If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "write_test_file";
@@ -1054,7 +1054,7 @@ TEST_F(UnistdFixture, SetuidReturnsErrorIfPassInvalidUid)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Setuid Returns Error If Pass Invalid Uid");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const uid_t uid_before_set = unit_->getuid();
@@ -1071,7 +1071,7 @@ TEST_F(UnistdFixture, SetuidReturnsNoErrorIfPassValidID)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Setuid Returns No Error If Pass Valid ID");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
 #if defined __QNX__
@@ -1091,7 +1091,7 @@ TEST_F(UnistdFixture, WriteReturnNoErrorAndSyncIfPassValidFd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Write Return No Error And Sync If Pass Valid Fd");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto path = "write_test_file";
@@ -1125,7 +1125,7 @@ TEST(Unistd, PMRDefaultShallReturnImplInstance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Unistd PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/utils/test/abortable_blocking_reader_test.cpp
+++ b/score/os/utils/test/abortable_blocking_reader_test.cpp
@@ -82,7 +82,7 @@ TEST_F(NonBlockingFileDescriptorTest, DefaultConstructionSetsUnderlyingFileDescr
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Default Construction Sets Underlying File Descriptor To Invalid Value");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     NonBlockingFileDescriptor non_blocking_file_descriptor{};
@@ -96,7 +96,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryWhenNonBlockingFlagI
     RecordProperty("Description",
                    "NonBlockingFileDescriptorTest Construction Via Factory When Non Blocking Flag Is Present In File "
                    "Descriptor Flags");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto expected_flags{existing_flags_ | Fcntl::Open::kNonBlocking};
@@ -115,7 +115,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryAddsNonBlockingFlagT
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Construction Via Factory Adds Non Blocking Flag To File Descriptor Flags");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::testing::InSequence sequence{};
@@ -138,7 +138,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryFailsIfCannotGetFlag
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Construction Via Factory Fails If Cannot Get Flags Of File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::testing::InSequence sequence{};
@@ -160,7 +160,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryFailsIfCannotSetFlag
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Construction Via Factory Fails If Cannot Set Flags Of File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto expected_flags{existing_flags_ | Fcntl::Open::kNonBlocking};
@@ -177,7 +177,7 @@ TEST_F(NonBlockingFileDescriptorTest, DestructionClosesUnderlyingFileDescriptor)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingFileDescriptorTest Destruction Closes Underlying File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
@@ -192,7 +192,7 @@ TEST_F(NonBlockingFileDescriptorTest, DestructionTerminatesIfItFailsToCloseUnder
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Destruction Terminates If It Fails To Close Underlying File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_DEATH(
@@ -213,7 +213,7 @@ TEST_F(NonBlockingFileDescriptorTest, MoveAssignmentTerminatesIfItFailsToCloseUn
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Move Assignment Terminates If It Fails To Close Underlying File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_DEATH(
@@ -237,7 +237,7 @@ TEST_F(NonBlockingFileDescriptorTest, DestructionDoesNotTryToCloseInvalidUnderly
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Destruction Does Not Try To Close Invalid Underlying File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const auto invalid_file_descriptor{-1};
@@ -255,7 +255,7 @@ TEST_F(NonBlockingFileDescriptorTest, MoveConstructedFromInstanceDoesNotCloseMov
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Move Constructed From Instance Does Not Close Moved Underlying File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
@@ -274,7 +274,7 @@ TEST_F(NonBlockingFileDescriptorTest, MoveAssignedFromInstanceDoesNotCloseMovedU
     RecordProperty(
         "Description",
         "NonBlockingFileDescriptorTest Move Assigned From Instance Does Not Close Moved Underyling File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     constexpr auto other_filepath{"/tmp/non_blocking_file_descriptor_test_other"};
@@ -304,7 +304,7 @@ TEST_F(NonBlockingFileDescriptorTest, GetUnderlyingReturnsUnderlyingFileDescript
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingFileDescriptorTest Get Underlying Returns Underlying File Descriptor");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
@@ -317,7 +317,7 @@ TEST_F(NonBlockingFileDescriptorTest, CanImplicitlyCastToInt32T)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingFileDescriptorTest Can Implicitly Cast To Int32T");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
@@ -414,7 +414,7 @@ TEST(AbortableBlockingReaderTestDefaultConstructor, CreatesNewPipeWhenConstructe
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTestDefaultConstructor Creates New Pipe When Constructed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     AbortableBlockingReader reader{};
@@ -426,7 +426,7 @@ TEST_F(AbortableBlockingReaderTest, CreatesNewPipeWhenConstructed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Creates New Pipe When Constructed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*unistd_mock_, pipe(::testing::_));
@@ -441,7 +441,7 @@ TEST_F(AbortableBlockingReaderTest, MarkedInvalidIfPipeCreationFailedDuringConst
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "AbortableBlockingReaderTest Marked Invalid If Pipe Creation Failed During Construction");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*unistd_mock_, pipe(::testing::_))
@@ -459,7 +459,7 @@ TEST_F(AbortableBlockingReaderTest, MarkedInvalidIfFirstPipeFileDescriptorCanNot
     RecordProperty(
         "Description",
         "AbortableBlockingReaderTest Marked Invalid If First Pipe File Descriptor Can Not Be Made Non Blocking");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*fcntl_mock_, fcntl(::testing::_, ::testing::_, ::testing::_))
@@ -477,7 +477,7 @@ TEST_F(AbortableBlockingReaderTest, MarkedInvalidIfSecondPipeFileDescriptorCanNo
     RecordProperty(
         "Description",
         "AbortableBlockingReaderTest Marked Invalid If Second Pipe File Descriptor Can Not Be Made Non Blocking");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*fcntl_mock_, fcntl(::testing::_, ::testing::_, ::testing::_))
@@ -494,7 +494,7 @@ TEST_F(AbortableBlockingReaderTest, ClosesPipeWhenDestructed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Closes Pipe When Destructed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::int32_t signaled_fd;
@@ -515,7 +515,7 @@ TEST_F(AbortableBlockingReaderTest, CanOnlyCallReadIfMarkedValid)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Can Only Call Read If Marked Valid");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*unistd_mock_, pipe(::testing::_))
@@ -534,7 +534,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsOnceDataBecomesAvailable)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Once Data Becomes Available");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<void> unblock_promise{};
@@ -568,7 +568,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfSelectFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If Select Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*syspoll_mock_, poll(::testing::_, ::testing::_, ::testing::_))
@@ -588,7 +588,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfFileDescriptorIsInvalid)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If File Descriptor Is Invalid");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     AbortableBlockingReader reader{fcntl_mock_, syspoll_mock_, unistd_mock_};
@@ -606,7 +606,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsWhenReaderIsDestructed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns When Reader Is Destructed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::future<void> read_future{};
@@ -642,7 +642,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsWhenStopCalled)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns When Stop Called");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<void> unblock_promise{};
@@ -677,7 +677,7 @@ TEST_F(AbortableBlockingReaderTest, StopIsInvokedUntilReaderReleasesTheMutex)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Stop Is Invoked Until Reader Releases The Mutex");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<void> unblock_promise{};
@@ -711,7 +711,7 @@ TEST_F(AbortableBlockingReaderTest, DestructorTerminatesOnUnexpectedError)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Destructor Terminates On Unexpected Error");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     auto stop_reader = [this] {
@@ -728,7 +728,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfAlreadyStopped)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If Already Stopped");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     AbortableBlockingReader reader{fcntl_mock_, syspoll_mock_, unistd_mock_};
@@ -747,7 +747,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfReadFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If Read Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_CALL(*unistd_mock_, read(file_descriptor_1_.GetUnderlying(), ::testing::_, ::testing::_))
@@ -771,7 +771,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsDataForMultipleFileDescriptorsSim
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
                    "AbortableBlockingReaderTest Read Returns Data For Multiple File Descriptors Simultaneously");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::promise<void> unblock_promise_1{};
@@ -822,7 +822,7 @@ TEST_F(AbortableBlockingReaderTest, WillUnblockReadsForMultipleFileDescriptorsSi
     RecordProperty(
         "Description",
         "AbortableBlockingReaderTest Will Unblock Reads For Multiple File Descriptors Simultaneously On Destruction");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::future<void> read_future_1{};

--- a/score/os/utils/test/detect_os_test.cpp
+++ b/score/os/utils/test/detect_os_test.cpp
@@ -40,7 +40,7 @@ TEST_F(DetectOsTest, IsEmpty)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Empty");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ::score::cpp::optional<SystemInfo> retVal{};
@@ -54,7 +54,7 @@ TEST_F(DetectOsTest, IsLinux)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Linux");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SystemInfo info{};
@@ -70,7 +70,7 @@ TEST_F(DetectOsTest, IsQnx)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Qnx");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SystemInfo info{};
@@ -86,7 +86,7 @@ TEST_F(DetectOsTest, IsWindows)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Windows");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     SystemInfo info{};

--- a/score/os/utils/test/high_resolution_steady_clock_test.cpp
+++ b/score/os/utils/test/high_resolution_steady_clock_test.cpp
@@ -25,7 +25,7 @@ TEST(HighResolutionSteadyClock, UnderlyingClock)
 {
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description",
@@ -55,7 +55,7 @@ TEST(HighResolutionSteadyClock, now)
 {
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     RecordProperty("Description",

--- a/score/os/utils/test/machine_test.cpp
+++ b/score/os/utils/test/machine_test.cpp
@@ -27,7 +27,7 @@ TEST(MachineImpl, instance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MachineImpl instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Machine& obj = score::os::Machine::instance();
@@ -39,7 +39,7 @@ TEST(MachineImpl, is_qemu)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MachineImpl is_qemu");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
 #ifdef MACHINE_QEMU
@@ -54,7 +54,7 @@ TEST(Machine, is_sctf)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Machine is_sctf");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_TRUE(setenv("SCTF", "TRUE", 1) == 0);
@@ -67,7 +67,7 @@ TEST(Machine, is_sctf_false)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Machine is_sctf_false");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     ASSERT_FALSE(is_sctf());

--- a/score/os/utils/test/mqueueintegration_test.cpp
+++ b/score/os/utils/test/mqueueintegration_test.cpp
@@ -122,7 +122,7 @@ TEST_F(FixtureMQueueShould, sendACharPointerToOtherProcess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould send AChar Pointer To Other Process");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const char* msg = "020223456"; /* TODO : create tests with different formats of the msg, for better check */
@@ -147,7 +147,7 @@ TEST_F(FixtureMQueueShould, sendAStringToOtherProcess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould send AString To Other Process");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string msg{std::to_string(0x01)};
@@ -167,7 +167,7 @@ TEST_F(FixtureMQueueMaxMsgSizeShould, SendALongStringToOtherProzess)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueMaxMsgSizeShould Send ALong String To Other Prozess");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::thread test_tr([&msg = msg]() {
@@ -187,7 +187,7 @@ TEST_F(FixtureMQueueMaxMsgSizeShould, ReopenOnlyWithId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueMaxMsgSizeShould Reopen Only With Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     size_t id = queue.get_id();
@@ -208,7 +208,7 @@ TEST(MQueue, TryOpenNotExistingMQqueue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue Try Open Not Existing MQqueue");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue test{"blah", AccessMode::kUse};
@@ -221,7 +221,7 @@ TEST(MQueue, shouldReturnId)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue should Return Id");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
@@ -235,7 +235,7 @@ TEST(MQueue, ShouldGetEmtpyMessage)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue Should Get Emtpy Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreateNonBlocking};
@@ -249,7 +249,7 @@ TEST_F(FixtureMQueueShould, timedBlockEmptyQueue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould timed Block Empty Queue");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::pair<std::string, bool> result = queue.timed_receive(std::chrono::milliseconds(100));
@@ -262,7 +262,7 @@ TEST(MQueue, timedNonBlockEmptyQueue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue timed Non Block Empty Queue");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreateNonBlocking};
@@ -277,7 +277,7 @@ TEST_F(FixtureMQueueShould, timedBlockSendMessage)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould timed Block Send Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::string msg{"thunder"};
@@ -296,7 +296,7 @@ TEST_F(FixtureMQueueStringShould, timedBlockCharArrayMessage)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueStringShould timed Block Char Array Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::thread test_tr1([]() {
@@ -320,7 +320,7 @@ TEST_F(FixtureMQueueStringShould, timedBlockDeffectedCharArrayMessage)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueStringShould timed Block Deffected Char Array Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::thread test_tr1([]() {
@@ -342,7 +342,7 @@ TEST_F(FixtureMQueueStringShould, timedBlockMessage)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueStringShould timed Block Message");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::thread test_tr1([]() {

--- a/score/os/utils/test/mqunit_test.cpp
+++ b/score/os/utils/test/mqunit_test.cpp
@@ -45,7 +45,7 @@ TEST_F(MQueueFixture, shouldConfigureNonBlock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue should configure non block");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite |
@@ -59,7 +59,7 @@ TEST_F(MQueueFixture, shouldConfigureBlock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue should configure block");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
@@ -73,7 +73,7 @@ TEST_F(MQueueFixture, shouldUnlinkDefinedQueue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mqueue should Unlink Defined Queue");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
@@ -87,7 +87,7 @@ TEST_F(MQueueFixture, shouldUnlinkUndefinedQueue)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mqueue should Unlink Undefined Queue");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
@@ -107,7 +107,7 @@ TEST_F(MQueueFixture, shouldFaileToUnlink)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mqueue should Faile To Unlink");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
@@ -125,7 +125,7 @@ TEST(MQueue, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue shall PMR Default Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
@@ -139,7 +139,7 @@ TEST_F(MQueueFixture, shouldFailToReceive)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Receive");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
@@ -156,7 +156,7 @@ TEST_F(MQueueFixture, shouldFailToReceiveTwice)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Receive Twice");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
@@ -174,7 +174,7 @@ TEST_F(MQueueFixture, shouldFailToSend)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Send");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     uint8_t send_arr[9] = {0x00, 0x02, 0x00, 0x02, 0x02, 0x03, 0x04, 0x05, 0x06};
@@ -192,7 +192,7 @@ TEST_F(MQueueFixture, shouldFailToSendDueInteruptSignal)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Send Due Interupt Signal");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     uint8_t send_arr[9] = {0x00, 0x02, 0x00, 0x02, 0x02, 0x03, 0x04, 0x05, 0x06};
@@ -211,7 +211,7 @@ TEST_F(MQueueFixture, shouldConfigurekExistUseOthCreate)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Configurek Exist Use Oth Create");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
@@ -225,7 +225,7 @@ TEST_F(MQueueFixture, shouldCallSend)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Call Send");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
@@ -242,7 +242,7 @@ TEST_F(MQueueFixture, shouldCallReceive)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Call Receive");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
@@ -259,7 +259,7 @@ TEST_F(MQueueFixture, shouldReturnErrorWhenOpenFailed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Return Error When Open Failed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
@@ -273,7 +273,7 @@ TEST_F(MQueueFixture, shouldReturnErrorWhenSetPermissionsFailed)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Return Error When Set Permissions Failed");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::StatMock stat_mock;
@@ -289,7 +289,7 @@ TEST_F(MQueueFixture, failOnGetQueuePermissions)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture fail On Get Queue Permissions");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const score::cpp::expected_blank<Error> error = score::cpp::make_unexpected(Error::createFromErrno(5));
@@ -309,7 +309,7 @@ TEST(Mqueue, shouldOpenReadAndWrite)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mqueue should Open Read And Write");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::MqueueMock mqueue_mock;
@@ -325,7 +325,7 @@ TEST(Mqueue, failOnGetQueueAttributes)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mqueue fail On Get Queue Attributes");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::MqueueMock mqueue_mock;

--- a/score/os/utils/test/path_test.cpp
+++ b/score/os/utils/test/path_test.cpp
@@ -30,7 +30,7 @@ TEST(get_base_name, man_page_examples)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_base_name man_page_examples");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(Path::instance().get_base_name("usr"), "usr");
@@ -50,7 +50,7 @@ TEST(get_exec_path, returns_non_empty)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_non_empty");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const score::cpp::expected<std::string, score::os::Error> result{Path::Default()->get_exec_path()};
@@ -64,7 +64,7 @@ TEST(get_exec_path, returns_length_lessthan_zero)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_length_lessthan_zero");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     UnistdMock mock_instance;
@@ -83,7 +83,7 @@ TEST(get_exec_path, returns_length_equalto_pathmax)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_length_equalto_pathmax");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     UnistdMock mock_instance;
@@ -102,7 +102,7 @@ TEST(get_exec_path, returns_length_greaterthan_pathmax)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_length_greaterthan_pathmax");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     UnistdMock mock_instance;
@@ -123,7 +123,7 @@ TEST(get_parent_dir, ManPageExamples)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_parent_dir Man Page Examples");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_EQ(Path::instance().get_parent_dir("/foo/bar"), "/foo");
@@ -140,7 +140,7 @@ TEST(PathTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PathTest PMRDefault Shall Return Impl Instance");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();

--- a/score/os/utils/test/pmutexTest.cpp
+++ b/score/os/utils/test/pmutexTest.cpp
@@ -28,7 +28,7 @@ TEST(InterprocessMutex, locks)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex locks");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::InterprocessMutex unit{};
@@ -43,7 +43,7 @@ TEST(InterprocessMutex, LocksAndFrees)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex Locks And Frees");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::InterprocessMutex unit{};
@@ -57,7 +57,7 @@ TEST(InterprocessMutex, DoubleTryLockFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex Double Try Lock Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::InterprocessMutex unit{};
@@ -72,7 +72,7 @@ TEST(InterprocessMutex, FulfillsBasicLockableRequirements)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex Fulfills Basic Lockable Requirements");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     score::os::InterprocessMutex unit{};

--- a/score/os/utils/test/signal_test.cpp
+++ b/score/os/utils/test/signal_test.cpp
@@ -79,7 +79,7 @@ TEST_F(SignalTest, handler_should_be_called)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest handler_should_be_called");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -97,7 +97,7 @@ TEST_F(SignalTest, is_not_a_member_works)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest is_not_a_member_works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -110,7 +110,7 @@ TEST_F(SignalTest, check_if_sig_set_is_empty_works)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest check_if_sig_set_is_empty_works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -127,7 +127,7 @@ TEST_F(SignalTest, get_current_blocked_signals)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest get_current_blocked_signals");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -143,7 +143,7 @@ TEST_F(SignalTest, is_signal_blocked)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest is_signal_blocked");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     block_signal(SIGUSR1);
@@ -157,7 +157,7 @@ TEST_F(SignalTest, pthread_sig_mask)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest pthread_sig_mask");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -185,7 +185,7 @@ TEST_F(SignalTest, send_self_sig_term)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest send_self_sig_term");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -203,7 +203,7 @@ TEST_F(SignalTest, sig_action)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest sig_action");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -232,7 +232,7 @@ TEST_F(SignalTest, kill)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest kill");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -249,7 +249,7 @@ TEST_F(SignalTest, sig_fill_set_works)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest sig_fill_set_works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -264,7 +264,7 @@ TEST_F(SignalTest, add_termination_signal_works)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest add_termination_signal_works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -278,7 +278,7 @@ TEST_F(SignalTest, isNotAMemberWorks)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest is Not AMember Works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -292,7 +292,7 @@ TEST_F(SignalTest, CheckIfSigSetIsEmptyWorks)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Check If Sig Set Is Empty Works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -313,7 +313,7 @@ TEST_F(SignalTest, GetCurrentBlockedSignals)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Get Current Blocked Signals");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     BlockSignal(SIGUSR1);
@@ -332,7 +332,7 @@ TEST_F(SignalTest, IsSignalBlocked)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Is Signal Blocked");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     BlockSignal(SIGUSR1);
@@ -349,7 +349,7 @@ TEST_F(SignalTest, PthreadSigMask)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Pthread Sig Mask");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -384,7 +384,7 @@ TEST_F(SignalTest, PthreadSigMaskReturnsOldSet)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Pthread Sig Mask Returns Old Set");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -421,7 +421,7 @@ TEST_F(SignalTest, SendSelfSigTerm)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Send Self Sig Term");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -439,7 +439,7 @@ TEST_F(SignalTest, SigAction)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Sig Action");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -470,7 +470,7 @@ TEST_F(SignalTest, Kill)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Kill");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     static bool triggered = false;
@@ -487,7 +487,7 @@ TEST_F(SignalTest, SigFillSetWorks)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Sig Fill Set Works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};
@@ -504,7 +504,7 @@ TEST_F(SignalTest, AddTerminationSignalWorks)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Add Termination Signal Works");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     sigset_t sigset{};

--- a/score/os/utils/test/spinlocktest.cpp
+++ b/score/os/utils/test/spinlocktest.cpp
@@ -58,7 +58,7 @@ TEST(SpinlockTest, ConcIntManipulation)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpinlockTest Conc Int Manipulation");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Spinlock lk;
@@ -84,7 +84,7 @@ TEST(SpinlockTest, TryLock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpinlockTest Try Lock");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Spinlock lk;
@@ -107,7 +107,7 @@ TEST(SpinlockTest, LockGuardSupport)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpinlockTest Lock Guard Support");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     Spinlock spinlock;

--- a/score/os/utils/test/tcp_keep_alive_test.cpp
+++ b/score/os/utils/test/tcp_keep_alive_test.cpp
@@ -40,7 +40,7 @@ TEST_F(TcpKeepAliveTest, TcpKeepAlive)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TcpKeepAliveTest Tcp Keep Alive");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     int socketfd = 0;

--- a/score/os/utils/test/thread_test.cpp
+++ b/score/os/utils/test/thread_test.cpp
@@ -104,7 +104,7 @@ TEST_F(ThreadNameTest, SetNameFails)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ThreadNameTest Set Name Fails");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     const size_t name_length = 200U;
@@ -127,7 +127,7 @@ TEST(ThreadAffinityTest, SetAffinitySucceeds)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ThreadAffinityTest Set Affinity Succeeds");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     EXPECT_TRUE(set_thread_affinity(0));

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_serializer_visitor.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_serializer_visitor.cpp
@@ -205,7 +205,7 @@ TEST(serializer_visitor, serialized)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization for different data type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_EQ(check_serialized<char>(), sizeof(char));
     EXPECT_EQ(check_serialized<uint8_t>(), sizeof(uint8_t));
@@ -262,7 +262,7 @@ TEST(serializer_visitor, serializer)
     RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization and deserialization for different data type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using namespace ::score::common::visitor;
     using s = serializer_t<real_alloc_t>;
@@ -518,7 +518,7 @@ TEST(serializer_visitor, custom)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization and deserialization for steady clock time_point.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using s = ::score::common::visitor::serializer_t<real_alloc_t>;
     char buffer[1024];
@@ -552,7 +552,7 @@ TEST(serializer_visitor, serialize_unit)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization and deserialization for a struct type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using s = ::score::common::visitor::serializer_t<real_alloc_t>;
     char buffer[1024];
@@ -653,7 +653,7 @@ TEST_F(serializer_visitor_overflows, basic__no_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a normal struct shall success when providing the "
                    "serialized and the deserialized buffers with the same sizes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 2048, 2048);
     EXPECT_EQ(result.first.operator bool(), true);
@@ -667,7 +667,7 @@ TEST_F(serializer_visitor_overflows, basic__serializer_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a normal struct shall overflow and reach zero offset "
                    "when deserialize more data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 100, 2048);
     EXPECT_EQ(result.first.getZeroOffset(), true);
@@ -681,7 +681,7 @@ TEST_F(serializer_visitor_overflows, basic__derserializer_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a normal struct shall overflow for reaching out of "
                    "bounds when deserialize less data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 2048, 100);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
@@ -695,7 +695,7 @@ TEST_F(serializer_visitor_overflows, basic_deserializer_overflow_const)
     RecordProperty("Description",
                    "The serialization and deserialization for a normal struct shall overflow for reaching out of "
                    "bounds when deserialize less data than the serialized one - const type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     constexpr auto size_in = 2048UL;
     constexpr auto size_out = 100UL;
@@ -713,7 +713,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part__no_overflow)
         "Description",
         "The serialization and deserialization for a struct with a huge dynamic part shall success when providing the "
         "serialized and the deserialized buffers with the same sizes when allocate a dynamic part.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     structureWithHugeDynamicPart.dynamicPart.resize(100);
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, 4096, 4096);
@@ -729,7 +729,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part__serializer_overflow)
         "Description",
         "The serialization and deserialization for a struct with a huge dynamic part shall overflow when providing the "
         "serialized and the deserialized buffers with the same sizes but without allocating a dynamic part.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     constexpr auto size_in_out = 4096UL;
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, size_in_out, size_in_out);
@@ -744,7 +744,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part_serializer_overflow_too_small_
     RecordProperty("Description",
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization and handle subsize overflows returning the ZeroOffset status.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     constexpr auto size_in_out = 4096UL;
     result_type result =
@@ -760,7 +760,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part__deserilizer_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a struct with a huge dynamic part shall overflow for "
                    "reaching out of bounds when deserialize less data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, 8192, 4096);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
@@ -774,7 +774,7 @@ TEST_F(serializer_visitor_overflows, string__no_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a string data shall success when providing the "
                    "serialized and the deserialized buffers with the same sizes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 4096, 4096);
     EXPECT_EQ(result.first.operator bool(), true);
@@ -788,7 +788,7 @@ TEST_F(serializer_visitor_overflows, string__serialization_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a string data shall overflow and reach zero offset when "
                    "deserialize more data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 2048, 4096);
     EXPECT_EQ(result.first.getZeroOffset(), true);
@@ -802,7 +802,7 @@ TEST_F(serializer_visitor_overflows, string_deserialization_overflow)
     RecordProperty("Description",
                    "The serialization and deserialization for a string data shall overflow for reaching out of bounds "
                    "when deserialize less data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 4096, 2048);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
@@ -814,7 +814,7 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_overflow)
     RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the inability of logger_type_info API to copy data bigger than the size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     constexpr auto cmpr = std::numeric_limits<char>::is_signed ? 0x7f : 0xff;
     constexpr auto array_size = 64UL;
@@ -839,7 +839,7 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_not_fit)
     RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the inability of logger_type_info API to copy data that does not fit size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     constexpr auto array_size = 64UL;
@@ -863,7 +863,7 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_fits)
     RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the ability of logger_type_info to copy data.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     constexpr auto array_size = 64UL;
@@ -894,7 +894,7 @@ TEST(logging_serializer_test, serialize_int_data_with_big_miss_match_size)
     RecordProperty("Description",
                    "Verify the inability of serialize integer data by providing a size bigger than"
                    "the original data size.");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::tuple<int, int> tuple_instance{1, 2};
@@ -911,7 +911,7 @@ TEST(logging_serializer_test, deserialize_int_data_with_big_miss_match_size)
     RecordProperty("Description",
                    "Verify the inability of deserialize integer data by providing a size bigger than"
                    "the original data size.");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     std::tuple<int, int> tuple_instance_in{1, 2};
@@ -934,7 +934,7 @@ TEST(logging_serializer_test, deserialize_byte_data_with_miss_match_size)
     RecordProperty("Description",
                    "Verify the inability of deserialize byte data by providing a size bigger than"
                    "the original data size.");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     test::StructOneSigned struct_one_signed_out;
@@ -963,7 +963,7 @@ TEST(clear_functionality_test, test_that_clear_function_can_clear_vector_of_int3
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the inability of clearing vector of int32.");
-    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("TestingTechnique", "interface-test");
     RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
 
     VectorWrapper vector_wrapper_instance{};

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_size_visitor.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_size_visitor.cpp
@@ -301,7 +301,7 @@ TYPED_TEST_P(SizeVisitorFixture, whenDataSerializedAndThenDeserializedDataShould
     ::testing::Test::RecordProperty("Description",
                                     "logging library shall provide an annotation mechanism for data structures to "
                                     "support automatic serialization/deserialization.");
-    ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
+    ::testing::Test::RecordProperty("TestingTechnique", "requirements-based");
     ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     using s = serializer_t<real_alloc_t>;

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_skip_deserialize.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_skip_deserialize.cpp
@@ -71,7 +71,7 @@ TEST(serializer_visitor, skip_deserialize)
     RecordProperty("Description",
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     // S has an "added" std::vector member compared to S3;, it should be detected as incompatible
     EXPECT_FALSE((::score::common::visitor::is_payload_compatible<test::S3s, test::S>()));
@@ -105,7 +105,7 @@ TEST(serializer_visitor, skip_deserialize_test_overflow)
     RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Skip deserialization in case the data to be serialized is bigger than the buffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     std::array<char, 4> buffer;

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_visitor_type_traits.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_visitor_type_traits.cpp
@@ -33,7 +33,7 @@ TEST(vistor_type_traits, is_vector_serializable)
         "Description",
         "Logging library shall provide an annotation mechanism for data structures to support automatic "
         "serialization/deserialization, So, we are checking some data types to be treated for vector serialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     using test::clearable_container;
@@ -58,7 +58,7 @@ TEST(vistor_type_traits, is_not_vector_serializable)
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization. So, we are checking those some data types shouldn't be treated as "
                    "vector serialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     using test::unserializable_container;

--- a/score/static_reflection_with_serialization/visitor/examples/ostream/test/ut/test_ostream_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/examples/ostream/test/ut/test_ostream_visitor.cpp
@@ -44,7 +44,7 @@ TEST(ostream_visitor, basic)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the basic types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
 
     EXPECT_EQ(test_to_string(char('A')), "A");
     EXPECT_EQ(test_to_string(5), "5");
@@ -84,7 +84,7 @@ TEST(ostream_visitor, compound)
 {
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the compound types.");
-    RecordProperty("TestType", "Interface test");
+    RecordProperty("TestType", "interface-test");
 
     using namespace std;
 

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_detail.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_detail.cpp
@@ -37,7 +37,7 @@ TEST(detail, extract_type)
     RecordProperty("Description",
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     const auto& likely_format = "static constexpr auto& test::struct_visitable_impl<test::S1>::namedata()";
     const auto type_string = ::score::common::visitor::detail::visitor_extract_type<std::string>(likely_format);
@@ -59,7 +59,7 @@ TEST(detail, skip_trailing_space)
     RecordProperty("Description",
                    "Verifies that 'strip_trailing_spaces' API shall return the value of the last parameter provided if "
                    "it gets a value out of range or a value zero for parameter 'end'.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     constexpr std::size_t expected_out_of_bounds_end_value = 16;
     constexpr std::size_t expected_zero_output_when_zero_input_end_value = 0;

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_struct_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_struct_visitor.cpp
@@ -179,7 +179,7 @@ TEST(struct_visitor, struct_visitable)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability of different structures.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     EXPECT_TRUE(check_visitable<test::S1>("test::S1", 1));
@@ -209,7 +209,7 @@ TEST(struct_visitor, visit_as)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability of different structures fields.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S1{}), 1);
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S2{}), 2);
@@ -278,7 +278,7 @@ TEST(struct_visitor, namespaces)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability fields.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using namespace ::score::common::visitor;
     EXPECT_EQ(struct_visitable<S1>::field_name(0), "x1");
@@ -305,7 +305,7 @@ TEST(struct_visitor, TemplatedStructShallNotContainTrailingWhitespace)
     RecordProperty("Description",
                    "Verifies that the templated structs shall not contain trailing whaitspace."
                    "serialization/deserialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using namespace ::score::common::visitor;
 

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_visitor.cpp
@@ -54,7 +54,7 @@ TEST(visitor, visitable_and_nonvisitable)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the visitability and the non-visitability.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     test_visitable_t v1;
     test_nonvisitable_t nv1;
@@ -135,7 +135,7 @@ TEST(visitor, namespaces)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability equality from different namespaces.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(ns1::test_visitor_t{}, ns1::test_visitable_t{}), 11);
@@ -176,7 +176,7 @@ TEST(visitor, overloads)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the int and float overloads for 'visit' API.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(test_visitor_t{}, 42.0), 42.0);
@@ -202,7 +202,7 @@ TEST(visitor, conversions)
     RecordProperty("ParentRequirement", "SCR-1633893");
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the convertible argument passing to 'visit' API.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
+    RecordProperty("TestingTechnique", "requirements-based");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(test_visitor_derived_t{}, test_int_convertible_t{42}), 6 * 9);

--- a/score/utils/base64_test.cpp
+++ b/score/utils/base64_test.cpp
@@ -11,7 +11,7 @@ namespace test
 
 TEST(Base64Test, EncodeEmptyString)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::EncodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input string is correctly encoded.");
     std::vector<std::uint8_t> input = {};
@@ -21,7 +21,7 @@ TEST(Base64Test, EncodeEmptyString)
 
 TEST(Base64Test, EncodeSingleByte)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::EncodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input string is correctly encoded.");
     std::vector<std::uint8_t> input = {'A'};
@@ -31,7 +31,7 @@ TEST(Base64Test, EncodeSingleByte)
 
 TEST(Base64Test, EncodeTwoBytes)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::EncodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input string is correctly encoded.");
     std::vector<std::uint8_t> input = {'A', 'B'};
@@ -41,7 +41,7 @@ TEST(Base64Test, EncodeTwoBytes)
 
 TEST(Base64Test, EncodeMultipleBytes)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::EncodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input string is correctly encoded.");
     std::vector<std::uint8_t> input = {'S', 'y', 's', 'f', 'c', 'n', 'U', 't', 'i', 'l', 's'};
@@ -51,7 +51,7 @@ TEST(Base64Test, EncodeMultipleBytes)
 
 TEST(Base64Test, DecodeEmptyString)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::DecodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input is correctly decoded.");
     std::string input = "";
@@ -61,7 +61,7 @@ TEST(Base64Test, DecodeEmptyString)
 
 TEST(Base64Test, DecodeSingleByte)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::DecodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input is correctly decoded.");
     std::string input = "QQ==";
@@ -71,7 +71,7 @@ TEST(Base64Test, DecodeSingleByte)
 
 TEST(Base64Test, DecodeTwoBytes)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::DecodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input is correctly decoded.");
     std::string input = "QUI=";
@@ -81,7 +81,7 @@ TEST(Base64Test, DecodeTwoBytes)
 
 TEST(Base64Test, DecodeMultipleBytes)
 {
-    ::testing::Test::RecordProperty("TestType", "Verification of control flow");
+    ::testing::Test::RecordProperty("TestType", "control-flow-analysis");
     ::testing::Test::RecordProperty("Verifies", "::score::utils::DecodeBase64()");
     ::testing::Test::RecordProperty("Description", "This test ensures that a input is correctly decoded.");
     std::vector<std::uint8_t> input(1000, 'A');


### PR DESCRIPTION
While the test type name the right type the actual type name does not follow the process_description and platform management plan guideline. This PR fixes the terminology.

Resolves: #63