### PR TITLE
Update wording of DerivationTechnique to match process description

### DIFF
--- a/score/json/internal/model/any_test.cpp
+++ b/score/json/internal/model/any_test.cpp
@@ -29,7 +29,7 @@ TEST(Any, CanDefaultConstruct)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Empty-constructed json objects have null value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     // Given Any with no specific value
     Any unit{};
@@ -47,7 +47,7 @@ TEST(Any, CanConstructFromBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Bool-constructed json objects have bool value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "1");
 
     // Given Any with a specific value
@@ -66,7 +66,7 @@ TEST(Any, CanConstructFromFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Float-constructed json objects have float value, cf. RFC-8259 section 3, 6, and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
     Any unit{4.2F};
@@ -85,7 +85,7 @@ TEST(Any, CanConstructFromFloatNumber)
     RecordProperty("Description",
                    "Float-number-constructed json objects have float value, cf. RFC-8259 section 3, 6, and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
     Any unit{Number{4.2F}};
@@ -103,7 +103,7 @@ TEST(Any, CanConstructFromUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Int64-constructed json objects have int64 value, cf. RFC-8259 section 3, 6, and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
     Any unit{std::uint64_t{42}};
@@ -122,7 +122,7 @@ TEST(Any, CanConstructFromIntegralNumber)
     RecordProperty("Description",
                    "Integral-number-constructed json objects have int value, cf. RFC-8259 section 3, 6, and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     // Given Any with a specific value
     Any unit{Number{42UL}};
@@ -140,7 +140,7 @@ TEST(Any, CanConstructFromString)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "String-constructed json objects have string value, cf. RFC-8259 section 3, 7 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{std::string{"foo"}};
 
@@ -155,7 +155,7 @@ TEST(Any, CanConstructFromNull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Null-constructed json objects have null value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{Null{}};
 
@@ -170,7 +170,7 @@ TEST(Any, CanConstructFromObject)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Object-constructed json objects have object value, cf. RFC-8259 section 3, 4 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{Object{}};
 
@@ -185,7 +185,7 @@ TEST(Any, CanConstructFromList)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "List-constructed json objects have list value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{List{}};
 
@@ -200,7 +200,7 @@ TEST(Any, CanAssignBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Bool-assigned json objects have bool value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     // Given Any with no specific value
     Any unit{};
@@ -221,7 +221,7 @@ TEST(Any, CanAssignFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Float-assigned json objects have float value, cf. RFC-8259 section 3, 6 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -239,7 +239,7 @@ TEST(Any, CanAssignFloatNumber)
     RecordProperty("Description",
                    "Float-number-assigned json objects have float value, cf. RFC-8259 section 3, 6 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -256,7 +256,7 @@ TEST(Any, CanAssignUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Int64-assigned json objects have int64 value, cf. RFC-8259 section 3, 6 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -274,7 +274,7 @@ TEST(Any, CanAssignUint64Number)
     RecordProperty("Description",
                    "Int64-number-assigned json objects have int64 value, cf. RFC-8259 section 3, 6 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -291,7 +291,7 @@ TEST(Any, CanAssignString)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "String-assigned json objects have string value, cf. RFC-8259 section 3, 7 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -308,7 +308,7 @@ TEST(Any, CanAssignNull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Null-assigned json objects have null value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{true};
 
@@ -325,7 +325,7 @@ TEST(Any, CanAssignObject)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Object-assigned json objects have object value, cf. RFC-8259 section 3, 4 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -342,7 +342,7 @@ TEST(Any, CanAssignList)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "List-assigned json objects have list value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
     Any unit{};
 
@@ -359,7 +359,7 @@ TEST(Any, CanRetrieveNumberForBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Bool-constructed json objects have numerical value, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     Any unit{false};
@@ -377,7 +377,7 @@ TEST(Any, CanNotRetrieveWronglyTypedValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "list json object can't be converted to string, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     // Given Any with a specific value
@@ -397,7 +397,7 @@ TEST(Any, CanNotRetrieveWronglyTypedReference)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "bool json object can't be converted to list, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     // Given Any with a specific value
@@ -418,7 +418,7 @@ TEST(Any, CanNotRetrieveWronglyTypedValueConst)
     RecordProperty("Description",
                    "const list json object can't be converted to const bool object, cf. RFC-8259 section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     // Given Any with a specific value
@@ -440,7 +440,7 @@ TEST(Any, CanNotRetrieveWronglyTypedReferenceConst)
                    "const bool json object can't be converted to const list object, cf. RFC-8259 "
                    "section 3 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     // Given Any with a specific value
@@ -461,7 +461,7 @@ TEST(Any, CanAccessStringAsAmpStringView)
     RecordProperty("Description",
                    "String-constructed json objects can be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     Any unit{std::string{"foo"}};
@@ -478,7 +478,7 @@ TEST(Any, CanAccessStringAsStdStringView)
     RecordProperty("Description",
                    "String-constructed json objects can be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     Any unit{std::string{"foo"}};
@@ -496,7 +496,7 @@ TEST(Any, CanNotRetrieveWronglyTypedAmpStringView)
         "Description",
         "non String-constructed json objects can not be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     // Given Any with a specific value
@@ -518,7 +518,7 @@ TEST(Any, CanNotRetrieveWronglyTypedStdStringView)
         "Description",
         "non String-constructed json objects can not be accessed as string_view, cf. RFC-8259 section 3, 7 and 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     // Given Any with a specific value
@@ -544,7 +544,7 @@ TEST(Any, CheckEqualOperator)
     RecordProperty("Description", "Tests the equal comparator of Any.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::json::Any::operator==");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
     {
         std::string content = "content";
@@ -607,7 +607,7 @@ TEST(Any, CloneBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves boolean value equality");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Given a Any object holing a boolean
@@ -626,7 +626,7 @@ TEST(Any, CloneNumber)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves numeric value equality");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Given a Any object holing a number
@@ -645,7 +645,7 @@ TEST(Any, CloneNull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves null value equality");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Given a Any object holing nothing
@@ -664,7 +664,7 @@ TEST(Any, CloneString)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves string value equality");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "2");
 
     // Given a Any object holing a string
@@ -683,7 +683,7 @@ TEST(Any, CloneObject)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves object value equality");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Given a Any object holing a json::Object
@@ -705,7 +705,7 @@ TEST(Any, CloneList)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CloneByValue preserves list value equality");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Given a Any object holing a List

--- a/score/json/internal/model/error_test.cpp
+++ b/score/json/internal/model/error_test.cpp
@@ -31,7 +31,7 @@ TEST(Error, CanMakeError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Use MakeError() to create Error instance.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(Error::kParsingError);
@@ -45,7 +45,7 @@ TEST(Error, CanMakeErrorWithUserMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Use MakeError() with error message to create Error instance.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     std::string_view userMessage{"User message"};
@@ -60,7 +60,7 @@ TEST(Error, CanGetMessageForWrongType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from WrongType error.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(Error::kWrongType);
@@ -76,7 +76,7 @@ TEST(Error, CanGetMessageForKeyNotFound)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from KeyNotFound error.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(Error::kKeyNotFound);
@@ -92,7 +92,7 @@ TEST(Error, CanGetMessageForParsingError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from ParsingError error.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(Error::kParsingError);
@@ -108,7 +108,7 @@ TEST(Error, CanGetMessageForInvalidFilePath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from InvalidFilePath error.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(Error::kInvalidFilePath);
@@ -124,7 +124,7 @@ TEST(Error, CanGetMessageForUnknownError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from UnknownError.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(Error::kUnknownError);
@@ -140,7 +140,7 @@ TEST(Error, CanGetMessageForUndefinedError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get error message from UndefinedError.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     score::result::Error error = score::json::MakeError(static_cast<Error>(-1));

--- a/score/json/internal/model/number_test.cpp
+++ b/score/json/internal/model/number_test.cpp
@@ -88,7 +88,7 @@ TEST(Number, FromUint8ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint8 max value to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromUnsignedToAnyOtherType<uint8_t>(true,   // uint8
@@ -110,7 +110,7 @@ TEST(Number, FromUint16ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint16 max value to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromUnsignedToAnyOtherType<uint16_t>(false,  // uint8
@@ -132,7 +132,7 @@ TEST(Number, FromUint32ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint32 max value to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromUnsignedToAnyOtherType<uint32_t>(false,  // uint8
@@ -154,7 +154,7 @@ TEST(Number, FromUint64ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of uint64 max value to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromUnsignedToAnyOtherType<uint64_t>(false,  // uint8
@@ -233,7 +233,7 @@ TEST(Number, FromInt8ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int8 different values to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromSignedToAnyOtherType<std::int8_t>(true,  // int8
@@ -251,7 +251,7 @@ TEST(Number, FromInt16ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int16 different values to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromSignedToAnyOtherType<std::int16_t>(false,  // int8
@@ -269,7 +269,7 @@ TEST(Number, FromInt32ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int32 different values to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromSignedToAnyOtherType<std::int32_t>(false,  // int8
@@ -287,7 +287,7 @@ TEST(Number, FromInt64ToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of int64 different values to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFromSignedToAnyOtherType<std::int64_t>(false,  // int8
@@ -603,7 +603,7 @@ TEST(Number, FromFloatToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of float values to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFloatingPointValues<float>(GetMaximumIntegerInFloat());
@@ -615,7 +615,7 @@ TEST(Number, FromDoubleToAnyOtherType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests conversion of double values to different data types.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     TestFloatingPointValues<double>(GetMaximumIntegerInDouble());
@@ -633,7 +633,7 @@ TEST(Number, CheckEqualOperator)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Tests the equal comparator of Number.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
     {
         uint64_t content = 42;

--- a/score/json/internal/model/object_test.cpp
+++ b/score/json/internal/model/object_test.cpp
@@ -68,7 +68,7 @@ TEST_F(AttributeGettersTest, GetBoolUsingResult)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get bool attribute using Result<> input.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Test passing Result:
@@ -83,7 +83,7 @@ TEST_F(AttributeGettersTest, GetBoolDirectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get bool attribute from direct Object reference.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Test passing direct value:
@@ -98,7 +98,7 @@ TEST_F(AttributeGettersTest, GetIntegerUsingResult)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get signed/unsigned integer attribute using Result<> input.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     Result<std::int64_t> attr_result_signed = GetAttribute<std::int64_t>(test_data_result_, "int");
@@ -116,7 +116,7 @@ TEST_F(AttributeGettersTest, GetIntegerDirectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get signed/unsigned integer attribute from direct Object reference.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     Result<std::int64_t> attr_result_signed = GetAttribute<std::int64_t>(test_data_value_, "int");
@@ -134,7 +134,7 @@ TEST_F(AttributeGettersTest, GetFloatingPointUsingResult)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get float attribute using Result<>; double retrieval is forbidden.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     Result<float> float_result = GetAttribute<float>(test_data_result_, "float");
@@ -152,7 +152,7 @@ TEST_F(AttributeGettersTest, GetFloatingPointDirectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get float attribute from direct value; double retrieval is forbidden.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     Result<float> float_result = GetAttribute<float>(test_data_value_, "float");
@@ -170,7 +170,7 @@ TEST_F(AttributeGettersTest, GetStringUsingResult)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get string attribute using Result<> input.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     Result<score::cpp::string_view> str_result = GetAttribute<score::cpp::string_view>(test_data_result_, "string");
@@ -186,7 +186,7 @@ TEST_F(AttributeGettersTest, GetStringDirectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get string attribute from direct Object reference.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     Result<score::cpp::string_view> str_result = GetAttribute<score::cpp::string_view>(test_data_value_, "string");
@@ -202,7 +202,7 @@ TEST_F(AttributeGettersTest, GetListUsingResult)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get list attribute using Result<> input.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     auto list_result = GetAttribute<json::List>(test_data_result_, "list");
@@ -217,7 +217,7 @@ TEST_F(AttributeGettersTest, GetListDirectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get list attribute from direct Object reference.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     auto list_result = GetAttribute<json::List>(test_data_value_, "list");
@@ -232,7 +232,7 @@ TEST_F(AttributeGettersTest, GetObjectUsingResult)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get nested object attribute using Result<> input.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     auto sub_object_result = GetAttribute<json::Object>(test_data_result_, "widget");
@@ -248,7 +248,7 @@ TEST_F(AttributeGettersTest, GetObjectDirectValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get nested object attribute from direct Object reference.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     auto sub_object_result = GetAttribute<json::Object>(test_data_value_, "widget");
@@ -264,7 +264,7 @@ TEST_F(AttributeGettersTest, CascadingAccessSuccessCase)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Traverse nested objects (widget/geometry/size/width) successfully.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     const auto widget = GetAttribute<json::Object>(test_data_value_, "widget");
@@ -287,7 +287,7 @@ TEST_F(AttributeGettersTest, CascadingAccessErrorCase)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Fail gracefully when traversing with invalid keys.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     // Invalid key

--- a/score/json/internal/parser/json_parser_test.cpp
+++ b/score/json/internal/parser/json_parser_test.cpp
@@ -54,7 +54,7 @@ TEST(JsonParserTest, FromBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing json object using FromBuffer(), cf. RFC-8259 section 9");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     json::JsonParser json_parser{};
@@ -71,7 +71,7 @@ TEST(JsonParserTest, ViaLiteral)
                    "Parsing json object using "
                    "_json operator, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     auto parsed_json = JSON_INPUT ""_json;
@@ -84,7 +84,7 @@ TEST(JsonParserTest, ViaErrorLiteral)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing invalid json object using _json operator, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     EXPECT_EXIT(JSON_ERROR_INPUT ""_json, ::testing::KilledBySignal(SIGABRT), "");
@@ -96,7 +96,7 @@ TEST(JsonParserTest, FromFileSuceess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing json object from file path, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    RecordProperty("DerivationTechnique", "boundary-values");
     RecordProperty("Priority", "3");
 
     const std::string file_path = std::tmpnam(nullptr);
@@ -119,7 +119,7 @@ TEST(JsonParserTest, FromFileParseError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Parsing invalid json object from file path causes failure, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Priority", "3");
 
     const std::string file_path = std::tmpnam(nullptr);

--- a/score/json/internal/parser/number_parser_test_suite.h
+++ b/score/json/internal/parser/number_parser_test_suite.h
@@ -100,7 +100,7 @@ TYPED_TEST_P(NumberTest, WhenParsingABoolStoredInAJsonThenParsingIsSuccessfulAnd
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of bool data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -124,7 +124,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint8StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint8 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -148,7 +148,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint16StoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint16 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -172,7 +172,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint32StoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint32 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -196,7 +196,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAUint64StoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of uint64 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -220,7 +220,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt8StoredInAJsonThenParsingIsSuccessfulAnd
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int8 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -244,7 +244,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt16StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int16 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -268,7 +268,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt32StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int32 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -292,7 +292,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAInt64StoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of int64 data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -315,7 +315,7 @@ TYPED_TEST_P(NumberTest, WhenParsingAFloatStoredInAJsonThenParsingIsSuccessfulAn
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of float data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it
@@ -339,7 +339,7 @@ TYPED_TEST_P(NumberTest, WhenParsingADoubleStoredInAJsonThenParsingIsSuccessfulA
     this->RecordProperty("Description",
                          "Test the limits, over-limit and under-limit of double data-type, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     // Given a simple JSON buffer and parsing it

--- a/score/json/internal/parser/parsers_test_suite.h
+++ b/score/json/internal/parser/parsers_test_suite.h
@@ -87,7 +87,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectBool)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse boolean value from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -106,7 +106,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectString)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse string value from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -125,7 +125,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectNull)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse Null value from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -144,7 +144,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectNumber)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse uint64_t value from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -163,7 +163,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectFloatingPointNumber)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse float value from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -187,7 +187,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectInObject)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse an object from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -206,7 +206,7 @@ TYPED_TEST_P(ParserTest, CanParseListInObject)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse a list from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a simple JSON buffer
@@ -228,7 +228,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectInObjectAndIterateOverKeys)
     this->RecordProperty("Description",
                          "parse an object where the keys are unknown to the program, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "1");
 
     // Given a JSON structure that contains objects in objects where the keys are unknown to the program
@@ -278,7 +278,7 @@ TYPED_TEST_P(ParserTest, EmitsErrorWhenParsingObjectWithValueButNoKey)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "failure in parsing an object with no keys, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
 
     std::string buffer{R"(
@@ -300,7 +300,7 @@ TYPED_TEST_P(ParserTest, EmitsErrorWhenParsingObjectWithBinaryValue)
     this->RecordProperty("Description",
                          "failure in parsing an object with binary value element, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
 
     // Binary content - format specific to vaJSON Parser
@@ -334,7 +334,7 @@ TYPED_TEST_P(ParserTest, EmitsErrorWhenParsingTooLargeNumber)
     this->RecordProperty("Description",
                          "failure in parsing an object with very large value element, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
 
     std::string buffer{R"({ "number": 1e+500 })"};
@@ -353,7 +353,7 @@ TYPED_TEST_P(ParserTest, FromFileFail)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Invalid file path returns error");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
     // Pass invalid file path
     auto foo = TypeParam::FromFile("foo");
@@ -367,7 +367,7 @@ TYPED_TEST_P(ParserTest, ParsingFromFileWorks)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Verifies that parsing JSON from a file works correctly");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
     // Given a simple JSON File
     std::string file_name{"test.json"};

--- a/score/json/internal/parser/vajson/number_parser_test.cpp
+++ b/score/json/internal/parser/vajson/number_parser_test.cpp
@@ -57,7 +57,7 @@ TEST(Number, Bool)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of bool data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<bool>("-1", "2");
 }
@@ -69,7 +69,7 @@ TEST(Number, Uint8)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint8 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::uint8_t>("-1", "256");
 }
@@ -81,7 +81,7 @@ TEST(Number, Uint16)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint16 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::uint16_t>("-1", "65536");
 }
@@ -93,7 +93,7 @@ TEST(Number, Uint32)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint32 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::uint32_t>("-1", "4294967296");
 }
@@ -105,7 +105,7 @@ TEST(Number, Uint64)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of uint64 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::uint64_t>("-1", "18446744073709551616");
 }
@@ -117,7 +117,7 @@ TEST(Number, Int8)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int8 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::int8_t>("-129", "128");
 }
@@ -129,7 +129,7 @@ TEST(Number, Int16)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int16 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::int16_t>("-32769", "32768");
 }
@@ -141,7 +141,7 @@ TEST(Number, Int32)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int32 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::int32_t>("-2147483649", "2147483648");
 }
@@ -153,7 +153,7 @@ TEST(Number, Int64)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of int64 data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<std::int64_t>("-9223372036854775809", "9223372036854775808");
 }
@@ -165,7 +165,7 @@ TEST(Number, Float)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of float data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<float>("-3.402823476385288598117e+38", "3.402823476385288598117e+38");
 }
@@ -177,7 +177,7 @@ TEST(Number, Double)
     RecordProperty("Description",
                    "Test the limits, over-limit and under-limit of double data-type, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     range_test<double>("-1.797693134862415708145e+308", "1.797693134862415708145e+308");
 }
@@ -189,7 +189,7 @@ TEST(Number, WithDecimalPointWithoutFractionalPartCannotBeParsedAsInteger)
     RecordProperty("Description",
                    "Test interpreting number with decimal point as floating point only, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Tolerated behavior of vajson that interprets any number with decimal point as floating point only.
     EXPECT_EQ(ParseNumberAs<int64_t>("-1.0").has_value(), false);
@@ -202,7 +202,7 @@ TEST(Number, WithExponentialNotationWithoutFractionalPartCannotBeParsedAsInteger
     RecordProperty("Description",
                    "Test interpreting number with exponent notation as floating point only, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Tolerated behavior of vajson that interprets any number with exponent notation as floating point only.
     EXPECT_EQ(ParseNumberAs<int64_t>("-1e2").has_value(), false);
@@ -216,7 +216,7 @@ TEST(Number, FloatingPointWithoutDecimalPoint)
     RecordProperty("Description",
                    "Number without decimal point can be treated as floating point too, cf. RFC-8259 section 9");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(ParseNumberAs<float>("-18446744073709551615").value_or(-999), -18446744073709551615.0f);
     EXPECT_EQ(ParseNumberAs<double>("18446744073709551615").value_or(-999), 18446744073709551615.0);

--- a/score/json/internal/parser/vajson/vajson_parser_test.cpp
+++ b/score/json/internal/parser/vajson/vajson_parser_test.cpp
@@ -30,7 +30,7 @@ TEST(VajsonParser, CanParseObjectHexadecimalNumber)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "parse hex value from json buffer, cf. RFC-8259 section 9");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string buffer_json_hex{R"(
         {

--- a/score/json/internal/writer/json_serialize/json_serialize_test.cpp
+++ b/score/json/internal/writer/json_serialize/json_serialize_test.cpp
@@ -40,7 +40,7 @@ TEST(JsonSerializeTest, SerializeString)
     RecordProperty("Description",
                    "constructing json object with string elements and serializing it, cf. RFC-8259 section 7");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "string1": "foo",
@@ -61,7 +61,7 @@ TEST(JsonSerializeTest, SerializeStringWithSpecialChars)
                    "constructing json object with string elements and serializing it, cf. RFC-8259 section 7 "
                    "considering special characters");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string expected_json_string{R"({
     "string1": "String with \"special\" characters like \\",
@@ -81,7 +81,7 @@ TEST(JsonSerializeTest, SerializeInt8)
     RecordProperty("Description",
                    "constructing json object with Int8 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(INT8_MIN) +
@@ -107,7 +107,7 @@ TEST(JsonSerializeTest, SerializeInt16)
     RecordProperty("Description",
                    "constructing json object with Int16 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(INT16_MIN) +
@@ -133,7 +133,7 @@ TEST(JsonSerializeTest, SerializeInt32)
     RecordProperty("Description",
                    "constructing json object with Int32 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(INT32_MIN) +
@@ -159,7 +159,7 @@ TEST(JsonSerializeTest, SerializeInt64)
     RecordProperty("Description",
                    "constructing json object with Int64 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(INT64_MIN) +
@@ -185,7 +185,7 @@ TEST(JsonSerializeTest, SerializeUint8)
     RecordProperty("Description",
                    "constructing json object with Uint8 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(UINT8_MAX) +
@@ -208,7 +208,7 @@ TEST(JsonSerializeTest, SerializeUint16)
     RecordProperty("Description",
                    "constructing json object with Uint16 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(UINT16_MAX) +
@@ -231,7 +231,7 @@ TEST(JsonSerializeTest, SerializeUint32)
     RecordProperty("Description",
                    "constructing json object with Uint32 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(UINT32_MAX) +
@@ -254,7 +254,7 @@ TEST(JsonSerializeTest, SerializeUint64)
     RecordProperty("Description",
                    "constructing json object with Uint64 elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "num1": )" + std::to_string(UINT32_MAX) +
@@ -277,7 +277,7 @@ TEST(JsonSerializeTest, SerializeFloat)
     RecordProperty("Description",
                    "constructing json object with float elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::ostringstream string_stream{};
     string_stream.precision(std::numeric_limits<float>::max_digits10);
@@ -307,7 +307,7 @@ TEST(JsonSerializeTest, SerializeDouble)
     RecordProperty("Description",
                    "constructing json object with double elements and serializing it, cf. RFC-8259 section 6");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::ostringstream string_stream{};
     string_stream.precision(std::numeric_limits<double>::max_digits10);
@@ -337,7 +337,7 @@ TEST(JsonSerializeTest, SerializeBool)
     RecordProperty("Description",
                    "constructing json object with bool elements and serializing it, cf. RFC-8259 section 3");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "bool1": 1,
@@ -357,7 +357,7 @@ TEST(JsonSerializeTest, SerializeNull)
     RecordProperty("Description",
                    "constructing json object with Null element and serializing it, cf. RFC-8259 section 3");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
     "null": null
@@ -375,7 +375,7 @@ TEST(JsonSerializeTest, SerializeMultipleTypes)
     RecordProperty("Description",
                    "constructing json object with multiple types elements and serializing it, cf. RFC-8259 section 3");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::ostringstream string_stream{};
     string_stream.precision(std::numeric_limits<float>::max_digits10);
@@ -404,7 +404,7 @@ TEST(JsonSerializeTest, SerializeList)
     RecordProperty("Description",
                    "constructing json object with list of elements and serializing it, cf. RFC-8259 section 5");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"([
     5,
@@ -424,7 +424,7 @@ TEST(JsonSerializeTest, SerializeEmptyList)
     RecordProperty("Description",
                    "constructing json object with empty list and serializing it, cf. RFC-8259 section 5");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"([
 ])"};
@@ -440,7 +440,7 @@ TEST(JsonSerializeTest, SerializeEmptyObject)
     RecordProperty("Description",
                    "constructing json object with empty object and serializing it, cf. RFC-8259 section 3");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"({
 })"};
@@ -458,7 +458,7 @@ TEST(JsonSerializeTest, SerializeNestedObjectAndList)
         "Description",
         "constructing json object with nested object and list and serializing it, cf. RFC-8259 section 4 and 5");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string input_json{R"([
     {
@@ -494,7 +494,7 @@ TEST(JsonSerializeAnyTest, SerializeAny)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test serializing json::Any with all type variants, cf. RFC-8259 section 3-7");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::vector<std::pair<std::string, score::json::Any>> v;
 

--- a/score/json/json_serializer_test.cpp
+++ b/score/json/json_serializer_test.cpp
@@ -207,7 +207,7 @@ TEST(JsonSerializerTest, TestFailingDeserialization)
                    "the correct error code");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON that does not match the structure of a serializable struct
     auto source = R"(
@@ -366,7 +366,7 @@ TEST(JsonSerializerTest, ErrorOnMissingMandatoryFields)
         "data for it. In this case, deserialization should fail with the correct error code");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON that matches the structure of a serializable struct with a mandatory field and the mandatory field
     // is not set in the JSON
@@ -438,7 +438,7 @@ TEST(JsonSerializerTest, FailToDeserializeWrongNumberType)
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON with a float number inside a field that expects an integer
     auto source = R"({
@@ -467,7 +467,7 @@ TEST(JsonSerializerTest, FailToDeserializeANonBooleanTypeToBool)
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON with a float number inside a field that expects an integer
     auto source = R"({
@@ -497,7 +497,7 @@ TEST(JsonSerializerTest, FailToDeserializeANonNumberTypeToAnInteger)
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON with a string inside a field that expects an integer
     auto source = R"({
@@ -527,7 +527,7 @@ TEST(JsonSerializerTest, FailToDeserializeToVectorIfJSONIsNotAList)
                    "for a given key");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON that is not a list
     auto source = R"("Not a list")"_json;
@@ -549,7 +549,7 @@ TEST(JsonSerializerTest, FailToDeserializeIntoAVectorIfJSONListHasMixedTypes)
     RecordProperty("Verifies", "::score::json::FromJsonAny");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON list that contains a string and a number
     auto source = R"(["Not a number", 42])"_json;
@@ -642,7 +642,7 @@ TEST(JsonSerializerTest, FailToDeserializeOptionalValueIfEnclosedTypesDoNotMatch
                    "Verify that deserializing an optional value fails if the enclosed type does not match");
     RecordProperty("ASIL", "QM");
     RecordProperty("Priority", "3");
-    RecordProperty("DerivationTechnique", "Error guessing");
+    RecordProperty("DerivationTechnique", "error-guessing");
 
     // Given a JSON that contains a string where an optional integer is expected
     auto source = R"({"mandatory_val": 42, "optional_val": [43]})"_json;

--- a/score/json/json_test.cpp
+++ b/score/json/json_test.cpp
@@ -21,7 +21,7 @@ TEST(JsonTest, ReadWrite)
     RecordProperty("Description",
                    "Create Json object with different attributes, write it to a buffer, then read it successfully.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     score::json::Object json{};
     json["string"] = std::string{"foo"};

--- a/score/json/json_writer_test.cpp
+++ b/score/json/json_writer_test.cpp
@@ -113,7 +113,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToBuffer)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
     this->RecordProperty("TestType", "Interface test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     typename TestFixture::SampleJson json;
@@ -129,7 +129,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToFile)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
     this->RecordProperty("TestType", "Interface test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     typename TestFixture::SampleJson json;
@@ -148,7 +148,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToUnsyncedFile)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
     this->RecordProperty("TestType", "Interface test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     typename TestFixture::SampleJson json;
@@ -166,7 +166,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToSyncedFile)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "writing json to string buffer, cf. RFC-8259 section 4, 5 and 9");
     this->RecordProperty("TestType", "Interface test");
-    this->RecordProperty("DerivationTechnique", "Analysis of equivalence classes and boundary values");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
     this->RecordProperty("Priority", "3");
 
     typename TestFixture::SampleJson json;
@@ -185,7 +185,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToUnsyncedFileResultsInError)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Invalid file path returns error when writing unsynced file");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
 
     typename TestFixture::SampleJson json;
@@ -207,7 +207,7 @@ TYPED_TEST(JsonWriterWriteToFileTest, ToSyncedFileResultsInError)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "Invalid file path returns error when writing with atomic update");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("Priority", "3");
 
     typename TestFixture::SampleJson json;

--- a/score/language/safecpp/aborts_upon_exception/aborts_upon_exception_test.cpp
+++ b/score/language/safecpp/aborts_upon_exception/aborts_upon_exception_test.cpp
@@ -132,7 +132,7 @@ TYPED_TEST_SUITE(TestSafeExcept, ExceptionThrowerTypes, /*unused*/);
 
 TYPED_TEST(TestSafeExcept, AllocationOfExceptionAbortsExecutionImmediately)
 {
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("ParentRequirement", "SSR-6593458");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty(
@@ -162,7 +162,7 @@ TYPED_TEST(TestSafeExcept, AllocationOfExceptionAbortsExecutionImmediately)
 
 TYPED_TEST(TestSafeExcept, AllocationOfExceptionAbortsExecutionImmediatelyEvenWhenBeingCaughtByType)
 {
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("ParentRequirement", "SSR-6593458");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty(
@@ -194,7 +194,7 @@ TYPED_TEST(TestSafeExcept, AllocationOfExceptionAbortsExecutionImmediatelyEvenWh
 
 TYPED_TEST(TestSafeExcept, AllocationOfExceptionAbortsExecutionImmediatelyEvenWhenBeingCaughtByWildcard)
 {
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("ParentRequirement", "SSR-6593458");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty(

--- a/score/memory/shared/memory_resource_proxy_test.cpp
+++ b/score/memory/shared/memory_resource_proxy_test.cpp
@@ -122,7 +122,7 @@ TEST_F(MemoryResourceManagerDeathTest, ProperHandleNonExistingMemoryResource)
                    "The MemoryRessourceProxy shall store its identifier in a way, that it can detect corruptions.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given multiple registered memory resources, but a MemoryResourceProxy pointing to a non-existing resource
     MemoryResourceProxy notValidIdentifier{12U};
@@ -186,7 +186,7 @@ TEST_F(BoundCheckedMemoryResourceManagerDeathTest, AllocationTerminatesWhenProxy
                    "The MemoryRessourceProxy shall store its identifier in a way, that it can detect corruptions.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a registered memory resource and a MemoryResourceProxy with the same ID but not in the memory region
     // managed by the ManagedMemoryResource.

--- a/score/memory/shared/shared_memory_factory_test.cpp
+++ b/score/memory/shared/shared_memory_factory_test.cpp
@@ -273,7 +273,7 @@ TEST_P(SharedMemoryFactoryTest, SharedMemoryResourceIsCreatedWithCorrectPath)
                    "The SharedMemoryFactory shall return the Shared Memory Resource associated with the given path.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     // Given that we can successfully create a shared memory region
@@ -307,7 +307,7 @@ TEST_F(SharedMemoryFactoryTest, SharedMemoryResourceFallbackToSystemMemory)
                    "The SharedMemoryFactory shall return the Shared Memory Resource associated with the given path.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     std::array<std::uint8_t, kSharedMemorySize> dataRegion{};
@@ -347,7 +347,7 @@ TEST_F(SharedMemoryFactoryTest, SharedMemoryResourceIsOpenedWithCorrectPath)
                    "The SharedMemoryFactory shall return the Shared Memory Resource associated with the given path.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr bool is_read_write = false;
@@ -477,7 +477,7 @@ TEST_F(SharedMemoryFactoryTest, AllowsAccessToMatchingProvidersPreventsNonMatchi
                    "SharedMemoryResource to be opened is not in the passed list of allowed providers.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr bool is_read_write = false;

--- a/score/memory/shared/shared_memory_resource_allocate_test.cpp
+++ b/score/memory/shared/shared_memory_resource_allocate_test.cpp
@@ -47,7 +47,7 @@ TEST_F(SharedMemoryResourceAllocateTest, AssociatedMemoryResourceProxyForwardsCa
                    "requested memory.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;
@@ -78,7 +78,7 @@ TEST_F(SharedMemoryResourceAllocateTest, SharedMemoryResourceAllocatesAlignedMem
         "SharedMemoryResource shall allocate memory in accordance to the alignment of that CPU architecture.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;
@@ -114,7 +114,7 @@ TEST_F(SharedMemoryResourceAllocateTest,
         "SharedMemoryResource shall allocate memory in accordance to the alignment of that CPU architecture.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;
@@ -208,7 +208,7 @@ TEST_F(SharedMemoryResourceAllocateDeathTest, AllocatingBlockLargerThanAllocated
                    "The process shall terminate when the SharedMemoryResource cannot allocate the requested memory.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;

--- a/score/memory/shared/shared_memory_resource_create_test.cpp
+++ b/score/memory/shared/shared_memory_resource_create_test.cpp
@@ -87,7 +87,7 @@ TEST_F(SharedMemoryResourceCreateTest, CreateSharedMemoryFreesResourcesOnDestruc
     RecordProperty("Description", "SharedMemoryResource shall free resources only on destruction.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 1;
@@ -612,7 +612,7 @@ TEST_F(SharedMemoryResourceCreateDeathTest, UnableToTruncateSharedMemoryCausesTe
     RecordProperty("Description", "A process shall terminate, if the truncation of a shared memory segment fails.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 1;

--- a/score/memory/shared/shared_memory_resource_open_test.cpp
+++ b/score/memory/shared/shared_memory_resource_open_test.cpp
@@ -47,7 +47,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpensSharedMemoryReadOnlyByDefault)
         "Can open shared memory segment read-only. Only opens shared memory segment provided in constructor.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;
@@ -67,7 +67,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpeningSharedMemoryFreesResourcesOnDestruct
     RecordProperty("Description", "SharedMemoryResource shall free resources only on destruction.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 1;
@@ -116,7 +116,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpensSharedMemoryWillWaitUntilLockFileIsGon
     RecordProperty("Description", "Can open shared memory segment read-only after a lock was created");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;
@@ -173,7 +173,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpensSharedMemoryReadWrite)
         "Can open shared memory segment read-write. Only opens shared memory segment provided in constructor.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     InSequence sequence{};
     constexpr std::int32_t file_descriptor = 5;
@@ -194,7 +194,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpeningResourceThatDoesNotExistWillReturnEr
                    "Checks that Open will return an error when the underlying resource cannot be found.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     constexpr bool is_read_write = false;
 
@@ -222,7 +222,7 @@ TEST_F(SharedMemoryResourceOpenTest, OpeningResourceWithoutTheRequiredACLsWillRe
                    "open the underlying resource.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     constexpr bool is_read_write = false;
 

--- a/score/memory/shared/test_offset_ptr/bounds_check_test.cpp
+++ b/score/memory/shared/test_offset_ptr/bounds_check_test.cpp
@@ -184,7 +184,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, DereferencingOffsetPtrReturnsCorrectValue)
     RecordProperty("Description", "Checks that dereferencing performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -204,7 +204,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, GettingOffsetPtr)
     RecordProperty("Description", "Checks that calling get() performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -224,7 +224,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, GettingOffsetPtrWithTypedGet)
     RecordProperty("Description", "Checks that calling typed get() performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -244,7 +244,7 @@ TEST_P(OffsetPtrBoundsCheckFixture, GettingOffsetPtrWithSizedGet)
     RecordProperty("Description", "Checks that calling get() that accepts size as argument performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -303,7 +303,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, DereferencingOffsetPtrTerminates)
     RecordProperty("Description", "Checks that dereferencing performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -321,7 +321,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, OffsetPtrGetTerminates)
     RecordProperty("Description", "Checks that calling get() performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -339,7 +339,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, OffsetPtrTypedGetTerminates)
     RecordProperty("Description", "Checks that calling typed get() performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -357,7 +357,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, OffsetPtrSizedGetTerminates)
     RecordProperty("Description", "Checks that calling get() that takes size as argument performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 
@@ -388,7 +388,7 @@ TEST_P(OffsetPtrBoundsCheckDeathFixture, ArrowOperatorTerminates)
     RecordProperty("Description", "Checks that calling get() performs bounds checking");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto& params = GetParam();
 

--- a/score/mw/log/configuration/configuration_file_discoverer_test.cpp
+++ b/score/mw/log/configuration/configuration_file_discoverer_test.cpp
@@ -133,7 +133,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindGlobalConfiguratio
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the discoverer shall find the global configuration file.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -152,7 +152,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
         "Description",
         "Verifies that the discoverer shall find the application specific configuration file under <cwd>/etc.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -173,7 +173,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
     RecordProperty("Description",
                    "Verifies that the discoverer shall find the application specific configuration file under <cwd>.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -194,7 +194,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
         "Description",
         "Verifies that the discoverer shall find the application specific configuration file under the binary path.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -217,7 +217,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -238,7 +238,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path. The <cwd>/etc. path should be ignored");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -260,7 +260,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path. The <cwd> path should be ignored");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -282,7 +282,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallFindConfigurationFileI
                    "Verifies that the discoverer shall find the application specific configuration file under the "
                    "environment variable path. The binary path should be ignored");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When ...
     AddExistingFile(kGlobalConfigFile);
@@ -302,7 +302,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallReturnEmptyIfNothingEx
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the discoverer shall return an empty list if no config file exists.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When no file exists then ...
     const auto result = discoverer_.FindConfigurationFiles();
@@ -315,7 +315,7 @@ TEST_F(ConfigurationFileDiscovererFixture, DiscovererShallReturnEmptyIfExecPathF
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the discoverer shall return an empty list if an error occurs.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When...
     AddExistingFile(kLocalConfigFileInExecPath);

--- a/score/mw/log/configuration/configuration_test.cpp
+++ b/score/mw/log/configuration/configuration_test.cpp
@@ -31,7 +31,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsBelowThresho
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log message shall be enabled if the log level is below the threshold.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -47,7 +47,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsEqualThresho
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log message shall be enabled if the log level is equal to the threshold.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -63,7 +63,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnFalseIfLogLevelIsAboveThresh
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log message shall be disabled if the log level is above to the threshold.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -80,7 +80,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsAboveOrEqual
     RecordProperty("Description",
                    "The log message shall be enabled if the log level is equal to the default log level threshold.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -96,7 +96,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnFalseIfLogLevelIsBelowDefaul
     RecordProperty("Description",
                    "The log message shall be disabled if the log level is below the default log level threshold.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -114,7 +114,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnTrueIfLogLevelIsAboveOrEqual
         "The log message for the console shall be enabled if the log level is equal to the default log level "
         "threshold for the console.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -131,7 +131,7 @@ TEST(ConfigurationTestSuite, IsLogEnabledShallReturnFalseIfLogLevelIsBelowDefaul
                    "The log message shall be disabled for the console if the log level is below the default log level "
                    "threshold for the console.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -146,7 +146,7 @@ TEST(ConfigurationTestSuite, AppidWithMoreThanFourCharactersShallBeTruncated)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The application identifier shall be limited to four characters.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 
@@ -160,7 +160,7 @@ TEST(ConfigurationTestSuite, EcuidWithMoreThanFourCharactersShallBeTruncated)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The ECU identifier shall be limited to four characters.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     Configuration config{};
 

--- a/score/mw/log/configuration/nvconfig_test.cpp
+++ b/score/mw/log/configuration/nvconfig_test.cpp
@@ -98,7 +98,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsExpectedValues)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Logging libraries use static configuration based on .json files.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     auto result = NvConfigFactory::CreateAndInit(JSON_PATH());
     ASSERT_TRUE(result.has_value());  // Verify config was created successfully
     auto& nvc1 = result.value();
@@ -129,7 +129,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsExpectedValuesWithOtherFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Logging libraries use static configuration based on .json files.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(JSON_PATH_2());
     ASSERT_TRUE(result.has_value());  // Verify config was created successfully
@@ -165,7 +165,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorOpenWhenGivenEmptyFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of parsing a general empty file.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(EMPTY_FILE());
     ASSERT_FALSE(result.has_value());  // error parse because it is a general empty file
@@ -178,7 +178,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorOpenWhenGivenPathToNonExistentFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ara::log shall discard configuration files that are not found.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(WRONG_JSON_PATH());
     ASSERT_FALSE(result.has_value());  // error parse because the file doesn't exist
@@ -191,7 +191,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsOkWhenGivenEmptyJsonFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of parsing an empty JSON file.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(EMPTY_JSON());
     EXPECT_TRUE(result.has_value());  // ok because this json file doesn't have items
@@ -204,7 +204,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorParseIfEmptyObject)
     RecordProperty("Description",
                    "Verifies the inability of parsing JSON file that has array instead of JSON object as a root node.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(EMPTY_JSON_OBJECT());
     ASSERT_FALSE(result.has_value());  // array instead of json object as one of the values
@@ -217,7 +217,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorParseIfThereIsSomethingElseInstedOf
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of parsing a JSON file that does not have object as value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_PARSE_1_PATH());
     ASSERT_FALSE(result.has_value());  // aray instead of json object as one of the values
@@ -232,7 +232,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorContentIfCtxidValuePairDoesntExists
         "Description",
         "Verifies the inability of parsing JSON file that misses ctxid key-value pair for one of the objects.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_1_PATH());
     ASSERT_FALSE(result.has_value());  // ctxid key-value pair is missing in one of the objects
@@ -247,7 +247,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorContentIfAppidValuePairDoesntExists
         "Description",
         "Verifies the inability of parsing JSON file that misses appid key-value pair for one of the objects.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_2_PATH());
     ASSERT_FALSE(result.has_value());  // appid key-value pair is missing in one of the objects
@@ -261,7 +261,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorContentIfIdValuePairDoesntExistsFor
     RecordProperty("Description",
                    "Verifies the inability of parsing JSON file that misses id key-value pair for one of the objects.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_3_PATH());
     ASSERT_FALSE(result.has_value());  // id key-value pair is missing in one of the objects
@@ -274,7 +274,7 @@ TEST_F(NonVerboseConfig, NvConfigReturnsErrorIfIdDataTypeIsWrong)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of parsing JSON file that has wrong id value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto result = NvConfigFactory::CreateAndInit(ERROR_CONTENT_WRONG_ID_VALUE());
     ASSERT_FALSE(result.has_value());  // wrong ID data type (string instead of int).

--- a/score/mw/log/configuration/target_config_reader_test.cpp
+++ b/score/mw/log/configuration/target_config_reader_test.cpp
@@ -156,7 +156,7 @@ TEST_F(TargetConfigReaderFixture, NoConfigFilesShallFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall return an error if no configuration files are found");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // For the case that no configuration files exist.
     SetConfigurationFiles({});
@@ -172,7 +172,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseEcuIdFromEcuConfig)
     RecordProperty("Description",
                    "TargetConfigReader shall parse the DLT ECU ID from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetEcuId(), kEcuConfigEcuId);
 }
@@ -184,7 +184,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseAppIdFromAppConfig)
     RecordProperty("Description",
                    "TargetConfigReader shall parse the DLT Application ID from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetAppId(), kAppConfigAppId);
 }
@@ -197,7 +197,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogLevelFromAppConfig)
         "Description",
         "TargetConfigReader shall parse the DLT Application log level from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDefaultLogLevel(), kAppConfigLogLevel);
 }
@@ -209,7 +209,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogModeFromAppConfig)
     RecordProperty("Description",
                    "TargetConfigReader shall parse the logging mode from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetLogMode(), kAppConfigLogMode);
 }
@@ -221,7 +221,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseAppDescriptionFromAppCon
     RecordProperty("Description",
                    "TargetConfigReader shall parse the application description from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetAppDescription(), kAppDescription);
 }
@@ -234,7 +234,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseBufferOverwriteOnFullSta
         "Description",
         "TargetConfigReader shall parse the overwrite ring buffer option from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_TRUE(GetReader().ReadConfig()->GetRingBufferOverwriteOnFull());
 }
@@ -247,7 +247,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseStackBufferSizeFromEcuCo
         "Description",
         "TargetConfigReader shall parse the stack buffer size in shared memory from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetStackBufferSize(), kEcuConfigStackBufferSize);
 }
@@ -260,7 +260,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseRingBufferSizeFromEcuCon
         "Description",
         "TargetConfigReader shall parse the ring buffer size in shared memory from the configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetRingBufferSize(), kEcuConfigRingBufferSize);
 }
@@ -273,7 +273,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogLevelConsoleFromEcuCo
                    "TargetConfigReader shall parse the default log level threshold for console logging from the "
                    "configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDefaultConsoleLogLevel(), kEcuConfigLogLevelConsole);
 }
@@ -286,7 +286,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseLogFilePathFromAppConfig
                    "TargetConfigReader shall parse the default log file path for console logging from the "
                    "configuration file correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetLogFilePath(), kAppConfigLogFilePath);
 }
@@ -299,7 +299,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseContextLogLevelFromEcuAn
                    "TargetConfigReader shall parse and combine the context log levels from the "
                    "configuration files correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetContextLogLevel(), kCombinedContextLogLevel);
 }
@@ -310,7 +310,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseNumberOfSlots)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall parse the number of slots for preallocation correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetNumberOfSlots(), kNumberOfSlots);
 }
@@ -321,7 +321,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseSlotSizeBytes)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall parse the size of the slots for preallocation correctly.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetSlotSizeInBytes(), kSlotSizeBytes);
 }
@@ -333,7 +333,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseDynamicDatarouterIdentif
     RecordProperty("Description",
                    "TargetConfigReader shall parse if datarouter dyanmic identifiers flag is enabled or not.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDynamicDatarouterIdentifiers(), kDynamicDatarouterIdentifiers);
 }
@@ -344,7 +344,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallParseDataRouterUid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TargetConfigReader shall parse datarouter user ID.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_EQ(GetReader().ReadConfig()->GetDataRouterUid(), kDatarouterUid);
 }
@@ -357,7 +357,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigSyntaxErrorShallFallbackToEcuConfig)
         "Description",
         "TargetConfigReader fall back to the ECU config file if the application config files contains syntax errors.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config contains a syntax error.
     SetConfigurationFiles({kEcuConfigFile(), kSyntaxErrorConfigFile()});
@@ -374,7 +374,7 @@ TEST_F(TargetConfigReaderFixture, WrongStructureConfigFileShallCauseDefaultAppId
                    "TargetConfigReader fall back to the hard-coded default application id if the configuration file "
                    "does not contain a valid JSON structure");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config has wrong structure.
     SetConfigurationFiles({kErrorContent()});
@@ -391,7 +391,7 @@ TEST_F(TargetConfigReaderFixture, WrongLogLevelValueShallFallbackToEcuConfig)
                    "TargetConfigReader fall back to the ECU config file if the if the logLevelThresholdConsole "
                    "has wrong value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config has wrong structure.
     SetConfigurationFiles({kWrongLogLevel()});
@@ -408,7 +408,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigInvalidLogLevelFallbackToEcuConfig)
                    "TargetConfigReader fall back to the valid value from the ECU configuration file if the application "
                    "config file contains an invalid log level.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config contains invalid default log level.
     SetConfigurationFiles({kEcuConfigFile(), kInvalidAppConfigFile()});
@@ -425,7 +425,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigInvalidLogModeFallbackToEcuConfig)
                    "TargetConfigReader fall back to the valid value from the ECU configuration file if the application "
                    "config file contains an invalid log mode.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config contains invalid log mode.
     SetConfigurationFiles({kEcuConfigFile(), kInvalidAppConfigFile()});
@@ -442,7 +442,7 @@ TEST_F(TargetConfigReaderFixture, AppConfigInvalidContextConfigFallbackToEcuConf
                    "TargetConfigReader fall back to the valid value from the ECU configuration file if the application "
                    "config file contains an invalid log level for a context.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config contains invalid context log level entries.
     SetConfigurationFiles({kEcuConfigFile(), kInvalidAppConfigFile()});
@@ -458,7 +458,7 @@ TEST_F(TargetConfigReaderFixture, WrongEntriesToContextConfigslShallReturnEmptyC
     RecordProperty("Description",
                    "TargetConfigReader shall return empty context config log level when providing wrong entries.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config contains invalid context config entries.
     SetConfigurationFiles({kWrongContextConfig()});
@@ -475,7 +475,7 @@ TEST_F(TargetConfigReaderFixture, WhenInvalidFilePathReaderShallReturnDefaultApp
                    "TargetConfigReader fall back to the hard-coded default application id if the configuration file "
                    "does not exist");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config does not exist
     SetConfigurationFiles({kInvalidConfigFilePath()});
@@ -492,7 +492,7 @@ TEST_F(TargetConfigReaderFixture, EmptyConfigFileShallCauseDefaultAppId)
                    "TargetConfigReader fall back to the hard-coded default application id if the configuration file "
                    "does not contain any value");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // The application config does not exist
     SetConfigurationFiles({kEmptyConfigFile()});
@@ -509,7 +509,7 @@ TEST_F(TargetConfigReaderFixture, ConfigReaderShallFallBackToContextLogLevelDefa
                    "TargetConfigReader fall back to the hard-coded default context log level values if there is no "
                    "valid value in the configuration files");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     SetConfigurationFiles({kCtxLevelBrokenConfigFile()});
 

--- a/score/mw/log/detail/circular_allocator_test.cpp
+++ b/score/mw/log/detail/circular_allocator_test.cpp
@@ -53,7 +53,7 @@ TEST_F(CircularAllocatorFixture, WriteSingleEntryWithoutThreads)
     RecordProperty("Description",
                    "Writing into the circular allocator shall succeed if there are multiple free slots.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a Ring-Buffer with enough space
     CircularAllocator<std::int32_t> unit{5};
@@ -70,7 +70,7 @@ TEST_F(CircularAllocatorFixture, WriteSingleEntryWithoutThreadsWithSingleSlotCap
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Writing into the circular allocator shall succeed if a single slot is free.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a Ring-Buffer with enough space
     CircularAllocator<std::int32_t> unit{1};
@@ -89,7 +89,7 @@ TEST_F(CircularAllocatorFixture, WriteSingleThreadedOverBufferSize)
                    "When writing more slots in the circular allocator than capacity, the write to the next slot shall "
                    "wrap around and succeed.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Overview of the expected storage layout:
     // | Slot 0 | Slot 1 | Slot 2 |
@@ -121,7 +121,7 @@ TEST_F(CircularAllocatorFixture, WritingFromMultipleThreadsIsSafe)
         "every slot allocation from every thread shall succeed if the number of threads is equal the "
         "number of slots.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a Ring-Buffer
     constexpr size_t number_of_slots = 10U;
@@ -153,7 +153,7 @@ TEST_F(CircularAllocatorFixture, WritingFromMultipleThreadsIsSafeWithInsufficien
                    "When writing to CircularAllocator with multiple threads in parallel and trying to allocate more "
                    "slots than capacity, the number of reserved slots shall be equal to the capacity.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a Ring-Buffer
     constexpr std::size_t number_of_slots{100};
@@ -193,7 +193,7 @@ TEST_F(CircularAllocatorFixture, TryAcquireWhenAllSlotsAcquired)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "When every slot is occupied acquiring another slot shall return an empty result.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a Ring-Buffer where all slots are acquired
     CircularAllocator<std::int32_t> unit{1};

--- a/score/mw/log/detail/dlt_argument_counter_test.cpp
+++ b/score/mw/log/detail/dlt_argument_counter_test.cpp
@@ -29,7 +29,7 @@ TEST(DltArgumentCounterShould, IncreaseCounter)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DltArgumentCounter should increase counter when an argument is added");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     uint8_t counter = 0;
     DltArgumentCounter sut{counter};
@@ -45,7 +45,7 @@ TEST(DltArgumentCounterShould, NotIncreaseCounterBecauseArgumentNotAdded)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DltArgumentCounter should not increase counter when no argument is added");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     uint8_t counter = 0;
     DltArgumentCounter sut{counter};
@@ -61,7 +61,7 @@ TEST(DltArgumentCounterShould, NotIncreaseCounterBecauseMaxCounterReached)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DltArgumentCounter should not increase counter when the counter has maximum value");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     uint8_t counter = 255;
     DltArgumentCounter sut{counter};
@@ -79,7 +79,7 @@ TEST(DltArgumentCounterShould, NotIncreaseCounterBecauseMaxCounterReachedAndNoAr
         "Description",
         "DltArgumentCounter should not increase counter when the counter has maximum value and no argument is added");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     uint8_t counter = 255;
     DltArgumentCounter sut{counter};

--- a/score/mw/log/detail/empty_recorder_test.cpp
+++ b/score/mw/log/detail/empty_recorder_test.cpp
@@ -37,7 +37,7 @@ TEST_F(EmptyRecorderFixture, StartRecord)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains StartRecord function for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.StartRecord("DFLT", LogLevel::kInfo);
 }
@@ -48,7 +48,7 @@ TEST_F(EmptyRecorderFixture, StopRecord)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains StopRecord function for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.StopRecord(SlotHandle{});
 }
@@ -59,7 +59,7 @@ TEST_F(EmptyRecorderFixture, LogBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log boolean for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, bool{});
 }
@@ -70,7 +70,7 @@ TEST_F(EmptyRecorderFixture, LogUint8_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint8_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::uint8_t{});
 }
@@ -81,7 +81,7 @@ TEST_F(EmptyRecorderFixture, LogInt8_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int8_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::int8_t{});
 }
@@ -92,7 +92,7 @@ TEST_F(EmptyRecorderFixture, LogUint16_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint16_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::uint16_t{});
 }
@@ -103,7 +103,7 @@ TEST_F(EmptyRecorderFixture, LogInt16_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int16_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::int16_t{});
 }
@@ -114,7 +114,7 @@ TEST_F(EmptyRecorderFixture, LogUint32_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint32_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::uint32_t{});
 }
@@ -125,7 +125,7 @@ TEST_F(EmptyRecorderFixture, LogInt32_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int32_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::int32_t{});
 }
@@ -136,7 +136,7 @@ TEST_F(EmptyRecorderFixture, LogUint64_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log uint64_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::uint64_t{});
 }
@@ -147,7 +147,7 @@ TEST_F(EmptyRecorderFixture, LogInt64_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log int64_t for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::int64_t{});
 }
@@ -158,7 +158,7 @@ TEST_F(EmptyRecorderFixture, LogFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log float for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, float{});
 }
@@ -169,7 +169,7 @@ TEST_F(EmptyRecorderFixture, LogDouble)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log double for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, double{});
 }
@@ -180,7 +180,7 @@ TEST_F(EmptyRecorderFixture, LogStringView)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log string view for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, std::string_view{});
 }
@@ -193,7 +193,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex8)
         "Description",
         "EmptyRecorder contains log function which can log 8 bits with hex represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogHex8{});
 }
@@ -206,7 +206,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex16)
         "Description",
         "EmptyRecorder contains log function which can log 16 bits with hex represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogHex16{});
 }
@@ -219,7 +219,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex32)
         "Description",
         "EmptyRecorder contains log function which can log 32 bits with hex represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogHex32{});
 }
@@ -232,7 +232,7 @@ TEST_F(EmptyRecorderFixture, Log_LogHex64)
         "Description",
         "EmptyRecorder contains log function which can log 64 bits with hex represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogHex64{});
 }
@@ -245,7 +245,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin8)
         "Description",
         "EmptyRecorder contains log function which can log 8 bits with bin represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogBin8{});
 }
@@ -258,7 +258,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin16)
         "Description",
         "EmptyRecorder contains log function which can log 16 bits with bin represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogBin16{});
 }
@@ -271,7 +271,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin32)
         "Description",
         "EmptyRecorder contains log function which can log 32 bits with bin represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogBin32{});
 }
@@ -284,7 +284,7 @@ TEST_F(EmptyRecorderFixture, Log_LogBin64)
         "Description",
         "EmptyRecorder contains log function which can log 64 bits with bin represenataton for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogBin64{});
 }
@@ -295,7 +295,7 @@ TEST_F(EmptyRecorderFixture, Log_LogRawBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains log function which can log raw buffer for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogRawBuffer{nullptr, 0});
 }
@@ -306,7 +306,7 @@ TEST_F(EmptyRecorderFixture, Log_LogSlog2Message)
     RecordProperty("Description",
                    "EmptyRecorder contains log function which can log LogSlog2Message for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     emptyRecorder.Log(SlotHandle{}, LogSlog2Message{11, "slog message"});
 }
@@ -317,7 +317,7 @@ TEST_F(EmptyRecorderFixture, IsLogEnabledShallReturnValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "EmptyRecorder contains IsLogEnabled for testing purpose.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_FALSE(emptyRecorder.IsLogEnabled(LogLevel::kInfo, std::string_view{"DFLT"}));
 }

--- a/score/mw/log/detail/error_test.cpp
+++ b/score/mw/log/detail/error_test.cpp
@@ -60,7 +60,7 @@ TEST_P(LogDetailErrorFixture, EachErrorShallReturnNonEmptyMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of raising the error codes with a specific error message.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error_code = ReturnError(GetParam());
     EXPECT_GT(error_code.Message().size(), 0);
@@ -71,7 +71,7 @@ TEST(LgDetailErrorUnknown, TestUnknownError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of raising the error codes with a specific error message.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error_code_out_of_range =
         LogDetailErrorFixture::ReturnError(static_cast<Error>(std::numeric_limits<std::size_t>::max()));

--- a/score/mw/log/detail/log_record_test.cpp
+++ b/score/mw/log/detail/log_record_test.cpp
@@ -55,7 +55,7 @@ TEST(LogRecord, LogRecordShallReturnExpectedLogEntry)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can be constructed with max payload size.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     LogRecord unit{kMaxPayloadSize};
     EXPECT_EQ(unit.getLogEntry().payload.capacity(), kMaxPayloadSize);
@@ -67,7 +67,7 @@ TEST(LogRecord, LogRecordShallReturnExpectedVerbosePayload)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide the expected verbose payload.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     LogRecord unit{kMaxPayloadSize};
     EXPECT_EQ(unit.getVerbosePayload().RemainingCapacity(), kMaxPayloadSize);
@@ -79,7 +79,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallCopyAssignAndUpdateRe
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide copy assignment operator with valid state.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     LogRecord unit{kMaxPayloadSize};
     {
@@ -96,7 +96,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallCopyConstructAndUpdat
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide copy constructor with valid state.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     score::cpp::optional<LogRecord> unit{};
     {
@@ -113,7 +113,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallMoveAssignAndUpdateRe
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide move assigment operator with validstate.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     LogRecord unit{kMaxPayloadSize};
     {
@@ -130,7 +130,7 @@ TEST_P(LogRecordCopyAndMoveOperatorsFixture, LogRecordShallMoveConstructAndUpdat
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord can provide move constructor with valid state.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     score::cpp::optional<LogRecord> unit{};
     {
@@ -147,7 +147,7 @@ TEST(LogRecord, SelfAssignmentShallNotModifyState)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogRecord handles self-assignment without modifying state.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Arrange: Create a LogRecord object and set some initial state
     LogRecord unit{kMaxPayloadSize};

--- a/score/mw/log/detail/logging_identifier_test.cpp
+++ b/score/mw/log/detail/logging_identifier_test.cpp
@@ -33,7 +33,7 @@ TEST(LoggingIdentifierTestSuite, CheckThatLongIdentifiersShallBeCropped)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "logging identifier has maximum length in which the identifier will be cropped.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     LoggingIdentifier identifier{"12345"};
     EXPECT_EQ(identifier.GetStringView(), std::string_view{"1234"});
@@ -45,7 +45,7 @@ TEST(LoggingIdentifierTestSuite, CheckThatHashMatchesIntHasher)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that hash matches int hasher.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string_view ctx{"CTX1"};
     std::int32_t val{};
@@ -60,7 +60,7 @@ TEST(LoggingIdentifierTestSuite, EqualityOperatorShallReturnTrueForTheSameString
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "logging identifiers with the same context name shall be equal.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::string_view ctx{"CTX1"};
     LoggingIdentifier lhs{ctx};
@@ -74,7 +74,7 @@ TEST(LoggingIdentifierTestSuite, InequalityOperatorShallReturnTrueForDifferentSt
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "logging identifiers with the different context name shall not be equal.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     LoggingIdentifier lhs{std::string_view{"CTX1"}};
     LoggingIdentifier rhs{std::string_view{"CTX"}};
@@ -86,7 +86,7 @@ TEST(LoggingIdentifierTestSuite, AssignOperatorShallCopyLoggingIdentifier)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the assign operator functionality.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string_view ctx{"CTX1"};
     std::string_view ctx2{"CTX2"};

--- a/score/mw/log/detail/text_recorder/file_output_backend_test.cpp
+++ b/score/mw/log/detail/text_recorder/file_output_backend_test.cpp
@@ -73,7 +73,7 @@ TEST_F(FileOutputBackendFixture, ReserveSlotShouldTriggerFlushing)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ReserveSlot shall trigger flushing.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
     auto unistd_mock = score::cpp::pmr::make_unique<score::os::UnistdMock>(memory_resource_);
@@ -97,7 +97,7 @@ TEST_F(FileOutputBackendFixture, FlushSlotShouldTriggerFlushing)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FlushSlot shall trigger flushing.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
     auto unistd_mock = score::cpp::pmr::make_unique<score::os::UnistdMock>(memory_resource_);
@@ -125,7 +125,7 @@ TEST_F(FileOutputBackendFixture, DepletedAllocatorShouldCauseEmptyOptionalReturn
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ReserveSlot will return None if all allocator's slots are reserved.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     for (std::size_t i = 0; i < pool_size_; i++)
     {
@@ -156,7 +156,7 @@ TEST_F(FileOutputBackendFixture, GetLogRecordReturnsObjectSameAsAllocatorWould)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetLogRecord can return object same as returned from the allocator.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
     auto unistd_mock = score::cpp::pmr::make_unique<score::os::UnistdMock>(memory_resource_);
@@ -182,7 +182,7 @@ TEST_F(FileOutputBackendFixture, BackendConstructionShallCallNonBlockingFileSetu
                    "File backend construction shall return non blocking file setup. The component shall set the "
                    "FD_CLOEXEC (or O_CLOEXEC) flag on all the file descriptor it owns");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     score::os::Fcntl::Open flags = score::os::Fcntl::Open::kReadWrite;
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
@@ -213,7 +213,7 @@ TEST_F(FileOutputBackendFixture, MissingFlagsShallSkipCallToSetupFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "File backend construction shall not do file setup if there is any missing flag.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto fcntl_mock = score::cpp::pmr::make_unique<score::os::FcntlMock>(memory_resource_);
     auto unistd_mock = score::cpp::pmr::make_unique<score::os::UnistdMock>(memory_resource_);

--- a/score/mw/log/detail/text_recorder/non_blocking_writer_test.cpp
+++ b/score/mw/log/detail/text_recorder/non_blocking_writer_test.cpp
@@ -61,7 +61,7 @@ TEST_F(NonBlockingWriterTestFixture, NonBlockingWriterWhenFlushingTwiceMaxChunkS
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingWrite can flush 2 max chunks size.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::array<uint8_t, 2 * max_chunk_size> payload{};
 
@@ -87,7 +87,7 @@ TEST_F(NonBlockingWriterTestFixture,
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingWrite can flush 2 different spans with different sizes.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::array<uint8_t, (2 * max_chunk_size) + 3> first_payload{};
 
@@ -127,7 +127,7 @@ TEST_F(NonBlockingWriterTestFixture, NonBlockingWriterShallReturnFalseWhenWriteS
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingWrite cannot flush if the system call write fails with error EBADF.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::array<uint8_t, max_chunk_size> payload{};
     score::cpp::span<const std::uint8_t> buffer{payload.data(),
@@ -151,7 +151,7 @@ TEST_F(NonBlockingWriterTestFixture,
         "Description",
         "NonBlockingWrite can flush 2 max chunk sizes when flushing span with correct indexes to system call write");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::array<uint8_t, 2 * max_chunk_size> payload{};
     score::cpp::span<const std::uint8_t> buffer{payload.data(),
@@ -178,7 +178,7 @@ TEST_F(NonBlockingWriterTestFixture,
                    "NonBlockingWrite can flush 1 k max chunk size on two different times even if the write returns "
                    "half of max chunk size");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::array<uint8_t, max_chunk_size> payload{};
 

--- a/score/mw/log/detail/text_recorder/slot_drainer_test.cpp
+++ b/score/mw/log/detail/text_recorder/slot_drainer_test.cpp
@@ -77,7 +77,7 @@ TEST_F(SlotDrainerFixture, TestOneWriteFileFailurePath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Writes will fail with IO error in case of failure path.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     //  Given write file error
     SlotDrainer unit(
@@ -106,7 +106,7 @@ TEST_F(SlotDrainerFixture, IncompleteWriteFileShouldMakeFlushSpansReturnWouldBlo
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "If write not completed, the Flush API would wait till flushing is complete.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     //  Given write file error
     SlotDrainer unit(
@@ -140,7 +140,7 @@ TEST_F(SlotDrainerFixture, TestOneSlotOneSpan)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Writes shall succeed in case of proper arguments.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     //  Given one slot flushed
     SlotDrainer unit(
@@ -175,7 +175,7 @@ TEST_F(SlotDrainerFixture, TestTooManySlotsForSingleCallShallNotBeAbleToFlushAll
     RecordProperty("Description",
                    "Fails to flush all slots in case of exceeding the limit of slots to be processed per one call.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t kLimiNumberOfSlotsProcesssedInOneCall = 2UL;
     const std::size_t kNumberOfSlotsQueued = 3UL;

--- a/score/mw/log/detail/text_recorder/text_format_test.cpp
+++ b/score/mw/log/detail/text_recorder/text_format_test.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(UnsupportedTypesCoverage, VerifyUnsupportedTypesActionsHex)
     ::testing::Test::RecordProperty(
         "Description", "Verifies Type-Information for integer values with hex representation can not be logged.");
     ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
-    ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
+    ::testing::Test::RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(this->payload_, this->value_, IntegerRepresentation::kHex);
     EXPECT_EQ(this->buffer_.size(), 0);
@@ -71,7 +71,7 @@ TYPED_TEST(UnsupportedTypesCoverage, VerifyUnsupportedTypesActionsOctal)
     ::testing::Test::RecordProperty(
         "Description", "Verifies Type-Information for integer values with octal representation can not be logged.");
     ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
-    ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
+    ::testing::Test::RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(this->payload_, this->value_, IntegerRepresentation::kOctal);
     EXPECT_EQ(this->buffer_.size(), 0);
@@ -84,7 +84,7 @@ TYPED_TEST(UnsupportedTypesCoverage, VerifyUnsupportedTypesActionsBin)
     ::testing::Test::RecordProperty(
         "Description", "Verifies Type-Information for integer values with binary representation can not be logged.");
     ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
-    ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
+    ::testing::Test::RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(this->payload_, this->value_, IntegerRepresentation::kBinary);
     EXPECT_EQ(this->buffer_.size(), 0);
@@ -96,7 +96,7 @@ TEST_F(TextFormatFixture, DepletedBufferPassed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies no log can be set for a zero buffer size.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(depleted_payload_, std::int32_t{123U});
 
@@ -109,7 +109,7 @@ TEST_F(TextFormatFixture, PositiveValueForBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with bool in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, bool{true});
 
@@ -127,7 +127,7 @@ TEST_F(TextFormatFixture, NegativeValueForBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with bool in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, bool{false});
 
@@ -146,7 +146,7 @@ TEST_F(TextFormatFixture, PositiveValueOnBufferFull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int64 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(capacity_two_payload_, std::string_view{"xxx"});
     TextFormat::Log(capacity_two_payload_, std::int8_t{123U});
@@ -163,7 +163,7 @@ TEST_F(TextFormatFixture, PositiveValueForInt8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int8 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::int8_t{123U});
 
@@ -180,7 +180,7 @@ TEST_F(TextFormatFixture, NegativeValueInt8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int8 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::int8_t{-123});
 
@@ -198,7 +198,7 @@ TEST_F(TextFormatFixture, PositiveValueForInt16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int16 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::int16_t{123U});
 
@@ -215,7 +215,7 @@ TEST_F(TextFormatFixture, NegativeValueInt16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int16 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::numeric_limits<int16_t>::min());
     EXPECT_EQ(buffer_.size(), 7);
@@ -228,7 +228,7 @@ TEST_F(TextFormatFixture, PositiveValueInt32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int32 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::numeric_limits<int32_t>::max());
     EXPECT_EQ(buffer_.size(), 11);
@@ -241,7 +241,7 @@ TEST_F(TextFormatFixture, NegativeValueInt32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int32 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::numeric_limits<int32_t>::min());
     EXPECT_EQ(buffer_.at(0), '-');
@@ -266,7 +266,7 @@ TEST_F(TextFormatFixture, PositiveValueInt64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a positive value with int64 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, int64_t{std::numeric_limits<int64_t>::max()});
 
@@ -280,7 +280,7 @@ TEST_F(TextFormatFixture, NegativeValueInt64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for a negative value with int64 size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::numeric_limits<int64_t>::min());
 
@@ -295,7 +295,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint8)
     RecordProperty("Description",
                    "Verifies Type-Information for positive value with uint8 representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint8_t{234U});
 
@@ -313,7 +313,7 @@ TEST_F(TextFormatFixture, HexFormatUint8)
     RecordProperty("Description",
                    "Verifies Type-Information for uint8 value with hex representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogHex8{234U});
 
@@ -330,7 +330,7 @@ TEST_F(TextFormatFixture, BinaryFormatUint8)
     RecordProperty("Description",
                    "Verifies Type-Information for uint8 value with binary representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogBin8{234U});
 
@@ -353,7 +353,7 @@ TEST_F(TextFormatFixture, OctalFormatUint8)
     RecordProperty("Description",
                    "Verifies Type-Information for uint8 value with octal representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint8_t{234U}, IntegerRepresentation::kOctal);
 
@@ -371,7 +371,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint16)
     RecordProperty("Description",
                    "Verifies Type-Information for a positive value with uint16 representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint16_t{43456U});
 
@@ -391,7 +391,7 @@ TEST_F(TextFormatFixture, HexFormatUint16)
     RecordProperty("Description",
                    "Verifies Type-Information for uint16 value with hex representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogHex16{123U});
 
@@ -408,7 +408,7 @@ TEST_F(TextFormatFixture, BinaryFormatUint16)
     RecordProperty("Description",
                    "Verifies Type-Information for uint16 value with binary representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogBin16{43456U});
 
@@ -423,7 +423,7 @@ TEST_F(TextFormatFixture, OctalFormatUint16)
     RecordProperty("Description",
                    "Verifies Type-Information for uint16 value with octal representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint16_t{43456U}, IntegerRepresentation::kOctal);
 
@@ -443,7 +443,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for positive value with uint32_t size in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint32_t{std::numeric_limits<int32_t>::max()} + 1);
 
@@ -457,7 +457,7 @@ TEST_F(TextFormatFixture, HexFormatUint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for uint32 with hex representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogHex32{52345U});
 
@@ -476,7 +476,7 @@ TEST_F(TextFormatFixture, BinFormatUint32)
     RecordProperty("Description",
                    "Verifies Type-Information for uint32 with binary representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogBin32{52345U});
 
@@ -491,7 +491,7 @@ TEST_F(TextFormatFixture, OctalFormatUint32)
     RecordProperty("Description",
                    "Verifies Type-Information for uint32 with octal representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint32_t{52349U}, IntegerRepresentation::kOctal);
 
@@ -506,7 +506,7 @@ TEST_F(TextFormatFixture, PositiveValueForUint64)
     RecordProperty("Description",
                    "Verifies Type-Information for positive value with uint64_t size  in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, uint64_t{std::numeric_limits<int64_t>::max()} + 1);
 
@@ -522,7 +522,7 @@ TEST_F(TextFormatFixture, BinaryFormat_InsufficientBuffer)
                    "Verifies Type-Information for binary representation shall be cropped in case of insufficent buffer "
                    "for its bytes.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(capacity_two_payload_, std::uint8_t{234U}, IntegerRepresentation::kBinary);
 
@@ -540,7 +540,7 @@ TEST_F(TextFormatFixture, BinaryFormatWhenBufferFull)
                    "Verifies Type-Information for binary representation shall be cropped in case of insufficent buffer "
                    "for its bytes.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     //  Make the buffer full
     TextFormat::Log(capacity_two_payload_, std::string_view{"xxx"});
@@ -561,7 +561,7 @@ TEST_F(TextFormatFixture, HexFormat_InsufficientBuffer)
                    "Verifies Type-Information for hex representation shall only store bytes of data equal to the "
                    "allocated capacity.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(capacity_two_payload_, std::uint32_t{52345U}, IntegerRepresentation::kHex);
 
@@ -577,7 +577,7 @@ TEST_F(TextFormatFixture, HexFormatUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for uint64 with hex representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogHex64{12379813812177893520U});
 
@@ -592,7 +592,7 @@ TEST_F(TextFormatFixture, BinaryFormatUint64)
     RecordProperty("Description",
                    "Verifies Type-Information for uint64 with binary representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, LogBin64{12379813812177893520U});
 
@@ -609,7 +609,7 @@ TEST_F(TextFormatFixture, OctalFormatUint64)
     RecordProperty("Description",
                    "Verifies Type-Information for uint64 with octal representation is in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::uint64_t{12379813812177893520U}, IntegerRepresentation::kOctal);
 
@@ -623,7 +623,7 @@ TEST_F(TextFormatFixture, LogFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for float in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, 1.23f);
 
@@ -646,7 +646,7 @@ TEST_F(TextFormatFixture, LogDouble)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for double in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, 1.23);
 
@@ -669,7 +669,7 @@ TEST_F(TextFormatFixture, StringValueCorrectlyTransformed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for string in correct format.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::string_view{"Hello World"});
 
@@ -696,7 +696,7 @@ TEST_F(TextFormatFixture, TerminateShallPutNewLine)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that TerminateLog shall put new line in data buffer.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::TerminateLog(payload_);
     ASSERT_EQ(buffer_.at(0), '\n');
@@ -709,7 +709,7 @@ TEST_F(TextFormatFixture, StringValueWhenBufferFull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for string shall be intact in case of using full buffer.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     //  Make the buffer full
     TextFormat::Log(capacity_two_payload_, std::string_view{"xxx"});
@@ -729,7 +729,7 @@ TEST_F(TextFormatFixture, EmptyString)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies Type-Information for empty string will not allocate memory.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     TextFormat::Log(payload_, std::string_view{""});
 
@@ -744,7 +744,7 @@ TEST_F(TextFormatFixture, RawValueSimpleConversionToHex)
         "Description",
         "Verifies Type-Information for raw value will be converted to hex values nibble by nibble before storing.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::vector<char> data{{1, 2, 0x1F}};
     TextFormat::Log(payload_, LogRawBuffer{data.data(), 3});
@@ -769,7 +769,7 @@ TEST_F(TextFormatFixture, RawValueSimpleConversionToHexInsufficientBuffer)
                    "Verifies Type-Information for raw value will be converted to hex values nibble by nibble and will "
                    "be cropped in case of using insufficient buffer.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::vector<char> data{{1, 2, 0x1F}};
     TextFormat::Log(capacity_two_payload_, LogRawBuffer{data.data(), 3});
@@ -788,7 +788,7 @@ TEST_F(TextFormatFixture, RawValueZeroLengthBuffer)
     RecordProperty("Description",
                    "Verifies Type-Information for raw value with zero size will not allocate any memory for logging.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::vector<char> data{};
     TextFormat::Log(payload_, LogRawBuffer{data.data(), 0});
@@ -804,7 +804,7 @@ TEST_F(TextFormatFixture, RawValueZeroMaxSizeBuffer)
     RecordProperty("Description",
                    "Verifies raw value with zero max size buffer will not allocate any memory for logging.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ByteVector buffer{};
     LogRawBuffer data{"test data"};
@@ -827,7 +827,7 @@ TEST(FormattingFunction, ShallReturnEmptyIfPayloadMaxSizeEqualToZero)
     RecordProperty("Description",
                    "Verifies getting empty payload in case of the max size for allocated memory is equal to zero.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ByteVector buffer{};
     VerbosePayload payload{0U, buffer};

--- a/score/mw/log/detail/text_recorder/text_message_builder_test.cpp
+++ b/score/mw/log/detail/text_recorder/text_message_builder_test.cpp
@@ -70,7 +70,7 @@ TEST_F(TextMessageBuilderFixture, ShallDepleteAfterHeaderAndPayload)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextMessageBuilder shall deplete after getting header and payload.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     unit_.SetNextMessage(log_record_);
     const auto first = unit_.GetNextSpan();
@@ -89,7 +89,7 @@ TEST_F(TextMessageBuilderFixture, HeaderShallHaveSpecificElements)
                    "Header of TextMessageBuilder shall have specific elements like context id, application id, ecu id, "
                    "and number of args.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     unit_.SetNextMessage(log_record_);
 
@@ -111,7 +111,7 @@ TEST_F(TextMessageBuilderFixture, PayloadShouldHaveSetText)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Payload of TextMessageBuilder shall have the set text.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     unit_.SetNextMessage(log_record_);
 
@@ -138,7 +138,7 @@ TEST_P(TextMessageBuilderFixture, HeaderShallHaveLevelPrintedForAllParams)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Header of TextMessageBuilder shall have printed level for all parameters.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto& log_entry = log_record_.getLogEntry();
     log_entry.log_level = GetParam();
@@ -157,7 +157,7 @@ TEST_F(TextMessageBuilderFixture, LogLevelToStringShouldReturnUndefinedForInvali
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LogLevelToString should return 'undefined' for an invalid log level.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto& log_entry = log_record_.getLogEntry();
 

--- a/score/mw/log/detail/text_recorder/text_recorder_test.cpp
+++ b/score/mw/log/detail/text_recorder/text_recorder_test.cpp
@@ -68,7 +68,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, WillObtainSlotForSufficientLogLevel
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The required slots will be returned in case of insufficent log level");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto slot = recorder_->StartRecord(context_id_, kActiveLogLevel);
     EXPECT_TRUE(slot.has_value());
@@ -80,7 +80,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, WillObtainEmptySlotForInsufficentLo
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Empty slots will be returned in case of insufficent log level");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto slot = recorder_->StartRecord(context_id_, kInActiveLogLevel);
     EXPECT_FALSE(slot.has_value());
@@ -92,7 +92,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, DisablesOrEnablesLogAccordingToLeve
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of enabling or disabling specific log level");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_TRUE(recorder_->IsLogEnabled(kActiveLogLevel, context_id_));
     EXPECT_FALSE(recorder_->IsLogEnabled(kInActiveLogLevel, context_id_));
@@ -104,7 +104,7 @@ TEST_F(TextRecorderFixtureWithLogLevelCheck, WillObtainEmptySlotsWhenNoSlotsRese
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Recorder shall returns zero slots if no slots were reserved.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto backend_mock = std::make_unique<BackendMock>();
     ON_CALL(*backend_mock, ReserveSlot()).WillByDefault(Invoke([]() -> score::cpp::optional<SlotHandle> {
@@ -157,7 +157,7 @@ TEST_F(TextRecorderFixture, TooManyArgumentsWillYieldTruncatedLog)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The log will be truncated in case of too many arguments");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     constexpr std::size_t byte_size_of_space_seperator = 1;
     const std::string_view message{"byte"};
@@ -179,7 +179,7 @@ TEST_F(TextRecorderFixture, TooLargeSinglePayloadWillYieldTruncatedLog)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "The logs will be truncated in case of too large single payload");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const std::size_t too_big_data_size = log_record_.getLogEntry().payload.capacity() + 1UL;
     std::vector<char> vec(too_big_data_size);
@@ -197,7 +197,7 @@ TEST_F(TextRecorderFixture, LogUint8_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint8_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::uint8_t{});
 }
@@ -208,7 +208,7 @@ TEST_F(TextRecorderFixture, LogBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log boolean.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, bool{});
 }
@@ -219,7 +219,7 @@ TEST_F(TextRecorderFixture, LogInt8_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int8_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::int8_t{});
 }
@@ -230,7 +230,7 @@ TEST_F(TextRecorderFixture, LogUint16_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint16_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::uint16_t{});
 }
@@ -241,7 +241,7 @@ TEST_F(TextRecorderFixture, LogInt16_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int16_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::int16_t{});
 }
@@ -252,7 +252,7 @@ TEST_F(TextRecorderFixture, LogUint32_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint32_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::uint32_t{});
 }
@@ -263,7 +263,7 @@ TEST_F(TextRecorderFixture, LogInt32_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int32_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::int32_t{});
 }
@@ -274,7 +274,7 @@ TEST_F(TextRecorderFixture, LogUint64_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log uint64_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::uint64_t{});
 }
@@ -285,7 +285,7 @@ TEST_F(TextRecorderFixture, LogInt64_t)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log int64_t.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::int64_t{});
 }
@@ -296,7 +296,7 @@ TEST_F(TextRecorderFixture, LogFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log float.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, float{});
 }
@@ -307,7 +307,7 @@ TEST_F(TextRecorderFixture, LogDouble)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log double.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, double{});
 }
@@ -318,7 +318,7 @@ TEST_F(TextRecorderFixture, LogStringView)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log string view.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, std::string_view{"Hello world"});
 }
@@ -329,7 +329,7 @@ TEST_F(TextRecorderFixture, LogHex8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 8 bits with hex representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, LogHex8{});
 }
@@ -340,7 +340,7 @@ TEST_F(TextRecorderFixture, LogHex16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TextRecorder can log 16 bits with hex representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     recorder_->Log(SlotHandle{}, LogHex16{});
 }
@@ -428,7 +428,7 @@ TEST(TextRecorderTests, DefaultLogLevelShallBeUsedIfCheckForConsoleIsDisabled)
     RecordProperty("Description",
                    "Verifies that the default log level will be used in case of disabling the console logging.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto default_log_level = LogLevel::kDebug;
     constexpr auto more_than_default_log_level = LogLevel::kVerbose;
@@ -461,7 +461,7 @@ TEST(TextRecorderTests, TextRecorderShouldClearSlotOnStart)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Recorder should clean slots before reuse.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Test setup is here since we cannot reuse the fixture here because we have a specific construction use case.
     Configuration config{};

--- a/score/mw/log/detail/verbose_payload_test.cpp
+++ b/score/mw/log/detail/verbose_payload_test.cpp
@@ -46,7 +46,7 @@ TEST_F(VerbosePayloadFixture, SinglePutStoresMemoryCorrect)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Put function stores data in correct order in the payload (buffer) if called once.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an empty verbose payload with enough space
     VerbosePayload unit = constructUnitWithSize(10);
@@ -71,7 +71,7 @@ TEST_F(VerbosePayloadFixture, MultiplePutStoresMemoryCorrectly)
     RecordProperty("Description",
                    "Put function stores data in correct order in the payload (buffer) if called multiple times.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an already filled buffer with enough space
     VerbosePayload unit = constructUnitWithSize(20);
@@ -98,7 +98,7 @@ TEST_F(VerbosePayloadFixture, PutZeroSize)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Put function handles zero size data requests gracefully");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an already filled buffer with enough space
     VerbosePayload unit = constructUnitWithSize(20);
@@ -114,7 +114,7 @@ TEST_F(VerbosePayloadFixture, PutStopsAtMaximumSize)
     RecordProperty("Description",
                    "Put function continues to fill data to maximum size and any additional data will not be filled.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an empty verbose payload with to few space
     VerbosePayload unit = constructUnitWithSize(3);
@@ -136,7 +136,7 @@ TEST_F(VerbosePayloadFixtureDeathTest, AssertForInvalidPointerKicksIn)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Put function will exit with failure in case of invalid data pointer.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an empty buffer
     VerbosePayload unit = constructUnitWithSize(0);
@@ -153,7 +153,7 @@ TEST_F(VerbosePayloadFixture, EmptyBufferHasNoWrongBehavior)
     RecordProperty("Description",
                    "Put function will not fill any data in case of empty buffer and will return successfully.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an empty verbose payload with no space
     VerbosePayload unit = constructUnitWithSize(0);
@@ -172,7 +172,7 @@ TEST_F(VerbosePayloadFixture, SizeFitsInPayload)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies size fits in payload.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an empty verbose payload with enough space
     VerbosePayload unit = constructUnitWithSize(5);
@@ -188,7 +188,7 @@ TEST_F(VerbosePayloadFixture, SizeFitsNotInPayload)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies size does not fit in payload.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given an empty verbose payload with enough space
     VerbosePayload unit = constructUnitWithSize(5);
@@ -207,7 +207,7 @@ TEST_F(VerbosePayloadFixture, SetBufferShallRebindReference)
         "Verifies setting new buffer for VerbosePayload will update the pointer to the new buffer and discards "
         "the old one.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given VerbosePayload is constructed with a different buffer.
     constexpr std::size_t kOldBufferSize = 5U;

--- a/score/mw/log/detail/wait_free_stack/wait_free_stack_test.cpp
+++ b/score/mw/log/detail/wait_free_stack/wait_free_stack_test.cpp
@@ -38,7 +38,7 @@ TEST(WaitFreeStack, AtomicOperationFetchAddForWriteIndex)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check atomic fetch_add function for write_index_.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     using AtomicType = std::size_t;
 
@@ -61,7 +61,7 @@ TEST(WaitFreeStack, AtomicShallBeLockFree)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check atomic lock-free.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(
         (WaitFreeStack<std::string, score::memory::shared::AtomicIndirectorReal>::AtomicIndex{}.is_always_lock_free));
@@ -77,7 +77,7 @@ TEST(WaitFreeStack, ConcurrentPushingAndReadingShouldReturnExpectedElements)
                    "Ensures that WaitFreeStack shall be capable of performing multiple "
                    "concurrent write operations without endless loops and return the correct data.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     constexpr auto stack_size = 10UL;
     WaitFreeStack<std::string, score::memory::shared::AtomicIndirectorReal> stack{stack_size};

--- a/score/mw/log/log_stream_test.cpp
+++ b/score/mw/log/log_stream_test.cpp
@@ -47,7 +47,7 @@ TEST(LogStream, CorrectlyHandleStartStop)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability to start and stop stream.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecorderMock recorder_mock_{};
     detail::Runtime::SetRecorder(&recorder_mock_);
 
@@ -68,7 +68,7 @@ TEST(LogStream, CanLogRecursive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that logging recursively calls the normal recorder");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecorderMock recorder_mock_{};
     detail::Runtime::SetRecorder(&recorder_mock_);
 
@@ -119,7 +119,7 @@ TYPED_TEST_P(DurationTest, insertion_operator_chrono_duration)
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description", "ara log shall be able to log chrono duration with unit suffix");
     this->RecordProperty("TestType", "Requirements-based test");
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // changing representation to double to prevent amiguity between int*, float and double types
     using d_TypeParam = std::chrono::duration<double, typename TypeParam::period>;
@@ -137,7 +137,7 @@ TEST(LogStream, WhenTryToGetStreamWithEmptyStringViewShallReturnDfltStream)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Getting stream with empty string view shall return the default context id.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecorderMock recorder_mock_{};
     detail::Runtime::SetRecorder(&recorder_mock_);
 
@@ -153,7 +153,7 @@ TEST(LogStream, TypeSupport)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the support for logging various types.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto ensure_that_log_stream_reports_support_for = [](auto value) {
         using ValueType = decltype(value);
@@ -234,7 +234,7 @@ TEST_F(LogStreamFixture, CanLogBool)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging boolean value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = true;
 
@@ -251,7 +251,7 @@ TEST_F(LogStreamFixture, CanLogUint8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int8 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::uint8_t{5};
 
@@ -268,7 +268,7 @@ TEST_F(LogStreamFixture, CanLogInt8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int8 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::int8_t{5};
 
@@ -285,7 +285,7 @@ TEST_F(LogStreamFixture, CanLogUint16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int16 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::uint16_t{5};
 
@@ -307,7 +307,7 @@ TEST_F(LogStreamFixture, CanLogSlog2Message)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int16 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto value = mw::log::LogSlog2Message{0U, std::string_view{"Any string"}};
 
@@ -327,7 +327,7 @@ TEST_F(LogStreamFixture, CanLogInt16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int16 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::int16_t{5};
 
@@ -344,7 +344,7 @@ TEST_F(LogStreamFixture, CanLogUint32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int32 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::uint32_t{5};
 
@@ -361,7 +361,7 @@ TEST_F(LogStreamFixture, CanLogInt32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int32 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::int32_t{5};
 
@@ -378,7 +378,7 @@ TEST_F(LogStreamFixture, CanLogUint64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int64 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::uint64_t{5};
 
@@ -395,7 +395,7 @@ TEST_F(LogStreamFixture, CanLogInt64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging int64 value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = std::int64_t{5};
 
@@ -412,7 +412,7 @@ TEST_F(LogStreamFixture, CanLogFloat)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging float value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = float{5.2F};
 
@@ -429,7 +429,7 @@ TEST_F(LogStreamFixture, CanLogDouble)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging double value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto constexpr value = double{5.2};
 
@@ -446,7 +446,7 @@ TEST_F(LogStreamFixture, CanLogAmpStringView)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging std::string_view value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto value = std::string_view{"Foo"};
 
@@ -463,7 +463,7 @@ TEST_F(LogStreamFixture, CanLogStdStringView)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging std::string_view value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto value = std::string_view{"Foo"};
 
@@ -480,7 +480,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyAmpStringViewShallNotLog)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that in case of empty std::string_view we shall expect no logs.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto value = std::string_view{};
 
@@ -497,7 +497,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyStdStringViewShallNotLog)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that in case of empty std::string_view we shall expect no logs.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     auto value = std::string_view{};
 
@@ -514,7 +514,7 @@ TEST_F(LogStreamFixture, CanLogConstStringReference)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging const string reference.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     const auto value = std::string{"Foo"};
 
@@ -531,7 +531,7 @@ TEST_F(LogStreamFixture, CanLogStdArrayOfChar)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging std::array<char> value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Expecting that the expected value will be transferred to the correct log call
     ::testing::InSequence in_sequence{};
@@ -548,7 +548,7 @@ TEST_F(LogStreamFixture, CanLogCharArrayLiteral)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging char[] literal value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Expecting that the expected value will be transferred to the correct log call
     EXPECT_CALL(recorder_mock_, LogStringView(HANDLE, std::string_view{__func__})).Times(2);
@@ -563,7 +563,7 @@ TEST_F(LogStreamFixture, CanLogPtrToNonConstChar)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging pointer to non-const char.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     std::array<char, 4> value{'F', 'o', 'o', '\0'};
 
@@ -580,7 +580,7 @@ TEST_F(LogStreamFixture, CanLogStringLiteral)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging string literal value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     LogString::CharPtr value = "Foo";
 
@@ -597,7 +597,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyStringLiteralShallNotLog)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that in case of empty string literal we shall expect no logs.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a value we want to log
     LogString::CharPtr value = nullptr;
 
@@ -614,7 +614,7 @@ TEST_F(LogStreamFixture, LogStreamMoveConstructorShallDetachMovedFromInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of log value using a moved LogStream instance.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // When logging the value
     auto log_stream_moved_from = Unit();
@@ -636,7 +636,7 @@ TEST_F(LogStreamFixture, CanLogHex8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int8 in hexdecimal representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogHex8 value{0xFF};
@@ -654,7 +654,7 @@ TEST_F(LogStreamFixture, CanLogHex16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int16 in hexdecimal representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogHex16 value{0xFFFF};
@@ -672,7 +672,7 @@ TEST_F(LogStreamFixture, CanLogHex32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int32 in hexdecimal representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogHex32 value{0xFFFFFF};
@@ -690,7 +690,7 @@ TEST_F(LogStreamFixture, CanLogHex64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int64 in hexdecimal representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogHex64 value{0xFFFFFFFF};
@@ -708,7 +708,7 @@ TEST_F(LogStreamFixture, CanLogBin8)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int8 in binary representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogBin8 value{0xFF};
@@ -726,7 +726,7 @@ TEST_F(LogStreamFixture, CanLogBin16)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int16 in binary representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogBin16 value{0xFFFF};
@@ -744,7 +744,7 @@ TEST_F(LogStreamFixture, CanLogBin32)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int32 in binary representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogBin32 value{0xFFFFFF};
@@ -761,7 +761,7 @@ TEST_F(LogStreamFixture, CanLogBin64)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging unsigned int64 in binary representation.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogBin64 value{0xFFFFFFFF};
@@ -778,7 +778,7 @@ TEST_F(LogStreamFixture, CanLogRawBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging LogRawBuffer.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     char s2[]{"1234"};
@@ -797,7 +797,7 @@ TEST_F(LogStreamFixture, WhenTryToLogEmptyRawBufferShallNotLog)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Logging empty LogRawBuffer shall not log.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     const LogRawBuffer value{nullptr, 1};
@@ -815,7 +815,7 @@ TEST_F(LogStreamFixture, CanLogACustomType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the ability of logging custom type (struct).");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ::testing::InSequence in_sequence{};
 
@@ -846,7 +846,7 @@ TEST(LogStreamFlush, WhenFlushingLogStreamAfterLogUint8ShallBeAbleToLogBoolAgain
                    "Verifies teh ability of flushing LogStream used to log unsigned int8 and then use it again to log "
                    "boolean value.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     constexpr auto value_uint8 = std::uint8_t{5};
@@ -881,7 +881,7 @@ TEST(LogStreamFlush, AvoidFormattingCallsWhenSlotIsNotAvailable)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies the inability of logging formatting functions if no slots are reserved.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     constexpr auto value_uint8 = std::uint8_t{5};
@@ -918,7 +918,7 @@ TEST(LogStreamFlush, WhenEmptyAppIdStringProvidedExpectDefaultOneReturned)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "When empty app id is provided the default context id shall be returned.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     // Given a value we want to log
     constexpr auto value_uint8 = std::uint8_t{5};
@@ -985,7 +985,7 @@ TEST_F(LogStreamFixture, UsesFallbackRecorderWithinOtherRecorder)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that the fallback recorder is used, if another recorder also uses logging");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto local_stream_ = Unit();
     // Expecting that we log once via the normal recorder

--- a/score/mw/log/log_types_test.cpp
+++ b/score/mw/log/log_types_test.cpp
@@ -36,7 +36,7 @@ TEST(LogStringTest, ConstructFromCharArray)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the detection of null-/non-null-terminated char array");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // When constructing our LogString type from an empty char[] literal
     const auto empty_log_str = mw::log::LogStr("");
@@ -86,7 +86,7 @@ TEST(LogStringTest, CanImplicitlyConvertFromStringLikeTypes)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating our LogString type view from string-like types");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto kExpected = "MyString";
 
@@ -130,7 +130,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromInteger)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from integer");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t value{15};
     LogRawBuffer log_raw_buffer{MakeLogRawBuffer(value)};
@@ -148,7 +148,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromIntegerStdArray)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from array of integers.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::array<std::int32_t, 2> values{15, 16};
     LogRawBuffer log_raw_buffer{MakeLogRawBuffer(values)};
@@ -166,7 +166,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromSpan)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from score::cpp::span.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t values[]{15, 16};
     const score::cpp::span<const std::int32_t> span{values, 2};
@@ -185,7 +185,7 @@ TEST(MakeLogRawBufferTest, MakeBufferFromVector)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability of creating a buffer from vector of integers");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::vector<std::int32_t> values{15, 16};
     LogRawBuffer log_raw_buffer{MakeLogRawBuffer(values)};

--- a/score/mw/log/logger_container_test.cpp
+++ b/score/mw/log/logger_container_test.cpp
@@ -43,7 +43,7 @@ TEST(LoggerContainerTests, WhenRequestingNonExistingNewLoggerItShallBeInsertedAn
         "Description",
         "Verifies the ability of requesting non-existing new logger shall be inserted and returned to the caller.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     LoggerContainer unit;
     EXPECT_EQ(unit.GetLogger(kContext1).GetContext(), kContext1);
 }
@@ -54,7 +54,7 @@ TEST(LoggerContainerTests, WhenGetingDefaultLoggerShallGetDLFTContextID)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that when getting a default logger it shall get DFLT context id.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     LoggerContainer unit;
     EXPECT_EQ(unit.GetDefaultLogger().GetContext(), kDefaultContext);
 }
@@ -67,7 +67,7 @@ TEST(LoggerContainerTests, WhenRequestingAlreadyExistingLoggerShallBeReturnedWit
         "Description",
         "Verifies that when requesting already existing logger shall be returned without inserting new logger.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     LoggerContainer unit;
     EXPECT_EQ(unit.GetLogger(kContext1).GetContext(), kContext1);
     EXPECT_EQ(unit.GetLogger(kContext1).GetContext(), kContext1);
@@ -81,7 +81,7 @@ TEST(LoggerContainerTests, WhenLoggerContainerIsFullShallGetDefaultContextWhenNe
         "Description",
         "Verifies that when logger container is full shall get default context when new logger is requested.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Expecting a log record of level verbose
     LoggerContainer unit;
     std::vector<std::string> contexts_vector(unit.GetCapacity());
@@ -120,7 +120,7 @@ TEST(LoggerContainerTests, WhenTwoThreadsRequestSameLoggerShallBeOnlyOneExisting
         "Description",
         "Verifies that when two threads request the same logger it shall be only one existing in logger container.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     LoggerContainer unit;
 
     std::thread t1(LoggerRequester1, std::ref(unit));

--- a/score/mw/log/logger_test.cpp
+++ b/score/mw/log/logger_test.cpp
@@ -63,7 +63,7 @@ TEST_F(LoggerFixture, CanLogVerboseWithContext)
     RecordProperty("Description", "Verify the ability of logging verbose message.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level verbose
@@ -79,7 +79,7 @@ TEST_F(LoggerFixture, CanLogDebugWithContext)
     RecordProperty("Description", "Verify the ability of logging debug message.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level debug
@@ -95,7 +95,7 @@ TEST_F(LoggerFixture, CanLogInfoWithContext)
     RecordProperty("Description", "Verify the ability of logging info message.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level info
@@ -111,7 +111,7 @@ TEST_F(LoggerFixture, CanLogWarnWithContext)
     RecordProperty("Description", "Verify the ability of logging warning message.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level warn
@@ -127,7 +127,7 @@ TEST_F(LoggerFixture, CanLogErrorWithContext)
     RecordProperty("Description", "Verify the ability of logging error message.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level error
@@ -143,7 +143,7 @@ TEST_F(LoggerFixture, CanLogFatalWithContext)
     RecordProperty("Description", "Verify the ability of logging fatal message.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level fatal
@@ -159,7 +159,7 @@ TEST_F(LoggerFixture, CheckThatWithLevelSetsCorrectLogLevel)
     RecordProperty("Description", "Verify the ability of logging warn message using WithLevel API.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level warn
@@ -175,7 +175,7 @@ TEST_F(BasicLoggerFixture, CheckThatIsLogEnabledReturnsCorrectValue)
     RecordProperty("Description", "Verify that IsLogEnabled API is returning the correct log level.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::Logger");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given IsLogEnabled is called with the expected context
     EXPECT_CALL(recorder_mock_, IsLogEnabled(LogLevel::kWarn, CONTEXT)).WillOnce(Return(true));
@@ -190,7 +190,7 @@ TEST(CreateLoggerGetContext, CreateLoggerWithNeededContext)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verifies that GetContext shall return the right context.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Logger unit = CreateLogger(CONTEXT);
     EXPECT_EQ(unit.GetContext(), CONTEXT);
 }
@@ -202,7 +202,7 @@ TEST(CreateLoggerGetContext, WhenCreateLoggerWIthEmptyContextShallReturnDefaultL
     RecordProperty("Description",
                    "Verifies that creating a logger with empty context it shall return the default logger.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Logger unit = CreateLogger(std::string_view{});
     EXPECT_EQ(unit.GetContext(), kDefaultContext);
 }
@@ -215,7 +215,7 @@ TEST(CreateLoggerGetContext, CreateLoggerPassingTwoArgs)
                    "Verifies that GetContext shall return the right context when instantiating the CreateLogger with "
                    "two arguments.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Logger unit = CreateLogger(CONTEXT, CONTEXT_DESCRIPTION);
     EXPECT_EQ(unit.GetContext(), CONTEXT);
 }

--- a/score/mw/log/logging_test.cpp
+++ b/score/mw/log/logging_test.cpp
@@ -40,7 +40,7 @@ TEST(Logging, CanSetAndRetrieveDefaultRecorder)
     RecordProperty("Description", "Verify the ability of retrieving the default logger.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SetLogRecorder");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given a Recorder
     RecorderMock recorder_mock{};
@@ -70,7 +70,7 @@ TEST_F(LoggingFixture, CanLogVerboseWithoutContext)
     RecordProperty("Description", "Verify the ability of logging verbose message without context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogVerbose");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Given nothing
@@ -87,7 +87,7 @@ TEST_F(LoggingFixture, CanLogDebugWithoutContext)
     RecordProperty("Description", "Verify the ability of logging debug message without context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogDebug");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level debug
@@ -103,7 +103,7 @@ TEST_F(LoggingFixture, CanLogInfoWithoutContext)
     RecordProperty("Description", "Verify the ability of logging info message without context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogInfo");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level info
@@ -119,7 +119,7 @@ TEST_F(LoggingFixture, CanLogWarnWithoutContext)
     RecordProperty("Description", "Verify the ability of logging warning message without context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogWarn");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level warn
@@ -135,7 +135,7 @@ TEST_F(LoggingFixture, CanLogErrorWithoutContext)
     RecordProperty("Description", "Verify the ability of logging error message without context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogError");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level error
@@ -151,7 +151,7 @@ TEST_F(LoggingFixture, CanLogFatalWithoutContext)
     RecordProperty("Description", "Verify the ability of logging fatal message without context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogFatal");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level fatal
@@ -167,7 +167,7 @@ TEST_F(LoggingFixture, CanLogVerboseWitContext)
     RecordProperty("Description", "Verify the ability of logging verbose message with context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogVerbose");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level verbose
@@ -183,7 +183,7 @@ TEST_F(LoggingFixture, CanLogDebugWithContext)
     RecordProperty("Description", "Verify the ability of logging debug message with context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogDebug");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level debug
@@ -199,7 +199,7 @@ TEST_F(LoggingFixture, CanLogInfoWithContext)
     RecordProperty("Description", "Verify the ability of logging info message with context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogInfo");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level info
@@ -215,7 +215,7 @@ TEST_F(LoggingFixture, CanLogWarnWithContext)
     RecordProperty("Description", "Verify the ability of logging warning message with context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogWarn");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level warn
@@ -231,7 +231,7 @@ TEST_F(LoggingFixture, CanLogErrorWithContext)
     RecordProperty("Description", "Verify the ability of logging error message with context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogError");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level error
@@ -247,7 +247,7 @@ TEST_F(LoggingFixture, CanLogFatalWithContext)
     RecordProperty("Description", "Verify the ability of logging fatal message with context provided.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::LogFatal");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given nothing
     // Expecting a log record of level fatal

--- a/score/mw/log/runtime_test.cpp
+++ b/score/mw/log/runtime_test.cpp
@@ -49,7 +49,7 @@ TEST_F(RuntimeFixture, CanSetALoggingBackend)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability to set backend logging without exception.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given an empty process
 
@@ -64,7 +64,7 @@ TEST_F(RuntimeFixture, CanRetrieveSetRecorder)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability to get the recorder properly.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given the recorder was already set
     Runtime::SetRecorder(&recorder_mock_);
@@ -79,7 +79,7 @@ TEST_F(RuntimeFixture, CanRetrieveFallbackRecorder)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the ability to get a fallback recorder.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given the runtime was initialized
 
@@ -96,7 +96,7 @@ TEST_F(RuntimeFixture, DefaultRecorderShallBeReturned)
     RecordProperty("Description",
                    "Verify the ability of returning the default recorder in case of null recorder is set.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given the unset recorder:
     Runtime::SetRecorder(&recorder_mock_);
@@ -117,7 +117,7 @@ TEST_F(RuntimeFixture, WithLoggerContainerHasFreeCapacityExpectedThatNewLoggerCo
     RecordProperty("Description",
                    "Verify if logger container has capacity will create this logger if it's not available.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::string_view context{"ctx"};
     EXPECT_EQ(context, Runtime::GetLoggerContainer().GetLogger(context).GetContext());
@@ -130,7 +130,7 @@ TEST(RuntimeTest, RuntimeInitializationWithPointer)
                    "This suite only exists to test the second branch of the runtime initialization. Since this is "
                    "static state we need a separate binary for this.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // This suite only exists to test the second branch of the runtime initialization.
     // Since this is static state we need a separate binary for this.

--- a/score/mw/log/runtime_test_instance_fallback.cpp
+++ b/score/mw/log/runtime_test_instance_fallback.cpp
@@ -49,7 +49,7 @@ TEST(RuntimeTest, RuntimeInitializationWithoutPointer)
                    "This suite only exists to test the first branch of the runtime initialization. Since this is "
                    "static state we need a separate binary for this.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Runtime::SetRecorder(nullptr, nullptr);
     // Do not add additional tests here, but in runtime_test.cpp.

--- a/score/mw/log/runtime_test_without_pointer_initialization.cpp
+++ b/score/mw/log/runtime_test_without_pointer_initialization.cpp
@@ -35,7 +35,7 @@ TEST(RuntimeTest, RuntimeInitializationWithoutPointer)
                    "This suite only exists to test the first branch of the runtime initialization. Since this is "
                    "static state we need a separate binary for this.");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Do not add additional tests here, but in runtime_test.cpp.
     auto& recorder = Runtime::GetRecorder();

--- a/score/mw/log/slot_handle_test.cpp
+++ b/score/mw/log/slot_handle_test.cpp
@@ -42,7 +42,7 @@ TEST(SlotHandle, SlotHandleShallDefaultInitializeToZero)
     RecordProperty("Description", "Check the default initialization of SlotHandle instance.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{};
     EXPECT_EQ(handle.GetSelectedRecorder(), SlotHandle::RecorderIdentifier{0});
@@ -56,7 +56,7 @@ TEST(SlotHandle, GetSlotOfSelectedRecorderShallReturnCorrectSlot)
     RecordProperty("Description", "Check Set/Get slot method.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{};
     handle.SetSlot(kSlotValue, kRecorderValue);
@@ -70,7 +70,7 @@ TEST(SlotHandle, GetSlotShallReturnCorrectValue)
     RecordProperty("Description", "Check getting the slot whose Set via constructor.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{kSlotValue};
     EXPECT_EQ(handle.GetSlot(SlotHandle::RecorderIdentifier{0}), kSlotValue);
@@ -83,7 +83,7 @@ TEST(SlotHandle, GetSlotShallReturnZeroOnIncorrectValue)
                    "Check the in-ability of getting the slot in case of invalid recorder identifier value.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{kSlotValue};
     EXPECT_EQ(handle.GetSlot(kInvalidRecorder), 0);
@@ -95,7 +95,7 @@ TEST(SlotHandle, SetSlotShallSetCorrectValue)
     RecordProperty("Description", "Check the ability of seting slot properly.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{kSlotValue};
     handle.SetSlot(kSlotValue, kRecorderValue);
@@ -108,7 +108,7 @@ TEST(SlotHandle, SetSlotShallDiscardInvalidRecorder)
     RecordProperty("Description", "Verify the in-ability of setting invalid recorder identifier value.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{};
     handle.SetSlot(kSlotValue, kInvalidRecorder);
@@ -121,7 +121,7 @@ TEST(SlotHandle, SetSelectedRecorderShallReturnCorrectValue)
     RecordProperty("Description", "Verify the ability of setting selected recorder.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{};
     handle.SetSelectedRecorder(kRecorderValue);
@@ -134,7 +134,7 @@ TEST(SlotHandle, SetSelectedRecorderShallIgnoreInvalidValue)
     RecordProperty("Description", "Verify the ability of SetSelectedRecorder to ignore invalid recorder.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{};
     handle.SetSelectedRecorder(kRecorderValue);
@@ -148,7 +148,7 @@ TEST(SlotHandle, GetSlotAvailableShallReturnTrueOnAssigned)
     RecordProperty("Description", "Verify the ability of checking the availability of specific slot.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{kSlotValue};
     EXPECT_EQ(handle.IsRecorderActive(SlotHandle::RecorderIdentifier{}), true);
@@ -160,7 +160,7 @@ TEST(SlotHandle, GetSlotAvailableShallReturnFalseOnInvalidRecorder)
     RecordProperty("Description", "Verify the ability of checking the availability of specific slot.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle handle{};
     EXPECT_EQ(handle.IsRecorderActive(kInvalidRecorder), false);
@@ -172,7 +172,7 @@ TEST(SlotHandle, ShallBeEqualIffSelectedRecorderAndSlotsAreEqual)
     RecordProperty("Description", "Check the equality of SlotHandle instances.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle rhs{};
     SlotHandle lhs{};
@@ -194,7 +194,7 @@ TEST(SlotHandle, ShallBeUnequalIfSelectedRecorderUnequal)
     RecordProperty("Description", "Check the inequality of SlotHandle instances.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle rhs{};
     SlotHandle lhs{};
@@ -210,7 +210,7 @@ TEST(SlotHandle, ShallBeUnequalIfAnySlotUnequal)
     RecordProperty("Description", "Check the inequality of SlotHandle instances.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle rhs{};
     SlotHandle lhs{};
@@ -226,7 +226,7 @@ TEST(SlotHandle, ShallBeUnequalIfAnySlotUnequalAssigned)
     RecordProperty("Description", "Check the inequality of SlotHandle instances.");
     RecordProperty("TestType", "Interface test");
     RecordProperty("Verifies", "::score::mw::log::SlotHandle");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SlotHandle rhs{};
     SlotHandle lhs{};

--- a/score/network/sock_async/sock_async_test.cpp
+++ b/score/network/sock_async/sock_async_test.cpp
@@ -99,7 +99,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZero)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
         .Times(Exactly(1))
@@ -154,7 +154,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroRaw)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful on RAW socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
         .Times(Exactly(1))
@@ -209,7 +209,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroTCP)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful on TCP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
         .Times(Exactly(1))
@@ -264,7 +264,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroDefaultSocket)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read operation is successful on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmsg(_, _, _))
         .Times(Exactly(1))
@@ -320,7 +320,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroMMsg)
     RecordProperty("Description",
                    "Verifies that async read of multiple messages operation is successful on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmmsg(_, _, _, _, _))
         .Times(Exactly(1))
@@ -381,7 +381,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroMMsgWithEndPoint)
                    "Verifies that async read of multiple messages operation is successful on UDP socket type "
                    "when endpoint is provided");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sock_mock_, recvmmsg(_, _, _, _, _))
         .Times(Exactly(1))
@@ -444,7 +444,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataEqualZero)
                    "Verifies that async read of multiple messages operation is successful on UDP socket type "
                    "empty data is provided ");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -479,7 +479,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroReadFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read will fail on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([this](struct pollfd* in_pollfd, nfds_t, int) {
         switch (this->cnt)
@@ -534,7 +534,7 @@ TEST_F(SocketAsyncTest, ReadAsyncWithDataGreaterThanZeroWithEndpoint)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async read will succeed on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([this](struct pollfd* in_pollfd, nfds_t, int) {
         switch (this->cnt)
@@ -591,7 +591,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytes)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -633,7 +633,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesRaw)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on RAW socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -675,7 +675,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesTCP)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on TCP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -717,7 +717,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesWithEndPoint)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will succeed on UDP socket type with endpoint");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -761,7 +761,7 @@ TEST_F(SocketAsyncTest, WriteAsyncWithDataGreaterThanZeroWriteFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write will fail on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -803,7 +803,7 @@ TEST_F(SocketAsyncTest, WriteAsyncBytesNoData)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that async write with empty data on UDP socket type");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(SOCKET_ID));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;

--- a/score/network/sock_async_raw/socket_raw_test.cpp
+++ b/score/network/sock_async_raw/socket_raw_test.cpp
@@ -67,7 +67,7 @@ TEST_F(SocketRAWTest, CreationSuccess)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of RAW async socket is successful");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     factory = new SocketFactory();
     std::shared_ptr<SocketAsync> socket_raw = factory->CreateSocket(SockType::RAW, Endpoint{}, 1);
@@ -81,7 +81,7 @@ TEST_F(SocketRAWTest, CreationFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of RAW async socket fails");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _))
         .Times(Exactly(1))
         .WillOnce(Return(score::cpp::make_unexpected(Error::createFromErrno(93))));
@@ -98,7 +98,7 @@ TEST_F(SocketRAWTest, ConnectFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that connection on RAW async socket fails");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     factory = new SocketFactory();
     std::shared_ptr<SocketAsync> socket_async = factory->CreateSocket(SockType::RAW, Endpoint{});

--- a/score/network/sock_async_tcp/socket_tcp_test.cpp
+++ b/score/network/sock_async_tcp/socket_tcp_test.cpp
@@ -79,7 +79,7 @@ TEST_F(SocketTCPTest, ConnectSuccess)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that connection on TCP async socket is successful");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -110,7 +110,7 @@ TEST_F(SocketTCPTest, CreationSuccess)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of TCP async socket is successful");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -129,7 +129,7 @@ TEST_F(SocketTCPTest, CreationFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of TCP async socket fails");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _))
         .Times(Exactly(1))
         .WillOnce(Return(score::cpp::make_unexpected(Error::createFromErrno(0))));

--- a/score/network/sock_async_udp/socket_udp_test.cpp
+++ b/score/network/sock_async_udp/socket_udp_test.cpp
@@ -73,7 +73,7 @@ TEST_F(SocketUDPTest, CreationSuccess)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of UDP async socket is successful");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;
@@ -92,7 +92,7 @@ TEST_F(SocketUDPTest, CreationFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that creation of UDP async socket fails");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _))
         .Times(Exactly(1))
         .WillOnce(Return(score::cpp::make_unexpected(Error::createFromErrno(0))));
@@ -113,7 +113,7 @@ TEST_F(SocketUDPTest, ConnectFailed)
     RecordProperty("Priority", "3");
     RecordProperty("Description", "Verifies that connection on UDP async socket fails");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_CALL(sock_mock_, socket(_, _, _)).Times(Exactly(1)).WillOnce(Return(kSocketFD));
     EXPECT_CALL(sysPollMock, poll(_, _, _)).WillRepeatedly([](struct pollfd* in_pollfd, nfds_t, int) {
         in_pollfd[0].revents = POLLIN;

--- a/score/os/test/ObjectSeam_test.cpp
+++ b/score/os/test/ObjectSeam_test.cpp
@@ -49,7 +49,7 @@ TEST(ObjectSeamTest, CopyConstructor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ObjectSeamTest Copy Constructor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MockObject mock("Testing Copy");
     TestableBase<MockObject> b1;
@@ -66,7 +66,7 @@ TEST(ObjectSeamTest, MoveConstructor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ObjectSeamTest Move Constructor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MockObject mock("Testing Move");
     TestableBase<MockObject> b1;

--- a/score/os/test/acl_test.cpp
+++ b/score/os/test/acl_test.cpp
@@ -60,7 +60,7 @@ TEST_F(AclTestFixture, CanAddGroupEntries)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer adding group entries");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kGroup).has_value());
 
@@ -120,7 +120,7 @@ TEST_F(AclTestFixture, SettingTagTokOwningGroup)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer adding tags to onwing group");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kOwningGroup).has_value());
     ASSERT_EQ(unit_.acl_get_tag_type(entry_).value(), ::score::os::Acl::Tag::kOwningGroup);
@@ -133,7 +133,7 @@ TEST_F(AclTestFixture, SettingTagTokMaximumAllowedPermissions)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer setting of maximum permission");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kMaximumAllowedPermissions).has_value());
     ASSERT_EQ(unit_.acl_get_tag_type(entry_).value(), ::score::os::Acl::Tag::kMaximumAllowedPermissions);
@@ -146,7 +146,7 @@ TEST_F(AclTestFixture, SettingTagTokOther)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer set tag type to kOther");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kOther).has_value());
     ASSERT_EQ(unit_.acl_get_tag_type(entry_).value(), ::score::os::Acl::Tag::kOther);
@@ -159,7 +159,7 @@ TEST_F(AclTestFixture, SettingTagTokOwningUser)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer set tag to kOwningUser");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kOwningUser).has_value());
     ASSERT_EQ(unit_.acl_get_tag_type(entry_).value(), ::score::os::Acl::Tag::kOwningUser);
@@ -172,7 +172,7 @@ TEST_F(AclTestFixture, GettingTagaclgroup)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall offer set tag to kGroup");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kGroup).has_value());
     ASSERT_EQ(unit_.acl_get_tag_type(entry_).value(), ::score::os::Acl::Tag::kGroup);
@@ -185,7 +185,7 @@ TEST_F(AclTestFixture, GetQualifierReturnErrorIfPassInvalidEntry)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error to get qualifier with default value");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto val = unit_.acl_get_qualifier(entry_);
     EXPECT_FALSE(val.has_value());
@@ -199,7 +199,7 @@ TEST_F(AclTestFixture, SetQualifierReturnErrorIfPassInvalidQualifier)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid qualifier");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto val = unit_.acl_set_qualifier(entry_, nullptr);
     EXPECT_FALSE(val.has_value());
@@ -213,7 +213,7 @@ TEST_F(AclTestFixture, AclValidToReturnErrorIfPassInvalidAcl)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid ACL");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto val = unit_.acl_valid(acl_);
     EXPECT_FALSE(val.has_value());
@@ -226,7 +226,7 @@ TEST_F(AclTestFixture, AclToTextToReturnOkIfPassValidAcl)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid ACL");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto* result = ::acl_get_file(file_name, ACL_TYPE_ACCESS);
     ssize_t len{0};
@@ -243,7 +243,7 @@ TEST_F(AclTestFixture, AclToTextToReturnErrorIfPassInvalidAcl)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid ACL");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto* result = ::acl_get_file("", ACL_TYPE_ACCESS);
     ssize_t len{0};
@@ -260,7 +260,7 @@ TEST_F(AclTestFixture, AclSetFdToReturnErrorIfPassInvalidParam)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid param");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto val = unit_.acl_set_fd(file_descriptor_, acl_);
     EXPECT_FALSE(val.has_value());
@@ -274,7 +274,7 @@ TEST_F(AclTestFixture, AclGetEntryToReturnErrorIfPassInvalidIndex)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if pass invalid index");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
 #if defined(__QNX__)
     score::os::Acl::EntryIndex invalid_index = -1;
@@ -291,7 +291,7 @@ TEST_F(AclTestFixture, AclGetPermissionTest)
     RecordProperty("Description",
                    "ACL shall true when the permission is present in the permissions set; false otherwise.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     ASSERT_TRUE(unit_.acl_set_tag_type(entry_, ::score::os::Acl::Tag::kGroup).has_value());
 
@@ -323,7 +323,7 @@ TEST_F(AclTestFixture, AclGetFilePositiveTest)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return correct acl for given filename if the file exists.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto acl_result = unit_.acl_get_file(file_name);
     ASSERT_TRUE(acl_result.has_value());
@@ -337,7 +337,7 @@ TEST_F(AclTestFixture, AclGetFileNegativeTest)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "ACL shall return error if provided path is empty.");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const std::string filepath{""};
     const auto acl_result = unit_.acl_get_file(filepath);

--- a/score/os/test/dirent_test.cpp
+++ b/score/os/test/dirent_test.cpp
@@ -45,7 +45,7 @@ TEST_F(DirentTest, ScanPositiveTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Scan shall return success for scan dir");
 
@@ -65,7 +65,7 @@ TEST_F(DirentTest, ScanNegativeTest)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Scan shall return error for invalid path");
 
@@ -79,7 +79,7 @@ TEST_F(DirentTest, OpenDirSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Open dir shall return success for valid dir");
 
@@ -95,7 +95,7 @@ TEST_F(DirentTest, OpenDirFailure)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Open dir shall return error for invalid dir");
 
@@ -108,7 +108,7 @@ TEST_F(DirentTest, ReadDirSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Read dir shall return success for valid dir");
 
@@ -142,7 +142,7 @@ TEST_F(DirentTest, ReadDirEnd)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Read dir shall return success for valid dir");
 
@@ -164,7 +164,7 @@ TEST_F(DirentTest, CloseDirSuccess)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Close dir shall return success for valid dir");
 
@@ -180,7 +180,7 @@ TEST(Dirent, get_instance)
     RecordProperty("Verifies", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description", "Dirent shall provide instance functionality");
 

--- a/score/os/test/errno_test.cpp
+++ b/score/os/test/errno_test.cpp
@@ -51,7 +51,7 @@ TEST_F(OsErrorViaLogStreamFixture, CanStreamViaRValueStream)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OsErrorViaLogStreamFixture Can Stream Via RValue Stream");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given a constructed error
     const Error error{Error::createFromErrno(EPERM)};
@@ -71,7 +71,7 @@ TEST_F(OsErrorViaLogStreamFixture, StreamIntoMwLogStream2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OsErrorViaLogStreamFixture Stream Into Mw Log Stream2");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given a constructed error
     const Error error{Error::createFromErrno(EPERM)};
@@ -92,7 +92,7 @@ TEST(Error, CreationFromErrno)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Creation From Errno");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Error error{Error::createFromErrno(EPERM)};
     EXPECT_EQ(error, Error::Code::kOperationNotPermitted);
@@ -104,7 +104,7 @@ TEST(Error, EqualityCompare)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Equality Compare");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
     const auto error2{Error::createFromErrno(EPERM)};
@@ -117,7 +117,7 @@ TEST(Error, InequalityCompare)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Inequality Compare");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
     const auto error3{Error::createFromErrno(EOVERFLOW)};
@@ -130,7 +130,7 @@ TEST(Error, InequalityCompareToErrorCode)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Inequality Compare To Error Code");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
     EXPECT_NE(error1, Error::Code::kNotEnoughSpace);
@@ -142,7 +142,7 @@ TEST(Error, CreateUnspecifiedError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create Unspecified Error");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createUnspecifiedError()};
     EXPECT_EQ(error1, Error::Code::kUnexpected);
@@ -154,7 +154,7 @@ TEST(Error, StreamingOut)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Streaming Out");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::stringstream ss;
     ss << Error::createFromErrno(EPERM);
@@ -167,7 +167,7 @@ TEST(Error, SetErrno)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Set Errno");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     seterrno(EPERM);
     EXPECT_EQ(geterrno(), EPERM);
@@ -179,7 +179,7 @@ TEST(Error, ToString)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error To String");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
     EXPECT_EQ(error1.ToString(), "An OS error has occurred with error code: Operation not permitted");
@@ -191,7 +191,7 @@ TEST(Error, GetOsDependentErrorCode)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Get Os Dependent Error Code");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromErrno(EPERM)};
     EXPECT_EQ(error1.GetOsDependentErrorCode(), EPERM);
@@ -203,7 +203,7 @@ TEST(Error, CreateFromGlobErrorNoSpace)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create From Glob Error No Space");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromGlobError(GLOB_NOSPACE)};
     EXPECT_EQ(error1, Error::Code::kGlobNoSpace);
@@ -215,7 +215,7 @@ TEST(Error, CreateFromGlobErrorNotImplemented)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create From Glob Error Not Implemented");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromGlobError(GLOB_NOSYS)};
     EXPECT_EQ(error1, Error::Code::kUnexpected);
@@ -227,7 +227,7 @@ TEST(Error, CreateFromErrnoFlockSpecificOperationNotSupported)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Create From Errno Flock Specific Operation Not Supported");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto error1{Error::createFromErrnoFlockSpecific(EOPNOTSUPP)};
     EXPECT_EQ(error1, Error::Code::kFdRefersToAnObject);
@@ -239,7 +239,7 @@ TEST(Error, ErrorCodeConversion)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Error Error Code Conversion");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::map<const std::int32_t, const Error::Code> error_code_map = {
         {EPERM, Error::Code::kOperationNotPermitted},

--- a/score/os/test/fcntl_impl_test.cpp
+++ b/score/os/test/fcntl_impl_test.cpp
@@ -75,7 +75,7 @@ TEST_F(FcntlImplTest, KFileSetStatusFlagsFailsWithWrongCommand)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest KFile Set Status Flags Fails With Wrong Command");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto command{Fcntl::Command::kFileGetStatusFlags};
     const Fcntl::Open open_flags{};
@@ -90,7 +90,7 @@ TEST_F(FcntlImplTest, CommandKFileSetStatusFlagsSetsFlags)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Set Status Flags Sets Flags");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const Fcntl::Command command{Fcntl::Command::kFileSetStatusFlags};
     const auto open_flags{Fcntl::Open::kNonBlocking};
@@ -108,7 +108,7 @@ TEST_F(FcntlImplTest, CommandKFileSetStatusFlagsFailsWithInvalidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Set Status Flags Fails With Invalid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::close(file_descriptor_);
 
@@ -125,7 +125,7 @@ TEST_F(FcntlImplTest, KFileGetStatusFlagsFailsWithWrongCommand)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest KFile Get Status Flags Fails With Wrong Command");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto command{Fcntl::Command::kFileSetStatusFlags};
     const auto fcntl_result = score::os::Fcntl::instance().fcntl(file_descriptor_, command);
@@ -139,7 +139,7 @@ TEST_F(FcntlImplTest, CommandKFileSetStatusFlagsGetsFlags)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Set Status Flags Gets Flags");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto command{Fcntl::Command::kFileGetStatusFlags};
     const auto fcntl_result = score::os::Fcntl::instance().fcntl(file_descriptor_, command);
@@ -156,7 +156,7 @@ TEST_F(FcntlImplTest, CommandKFileGetStatusFlagsFailsWithInvalidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Command KFile Get Status Flags Fails With Invalid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::close(file_descriptor_);
 
@@ -172,7 +172,7 @@ TEST_F(FcntlImplTest, OpenSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open Succeeds");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly};
     const auto result = score::os::Fcntl::instance().open(filename_, open_flags);
@@ -188,7 +188,7 @@ TEST_F(FcntlImplTest, OpenFailsWithInvalidPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open Fails With Invalid Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly};
     const auto invalid_filename{"invalid"};
@@ -203,7 +203,7 @@ TEST_F(FcntlImplTest, OpenWithModeSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open With Mode Succeeds");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly | Fcntl::Open::kCreate | Fcntl::Open::kExclusive};
     const auto status_flags{Stat::Mode::kReadUser | Stat::Mode::kWriteUser};
@@ -222,7 +222,7 @@ TEST_F(FcntlImplTest, OpenWithModeFailsWithInvalidPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Open With Mode Fails With Invalid Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto open_flags{Fcntl::Open::kReadOnly | Fcntl::Open::kCreate | Fcntl::Open::kExclusive};
     const auto status_flags{Stat::Mode::kReadUser | Stat::Mode::kWriteUser};
@@ -237,7 +237,7 @@ TEST_F(FcntlImplTest, PosixFallocateSucceedsWithValidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Posix Fallocate Succeeds With Valid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const off_t offset{0};
     const off_t length{200};
@@ -254,7 +254,7 @@ TEST_F(FcntlImplTest, PosixFallocateFailsWithInvalidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Posix Fallocate Fails With Invalid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::close(file_descriptor_);
     const off_t offset{0};
@@ -270,7 +270,7 @@ TEST_F(FcntlImplTest, FlockFailsWithInvalidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails With Invalid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::close(file_descriptor_);
     const auto result = score::os::Fcntl::instance().flock(file_descriptor_, Fcntl::Operation::kLockShared);
@@ -284,7 +284,7 @@ TEST_F(FcntlImplTest, FlockFailsWithKUnLock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails With KUn Lock");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::close(file_descriptor_);
     const auto result = score::os::Fcntl::instance().flock(file_descriptor_, Fcntl::Operation::kUnLock);
@@ -298,7 +298,7 @@ TEST_F(FcntlImplTest, FlockSucceedsWithValidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Succeeds With Valid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = score::os::Fcntl::instance().flock(file_descriptor_, Fcntl::Operation::kLockShared);
     ASSERT_TRUE(result.has_value());
@@ -311,7 +311,7 @@ TEST_F(FcntlImplTest, FlockSucceedsWithValidFileDescriptorAndWithExclusiveUnLock
     RecordProperty("Description",
                    "FcntlImplTest Flock Succeeds With Valid File Descriptor And With Exclusive Un Lock Combination");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = score::os::Fcntl::instance().flock(file_descriptor_,
                                                          Fcntl::Operation::kLockExclusive | Fcntl::Operation::kLockNB);
@@ -324,7 +324,7 @@ TEST_F(FcntlImplTest, FlockFailsWhenTryToObtainExclusiveLockTwice)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails When Try To Obtain Exclusive Lock Twice");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto ret = fork();
     ASSERT_NE(ret, -1) << "Fork failed";
@@ -362,7 +362,7 @@ TEST_F(FcntlImplTest, FlockFailsWhenTryToObtainExclusiveLockAndSharedLock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Fails When Try To Obtain Exclusive Lock And Shared Lock");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto ret = fork();
     ASSERT_NE(ret, -1) << "Fork failed";
@@ -400,7 +400,7 @@ TEST_F(FcntlImplTest, FlockSucceedsWhenTryToObtainSharedLockTwice)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FcntlImplTest Flock Succeeds When Try To Obtain Shared Lock Twice");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto ret = fork();
     ASSERT_NE(ret, -1) << "Fork failed";

--- a/score/os/test/fcntl_test.cpp
+++ b/score/os/test/fcntl_test.cpp
@@ -33,7 +33,7 @@ TEST(CommandToInteger, kFileGetStatusFlags)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CommandToInteger k File Get Status Flags");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::CommandToInteger(Fcntl::Command::kFileGetStatusFlags);
     ASSERT_TRUE(result.has_value());
@@ -46,7 +46,7 @@ TEST(CommandToInteger, kFileSetStatusFlags)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CommandToInteger k File Set Status Flags");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::CommandToInteger(Fcntl::Command::kFileSetStatusFlags);
     ASSERT_TRUE(result.has_value());
@@ -59,7 +59,7 @@ TEST(CommandToInteger, kInvalid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "CommandToInteger k Invalid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::CommandToInteger(Fcntl::Command::kInvalid);
     ASSERT_FALSE(result.has_value());
@@ -72,7 +72,7 @@ TEST(IntegerToOpenFlag, Translate_O_RDONLY)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_RDONLY");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_RDONLY);
     EXPECT_EQ(result, Fcntl::Open::kReadOnly);
@@ -84,7 +84,7 @@ TEST(IntegerToOpenFlag, Translate_O_WRONLY)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_WRONLY");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_WRONLY);
     EXPECT_EQ(result, Fcntl::Open::kWriteOnly);
@@ -96,7 +96,7 @@ TEST(IntegerToOpenFlag, Translate_O_RDWR)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_RDWR");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_RDWR);
     EXPECT_EQ(result, Fcntl::Open::kReadWrite);
@@ -108,7 +108,7 @@ TEST(IntegerToOpenFlag, Translate_O_CREAT)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_CREAT");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_CREAT);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -121,7 +121,7 @@ TEST(IntegerToOpenFlag, Translate_O_CLOEXEC)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_CLOEXEC");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_CLOEXEC);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -134,7 +134,7 @@ TEST(IntegerToOpenFlag, Translate_O_NONBLOCK)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_NONBLOCK");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_NONBLOCK);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -147,7 +147,7 @@ TEST(IntegerToOpenFlag, Translate_O_EXCL)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_EXCL");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_EXCL);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -160,7 +160,7 @@ TEST(IntegerToOpenFlag, Translate_O_TRUNC)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_TRUNC");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_TRUNC);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -173,7 +173,7 @@ TEST(IntegerToOpenFlag, Translate_O_DIRECTORY)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_DIRECTORY");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_DIRECTORY);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -194,7 +194,7 @@ TEST(IntegerToOpenFlag, Translate_O_SYNC)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate_O_SYNC");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_SYNC);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -208,7 +208,7 @@ TEST(IntegerToOpenFlag, TranslateMultiple)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "IntegerToOpenFlag Translate Multiple");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::IntegerToOpenFlag(O_RDWR | O_CREAT);
     // Open flags have always an access mode. If none is explicitly set it is readonly
@@ -221,7 +221,7 @@ TEST(OpenFlagToInteger, TranslateKReadOnly)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KRead Only");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kReadOnly);
     EXPECT_EQ(result, O_RDONLY);
@@ -233,7 +233,7 @@ TEST(OpenFlagToInteger, TranslateKWriteOnly)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KWrite Only");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kWriteOnly);
     EXPECT_EQ(result, O_WRONLY);
@@ -245,7 +245,7 @@ TEST(OpenFlagToInteger, TranslateKReadWrite)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KRead Write");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kReadWrite);
     EXPECT_EQ(result, O_RDWR);
@@ -257,7 +257,7 @@ TEST(OpenFlagToInteger, TranslateKCreate)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KCreate");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kCreate);
     EXPECT_EQ(result, O_CREAT);
@@ -269,7 +269,7 @@ TEST(OpenFlagToInteger, TranslateKCloseOnExec)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KClose On Exec");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kCloseOnExec);
     EXPECT_EQ(result, O_CLOEXEC);
@@ -281,7 +281,7 @@ TEST(OpenFlagToInteger, TranslateKNonBlocking)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KNon Blocking");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kNonBlocking);
     EXPECT_EQ(result, O_NONBLOCK);
@@ -293,7 +293,7 @@ TEST(OpenFlagToInteger, TranslateKExclusive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KExclusive");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kExclusive);
     EXPECT_EQ(result, O_EXCL);
@@ -305,7 +305,7 @@ TEST(OpenFlagToInteger, TranslateKTruncate)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KTruncate");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kTruncate);
     EXPECT_EQ(result, O_TRUNC);
@@ -317,7 +317,7 @@ TEST(OpenFlagToInteger, TranslateKDirectory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KDirectory");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kDirectory);
     EXPECT_EQ(result, O_DIRECTORY);
@@ -336,7 +336,7 @@ TEST(OpenFlagToInteger, TranslateKSynchronized)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "OpenFlagToInteger Translate KSynchronized");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = internal::fcntl_helper::OpenFlagToInteger(Fcntl::Open::kSynchronized);
     EXPECT_EQ(result, O_SYNC);
@@ -349,7 +349,7 @@ TEST(fcntl, DefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "fcntl Default Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto default_instance = score::os::Fcntl::Default();
     ASSERT_TRUE(default_instance != nullptr);
@@ -362,7 +362,7 @@ TEST(fcntl, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "fcntl PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Fcntl::Default(memory_resource);
@@ -376,7 +376,7 @@ TEST(fcntl, CanGetInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "fcntl Can Get Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_NO_FATAL_FAILURE(Fcntl::instance());
 }

--- a/score/os/test/ftw_test.cpp
+++ b/score/os/test/ftw_test.cpp
@@ -40,7 +40,7 @@ TEST_F(FtwMockTest, ftw)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FtwMockTest ftw");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(ftwmock, ftw);
     ftwmock.ftw("/invalid_path", nullptr, 0);
@@ -59,7 +59,7 @@ TEST(FtwTest, ftw_walk)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FtwTest ftw_walk");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::unique_ptr<score::os::Ftw> ftw_object = std::make_unique<score::os::FtwPosix>();
     constexpr auto dir_path = "/tmp/ftw_dir";
@@ -74,7 +74,7 @@ TEST(FtwTest, ftw_fail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FtwTest ftw_fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::unique_ptr<score::os::Ftw> ftw_object = std::make_unique<score::os::FtwPosix>();
     constexpr auto dir_path = "/tmp/ftw_invalid_dir";

--- a/score/os/test/getopt_test.cpp
+++ b/score/os/test/getopt_test.cpp
@@ -27,7 +27,7 @@ TEST(GetOptTest, GetoptTestSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getopt Test Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     optind = 1;
     char program_name[] = "GetoptSuccess";
@@ -52,7 +52,7 @@ TEST(GetOptTest, GetOptLong)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Get Opt Long");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     optind = 1;
     char program_name[] = "GetOptLong";
@@ -96,7 +96,7 @@ TEST(GetOptTest, GetoptTestFailureUnknownOption)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getopt Test Failure Unknown Option");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     optind = 1;
     char program_name[] = "GetoptSuccess";
@@ -118,7 +118,7 @@ TEST(GetOptTest, GetoptindTest)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getoptind Test");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     optind = 4;
     EXPECT_EQ(score::os::Getopt::instance().getoptind(), 4);
@@ -130,7 +130,7 @@ TEST(GetOptTest, GetopterrTest)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getopterr Test");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     opterr = 5;
     EXPECT_EQ(score::os::Getopt::instance().getopterr(), 5);
@@ -142,7 +142,7 @@ TEST(GetOptTest, GetoptoptTest)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetOptTest Getoptopt Test");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     optopt = 3;
     EXPECT_EQ(score::os::Getopt::instance().getoptopt(), 3);

--- a/score/os/test/glob_impl_test.cpp
+++ b/score/os/test/glob_impl_test.cpp
@@ -77,7 +77,7 @@ TEST_F(GlobImplTest, MatchExistingFiles)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match Existing Files");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = glob_instance_->Match("testfile*.txt", Glob::Flag::kNoSort);
     ASSERT_TRUE(result.has_value());
@@ -93,7 +93,7 @@ TEST_F(GlobImplTest, MatchTerminatesOnErrorWithGlobErrFlag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match Terminates On Error With Glob Err Flag");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = glob_instance_->Match("restricted_dir/*", Glob::Flag::kErr);
     ASSERT_FALSE(result.has_value());
@@ -106,7 +106,7 @@ TEST_F(GlobImplTest, MatchCombiningAppendAndSortFlags)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match Combining Append And Sort Flags");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto first_result = glob_instance_->Match("*.txt", Glob::Flag::kNoSort);
     ASSERT_TRUE(first_result.has_value());
@@ -127,7 +127,7 @@ TEST_F(GlobImplTest, MatchNoMatchFound)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Match No Match Found");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = glob_instance_->Match("nonexistentfilepattern.*", Glob::Flag::kNoSort);
     ASSERT_FALSE(result.has_value());
@@ -140,7 +140,7 @@ TEST_F(GlobImplTest, MoveAssignmentFreesCurrentData)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Move Assignment Frees Current Data");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GlobImpl glob1{};
     GlobImpl glob2{};
@@ -178,7 +178,7 @@ TEST_F(GlobImplTest, MoveAssignmentToNewInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Move Assignment To New Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GlobImpl glob1{};
     GlobImpl glob2{};
@@ -211,7 +211,7 @@ TEST_F(GlobImplTest, MoveConstructor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Move Constructor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GlobImpl glob1{};
 
@@ -251,7 +251,7 @@ TEST_F(GlobImplTest, DefaultWithMemoryResource)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GlobImplTest Default With Memory Resource");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto glob = Glob::Default(score::cpp::pmr::get_default_resource());
 

--- a/score/os/test/glob_test.cpp
+++ b/score/os/test/glob_test.cpp
@@ -35,7 +35,7 @@ TEST_P(FlagToIntegerTests, ConvertFlag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FlagToIntegerTests Convert Flag");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto flag = std::get<0>(GetParam());
     auto expected = std::get<1>(GetParam());
@@ -77,7 +77,7 @@ TEST(FlagToIntegerTests, MultipleFlagsConversion)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FlagToIntegerTests Multiple Flags Conversion");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto combinedFlags = Glob::Flag::kAppend | Glob::Flag::kNoCheck | Glob::Flag::kPeriod;
     Glob::FlagType expected = GLOB_APPEND | GLOB_NOCHECK | GLOB_PERIOD;

--- a/score/os/test/grp_test.cpp
+++ b/score/os/test/grp_test.cpp
@@ -27,7 +27,7 @@ TEST(GetGrNam, ReturnsCorrectBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Returns Correct Buffer");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto group_name{"root"};
     const auto result = Grp::instance().getgrnam(group_name);
@@ -42,7 +42,7 @@ TEST(GetGrNam, SecondCallDoesNotOverwriteBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Second Call Does Not Overwrite Buffer");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto group_name_root{"root"};
     const auto result_root = Grp::instance().getgrnam(group_name_root);
@@ -75,7 +75,7 @@ TEST(GetGrNam, ReturnsErrorWhenGroupUnknown)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Returns Error When Group Unknown");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto group_name{"invalid"};
     const auto result = Grp::instance().getgrnam(group_name);
@@ -89,7 +89,7 @@ TEST(GetGrNam, ReturnsErrorWhenGroupNameSizeBiggerThanSupported)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "GetGrNam Returns Error When Group Name Size Bigger Than Supported");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto group_name{"VeryVeryVeryVeryGroup"};
     const auto result = Grp::instance().getgrnam(group_name);

--- a/score/os/test/inotify_test.cpp
+++ b/score/os/test/inotify_test.cpp
@@ -52,7 +52,7 @@ TEST_F(InotifyTest, AddWatchSuccessfull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Successfull");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto wd = score::os::Inotify::instance().inotify_add_watch(
         fd.value(), temp_dir_.c_str(), score::os::Inotify::EventMask::kAccess);
@@ -65,7 +65,7 @@ TEST_F(InotifyTest, AddWatchFailsIfDirectoryDoesNotExist)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Fails If Directory Does Not Exist");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto wd =
         score::os::Inotify::instance().inotify_add_watch(fd.value(), "/blah", score::os::Inotify::EventMask::kInCreate);
@@ -79,7 +79,7 @@ TEST_F(InotifyTest, AddWatchFailsWithoutInit)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Fails Without Init");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto wd =
         score::os::Inotify::instance().inotify_add_watch(0, temp_dir_.c_str(), score::os::Inotify::EventMask::kInCreate);
@@ -93,7 +93,7 @@ TEST_F(InotifyTest, AddWatchFailsWithEBADF)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Add Watch Fails With EBADF");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto wd =
         score::os::Inotify::instance().inotify_add_watch(-1, temp_dir_.c_str(), score::os::Inotify::EventMask::kInCreate);
@@ -107,7 +107,7 @@ TEST_F(InotifyTest, RemoveWatchSuccessfull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Successfull");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto wd = score::os::Inotify::instance().inotify_add_watch(
         fd.value(), temp_dir_.c_str(), score::os::Inotify::EventMask::kInMovedTo);
@@ -122,7 +122,7 @@ TEST_F(InotifyTest, RemoveWatchFailsWithoutInit)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Fails Without Init");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto ret = score::os::Inotify::instance().inotify_rm_watch(1, 1);
     ASSERT_FALSE(ret.has_value());
@@ -135,7 +135,7 @@ TEST_F(InotifyTest, RemoveWatchFailsWithEBADF)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Fails With EBADF");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto ret = score::os::Inotify::instance().inotify_rm_watch(-1, 0);
     ASSERT_FALSE(ret.has_value());
@@ -148,7 +148,7 @@ TEST_F(InotifyTest, RemoveWatchFailsWithInvalidArguments)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InotifyTest Remove Watch Fails With Invalid Arguments");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto ret = score::os::Inotify::instance().inotify_rm_watch(0, 0);
     ASSERT_FALSE(ret.has_value());

--- a/score/os/test/ioctl_test.cpp
+++ b/score/os/test/ioctl_test.cpp
@@ -33,7 +33,7 @@ TEST(IoctlTest, ReadNumberOfCharactorsWaitingToBeRead)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto sockfd = socket(AF_INET, SOCK_STREAM, 0);
     ASSERT_NE(sockfd, -1) << "Error creating socket: " << errno;
@@ -54,7 +54,7 @@ TEST(IoctlTest, InvalidFd)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl for invalid file descriptor");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     const auto invalid_fd = -1;
     std::int32_t number_of_char{};
@@ -78,7 +78,7 @@ TEST_F(IoctlMockTest, NoAdditionalArgument)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_CALL(ioctlmock, ioctl(1, 2, An<void*>()));
     score::os::Ioctl::instance().ioctl(1, 2, nullptr);
@@ -90,7 +90,7 @@ TEST_F(IoctlMockTest, Integer)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     auto value{0};
     EXPECT_CALL(ioctlmock, ioctl(1, 2, &value));
@@ -103,7 +103,7 @@ TEST_F(IoctlMockTest, Pointer)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "The operating system shall support ioctl");
     RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_CALL(ioctlmock, ioctl(1, 2, An<void*>()))
         .WillOnce(DoAll(Invoke([](std::int32_t, std::int32_t, void* arg) {

--- a/score/os/test/libgen_test.cpp
+++ b/score/os/test/libgen_test.cpp
@@ -22,7 +22,7 @@ TEST(LibgenImplTest, GetBaseName)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LibgenImplTest Get Base Name");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char input1[] = "usr";
     EXPECT_STREQ(score::os::Libgen::instance().base_name(input1), "usr");
@@ -40,7 +40,7 @@ TEST(LibgenImplTest, GetDirName)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LibgenImplTest Get Dir Name");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char input1[] = "/foo/bar";
     EXPECT_STREQ(score::os::Libgen::instance().dirname(input1), "/foo");
@@ -63,7 +63,7 @@ TEST(LibgenTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "LibgenTest PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Libgen::Default(memory_resource);

--- a/score/os/test/memory_allocator_test.cpp
+++ b/score/os/test/memory_allocator_test.cpp
@@ -29,7 +29,7 @@ TEST(SafeMemoryAllocatorTest, MallocFail)
     // ThreadSanitizer (TSAN) is expected to fail in this scenario because its allocator terminates
     // the program on such failures instead of returning null. Therefore, we only run the test outside of TSAN.
 #if !defined(__SANITIZE_THREAD__)
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("ParentRequirement", "SCR-109773");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",
@@ -50,7 +50,7 @@ TEST(SafeMemoryAllocatorTest, ReallocFail)
     // ThreadSanitizer (TSAN) is expected to fail in this scenario because its allocator terminates
     // the program on such failures instead of returning null. Therefore, we only run the test outside of TSAN.
 #if !defined(__SANITIZE_THREAD__)
-    this->RecordProperty("DerivationTechnique", "Analysis of requirements");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
     this->RecordProperty("ParentRequirement", "SCR-109773");
     this->RecordProperty("ASIL", "B");
     this->RecordProperty("Description",

--- a/score/os/test/mmanTest.cpp
+++ b/score/os/test/mmanTest.cpp
@@ -30,7 +30,7 @@ TEST(mmap, MapAndUnmap)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Map And Unmap");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"mmap_file"};
     constexpr auto offset{0};
@@ -63,7 +63,7 @@ TEST(mmap, MapFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Map Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto offset{0};
     constexpr auto size{0};
@@ -85,7 +85,7 @@ TEST(mmap, UnmapFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Unmap Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     void* invalid_address = reinterpret_cast<void*>(0xDEADBEEF);
     std::size_t size{0};
@@ -100,7 +100,7 @@ TEST(mmap, OpenAndCloseSharedMemory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Open And Close Shared Memory");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "/test_mmap";
     Fcntl::Open oflag = Fcntl::Open::kCreate | Fcntl::Open::kReadWrite;
@@ -119,7 +119,7 @@ TEST(mmap, ShmOpenNonExistingFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Shm Open Non Existing File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "";
     Fcntl::Open oflag = Fcntl::Open::kCreate | Fcntl::Open::kReadOnly | Fcntl::Open::kExclusive;
@@ -135,7 +135,7 @@ TEST(mmap, UnlinkNonExistentSharedMemory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Unlink Non Existent Shared Memory");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = score::os::Mman::instance().shm_unlink("");
     EXPECT_FALSE(result.has_value());
@@ -149,7 +149,7 @@ TEST(mmap, OpenInvalidTypedMemory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Open Invalid Typed Memory");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "";
     Fcntl::Open oflag = Fcntl::Open::kReadWrite;
@@ -168,7 +168,7 @@ TEST(mmap, GetInfoInvalidFD)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Get Info Invalid FD");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t invalid_fd = -1;
     struct posix_typed_mem_info info;
@@ -185,7 +185,7 @@ TEST(mmap, OpenTypedMemory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Open Typed Memory");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "/memory";
     Fcntl::Open oflag = Fcntl::Open::kReadOnly;
@@ -209,7 +209,7 @@ TEST(mmap, InfoTypedMemory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Info Typed Memory");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "/memory";
 
@@ -233,7 +233,7 @@ TEST(mmap, DefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mmap Default Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto default_instance = score::os::Mman::Default();
     ASSERT_TRUE(default_instance != nullptr);
@@ -246,7 +246,7 @@ TEST(MmanTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MmanTest PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Mman::Default(memory_resource);

--- a/score/os/test/mount_test.cpp
+++ b/score/os/test/mount_test.cpp
@@ -27,7 +27,7 @@ TEST(MountTest, MountTestMountFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MountTest Mount Test Mount Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::mkdir("/mnt/home", S_IRWXU | S_IRWXG | S_IRWXO);
 
@@ -42,7 +42,7 @@ TEST(MountTest, MountTestUmountFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MountTest Mount Test Umount Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* dir = "/mnt/home";
     score::cpp::expected_blank<Error> result = score::os::Mount::instance().umount(dir);
@@ -55,7 +55,7 @@ TEST(MountTest, MountTestConvertFlag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MountTest Mount Test Convert Flag");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::mkdir("/mnt/home", S_IWUSR | S_IWGRP | S_IWOTH);
 

--- a/score/os/test/mqueue_test.cpp
+++ b/score/os/test/mqueue_test.cpp
@@ -46,7 +46,7 @@ TEST_F(MqueueTest, mq_open_succeeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_open_succeeds");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Mqueue::OpenFlag flags{Mqueue::OpenFlag::kCreate};
     Mqueue::ModeFlag perm{Mqueue::ModeFlag::kReadUser};
@@ -66,7 +66,7 @@ TEST_F(MqueueTest, mq_open_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_open_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Mqueue::OpenFlag flags{Mqueue::OpenFlag::kExclusive};
     Mqueue::ModeFlag perm{Mqueue::ModeFlag::kReadGroup};
@@ -79,7 +79,7 @@ TEST_F(MqueueTest, mq_open_failure_without_create_flag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_open_failure_without_create_flag");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Mqueue::OpenFlag flags{Mqueue::OpenFlag::kReadOnly};
     ASSERT_FALSE(mqueue_.mq_open(m_name_.c_str(), flags).has_value());
@@ -91,7 +91,7 @@ TEST_F(MqueueTest, mq_unlink_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_unlink_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(mqueue_.mq_unlink(m_name_.c_str()).has_value());
 }
@@ -102,7 +102,7 @@ TEST_F(MqueueTest, mq_send_and_timedreceive_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_send_and_timedreceive_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string message = "Test Message";
     const size_t message_length = message.size() + 1;
@@ -156,7 +156,7 @@ TEST_F(MqueueTest, mq_send_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_send_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string message = "Test Message";
     const size_t message_length = message.size() + 1;
@@ -186,7 +186,7 @@ TEST_F(MqueueTest, mq_timedsend_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_timedsend_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string message = "Test Message";
     const size_t message_length = message.size() + 1;
@@ -218,7 +218,7 @@ TEST_F(MqueueTest, mq_timedreceive_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_timedreceive_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     mq_attr attr;
     attr.mq_maxmsg = 1;
@@ -248,7 +248,7 @@ TEST_F(MqueueTest, mq_timedsend_and_mq_receive_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_timedsend_and_mq_receive_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string message = "Test Message";
     const size_t message_length = message.size() + 1;
@@ -305,7 +305,7 @@ TEST_F(MqueueTest, mq_receive_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_receive_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char buffer[100];
     std::uint32_t msg_prio;
@@ -320,7 +320,7 @@ TEST_F(MqueueTest, mq_close_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_close_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto mqd =
         mqueue_.mq_open(m_name_.c_str(),
@@ -339,7 +339,7 @@ TEST_F(MqueueTest, mq_close_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_close_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = mqueue_.mq_close(kInvalidMqd);
     EXPECT_FALSE(result.has_value());
@@ -351,7 +351,7 @@ TEST_F(MqueueTest, mq_getattr_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_getattr_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     mq_attr attr;
     attr.mq_maxmsg = 3;
@@ -374,7 +374,7 @@ TEST_F(MqueueTest, mq_getattr_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest mq_getattr_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     mq_attr attr;
     auto result = mqueue_.mq_getattr(kInvalidMqd, attr);
@@ -387,7 +387,7 @@ TEST_F(MqueueTest, modeflag_to_nativeflag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MqueueTest modeflag_to_nativeflag");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     using OpenFlag = Mqueue::OpenFlag;
     Mqueue::OpenFlag flags{OpenFlag::kWriteOnly | OpenFlag::kCreate | OpenFlag::kReadWrite | OpenFlag::kNonBlocking |
@@ -405,7 +405,7 @@ TEST(SchedTest, get_instance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedTest get_instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_NO_FATAL_FAILURE(Mqueue::instance());
 }

--- a/score/os/test/pthread_test.cpp
+++ b/score/os/test/pthread_test.cpp
@@ -107,7 +107,7 @@ TEST_F(PthreadNameTest, GetCpuClockIdFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadNameTest Get Cpu Clock Id Fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_t thread;
 
@@ -184,7 +184,7 @@ TEST(PthreadTestingInstanceTest, RestoresOriginalAfterSettingTestingInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadTestingInstanceTest Restores Original After Setting Testing Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const Pthread* instance = &Pthread::instance();
 
@@ -222,7 +222,7 @@ TEST_F(PthreadMockTest, SetNameCallsPOSIXAPI)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMockTest Set Name Calls POSIXAPI");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(mock_pthread, setname_np);
     Pthread::instance().setname_np(Pthread::instance().self(), expected);
@@ -234,7 +234,7 @@ TEST_F(PthreadMockTest, GetNameCallsPOSIXAPI)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMockTest Get Name Calls POSIXAPI");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(mock_pthread, getname_np);
     Pthread::instance().getname_np(Pthread::instance().self(), actual, length);
@@ -246,7 +246,7 @@ TEST(PthreadCondAttrTest, Init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Init");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_condattr_t attr{};
     const auto result = Pthread::instance().condattr_init(&attr);
@@ -259,7 +259,7 @@ TEST(PthreadCondAttrTest, SetPSharedSetsNewAttribute)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Set PShared Sets New Attribute");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_condattr_t attr{};
     const std::int32_t pshared{PTHREAD_PROCESS_SHARED};
@@ -277,7 +277,7 @@ TEST(PthreadCondAttrTest, SetPSharedFailsWhenNewAttributeUnknown)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Set PShared Fails When New Attribute Unknown");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_condattr_t attr{};
     const std::int32_t invalid_pshared{5};
@@ -292,7 +292,7 @@ TEST(PthreadCondAttrTest, Destroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondAttrTest Destroy");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_condattr_t attr{};
     const auto result = Pthread::instance().condattr_destroy(&attr);
@@ -305,7 +305,7 @@ TEST(PthreadCondTest, Init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondTest Init");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_cond_t cond{};
     pthread_condattr_t attr{};
@@ -319,7 +319,7 @@ TEST(PthreadCondTest, Destroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadCondTest Destroy");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_cond_t cond{};
     const auto result = Pthread::instance().cond_destroy(&cond);
@@ -332,7 +332,7 @@ TEST(PthreadMutexAttrTest, Init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Init");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_mutexattr_t attr{};
     const auto result = Pthread::instance().mutexattr_init(&attr);
@@ -345,7 +345,7 @@ TEST(PthreadMutexAttrTest, SetPSharedSetsNewAttribute)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Set PShared Sets New Attribute");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_mutexattr_t attr{};
     const std::int32_t pshared{PTHREAD_PROCESS_SHARED};
@@ -363,7 +363,7 @@ TEST(PthreadMutexAttrTest, SetPSharedFailsWhenNewAttributeUnknown)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Set PShared Fails When New Attribute Unknown");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_mutexattr_t attr{};
     const std::int32_t invalid_pshared{5};
@@ -378,7 +378,7 @@ TEST(PthreadMutexAttrTest, Destroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexAttrTest Destroy");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_mutexattr_t attr{};
     const auto result = Pthread::instance().mutexattr_destroy(&attr);
@@ -391,7 +391,7 @@ TEST(PthreadMutexTest, Init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexTest Init");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_mutex_t mutex{};
     pthread_mutexattr_t attr{};
@@ -405,7 +405,7 @@ TEST(PthreadMutexTest, Destroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexTest Destroy");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pthread_mutex_t mutex{};
     const auto result = Pthread::instance().mutex_destroy(&mutex);
@@ -418,7 +418,7 @@ TEST(PthreadMutexTest, DestroyFailsIfMutexLockedByOtherThread)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadMutexTest Destroy Fails If Mutex Locked By Other Thread");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // TSAN is rightly complaining that we try to destroy a locked mutex. But this behavior is the core of the test.
     // If a user tries to destroy a mutex that is still locked, he should get an error as intended by POSIX. This test
@@ -458,7 +458,7 @@ TEST(PthreadSchedParamTest, SetSchedParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Set Sched Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<pthread_t> thread_id_promise{};
     std::promise<void> destroy_promise{};
@@ -490,7 +490,7 @@ TEST(PthreadSchedParamTest, SetSchedParamFailsWithInvalidThread)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Set Sched Param Fails With Invalid Thread");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<pthread_t> thread_id_promise{};
     std::promise<void> destroy_promise{};
@@ -517,7 +517,7 @@ TEST(PthreadSchedParamTest, GetSchedParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Get Sched Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<pthread_t> thread_id_promise{};
     std::promise<void> destroy_promise{};
@@ -557,7 +557,7 @@ TEST(PthreadSchedParamTest, GetSchedParamFailsWithJoinedThread)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PthreadSchedParamTest Get Sched Param Fails With Joined Thread");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<pthread_t> thread_id_promise{};
     std::promise<void> destroy_promise{};

--- a/score/os/test/qnx/channel_impl_test.cpp
+++ b/score/os/test/qnx/channel_impl_test.cpp
@@ -83,7 +83,7 @@ TEST_F(ChannelImplFixture, MsgReceiveReturnsErrorIfInvalidChId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receive returns Error If Invalid Ch Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = unit_->MsgReceive(kInvalidId, kNoMsg, kNoBytes, kNoInfo);
     EXPECT_FALSE(result.has_value());
@@ -95,7 +95,7 @@ TEST_F(ChannelImplFixture, MsgReceivevReturnsErrorIfInvalidChId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receivev returns Error If Invalid Ch Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto riov_size = 8;
     iov_t riov[riov_size]{};
@@ -111,7 +111,7 @@ TEST_F(ChannelImplFixture, MsgReceivePulseReturnsErrorIfInvalidChId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receive Pulse returns Error If Invalid Ch Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = unit_->MsgReceivePulse(kInvalidId, kNoMsg, kNoBytes, kNoInfo);
     EXPECT_FALSE(result.has_value());
@@ -123,7 +123,7 @@ TEST_F(ChannelImplFixture, MsgReplyReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message reply returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto buff_size = 255;
     char buff[buff_size];
@@ -139,7 +139,7 @@ TEST_F(ChannelImplFixture, MsgReplyvReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message reply returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto riov_size = 8;
     iov_t riov[riov_size]{};
@@ -155,7 +155,7 @@ TEST_F(ChannelImplFixture, MsgErrorReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Error returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t error = EOK;
     const auto result = unit_->MsgError(kInvalidId, error);
@@ -168,7 +168,7 @@ TEST_F(ChannelImplFixture, MsgSendReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MessageData data{};
     const auto result = unit_->MsgSend(kInvalidId, &data, sizeof(data), kNoReply, kNoBytes);
@@ -181,7 +181,7 @@ TEST_F(ChannelImplFixture, MsgSendvReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Sendv returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto iov_size = 8;
     iov_t siov[iov_size]{};
@@ -198,7 +198,7 @@ TEST_F(ChannelImplFixture, SetIovFillsPredefinedMsgData)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Set Iov Fills Predefined Msg Data");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iov_t msg{};
     MessageData data{};
@@ -216,7 +216,7 @@ TEST_F(ChannelImplFixture, SetIovConstFillsPredefinedMsgData)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Set Iov Const Fills Predefined Msg Data");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iov_t msg{};
     MessageData data{};
@@ -234,7 +234,7 @@ TEST_F(ChannelImplFixture, MsgSendPulseReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t calling_thread_priority{-1};
     constexpr std::int32_t code{0};
@@ -251,7 +251,7 @@ TEST_F(ChannelImplFixture, MsgSendPulsePtrReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse Ptr returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t calling_thread_priority{-1};
     constexpr std::int32_t code{0};
@@ -268,7 +268,7 @@ TEST_F(ChannelImplFixture, MsgDeliverEventReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Deliver Event returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr sigevent* no_event{nullptr};
     const auto result = unit_->MsgDeliverEvent(kInvalidId, no_event);
@@ -281,7 +281,7 @@ TEST_F(ChannelImplFixture, ConnectClientInfoReturnsErrorIfNonExistingCoid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Client Info returns Error If Non Existing Coid");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr int32_t non_existing_coid{std::numeric_limits<int32_t>::min()};
     constexpr _client_info* no_client_info{nullptr};
@@ -298,7 +298,7 @@ TEST_F(ChannelImplFixture, ConnectAttachReturnsErrorIfInvalidInput)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach returns Error If Invalid Input");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = unit_->ConnectAttach(kAttachId, kInvalidPid, kInvalidId, kAttachIndex, kAttachFlags);
     EXPECT_FALSE(result.has_value());
@@ -310,7 +310,7 @@ TEST_F(ChannelImplFixture, ConnectDetachReturnsErrorIfInvalidRcvId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Detach returns Error If Invalid Rcv Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = unit_->ConnectDetach(kInvalidId);
     EXPECT_FALSE(result.has_value());
@@ -322,7 +322,7 @@ TEST_F(ChannelImplFixture, ConnectAttachAndDetatchFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach And Detatch Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto chid = ChannelCreate(kOpenFlags);
     const auto coid = this->unit_->ConnectAttach(kAttachId, kAttachId, chid, kAttachIndex, kAttachFlags);
@@ -337,7 +337,7 @@ TEST_F(ChannelImplFixture, ConnectAttachAndMsgRegisterEventFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach And Msg Register Event Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto chid = ChannelCreate(kOpenFlags);
     const auto coid = this->unit_->ConnectAttach(kAttachId, kAttachId, chid, kAttachIndex, kAttachFlags);
@@ -356,7 +356,7 @@ TEST_F(ChannelImplFixture, MsgRegisterEventReturnsError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MsgRegisterEvent returns error if called with invalid connection id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr sigevent* no_event{nullptr};
     const auto result = this->unit_->MsgRegisterEvent(no_event, kInvalidId);
@@ -369,7 +369,7 @@ TEST_F(ChannelImplFixture, MsgDeliverEventFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Deliver Event Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // This test sends MsgDeliverEvent from main thread to client.
     // Sequence call:
@@ -454,7 +454,7 @@ TEST_F(ChannelImplFixture, MessageFlow_SendReceiveReply)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Flow: Send receive Reply");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     /*
         MsgSendv is called from main thread and gets blocked until client reads the message by MsgReceivev and reply

--- a/score/os/test/qnx/channel_test.cpp
+++ b/score/os/test/qnx/channel_test.cpp
@@ -72,7 +72,7 @@ TEST_F(ChannelMockTest, MsgReceive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Receive");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgReceive);
     score::os::Channel::instance().MsgReceive(invalid_id, no_msg, no_bytes, no_info);
@@ -84,7 +84,7 @@ TEST_F(ChannelMockTest, MsgReceivePulse)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message receive Pulse");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgReceivePulse);
     score::os::Channel::instance().MsgReceivePulse(invalid_id, no_msg, no_bytes, no_info);
@@ -96,7 +96,7 @@ TEST_F(ChannelMockTest, MsgReply)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Reply");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgReply);
     score::os::Channel::instance().MsgReply(invalid_id, status, no_reply, no_bytes);
@@ -108,7 +108,7 @@ TEST_F(ChannelMockTest, MsgError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Error");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgError);
     score::os::Channel::instance().MsgError(invalid_id, error);
@@ -120,7 +120,7 @@ TEST_F(ChannelMockTest, MsgSend)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Send");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgSend);
     score::os::Channel::instance().MsgSend(invalid_id, no_msg, no_bytes, no_reply, no_bytes);
@@ -132,7 +132,7 @@ TEST_F(ChannelMockTest, MsgSendPulse)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgSendPulse);
     score::os::Channel::instance().MsgSendPulse(invalid_id, calling_thread_priority, code, value);
@@ -144,7 +144,7 @@ TEST_F(ChannelMockTest, MsgSendPulsePtr)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message send Pulse Ptr");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgSendPulsePtr);
     score::os::Channel::instance().MsgSendPulsePtr(invalid_id, calling_thread_priority, code_ptr, value_ptr);
@@ -156,7 +156,7 @@ TEST_F(ChannelMockTest, MsgDeliverEvent)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Deliver Event");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgDeliverEvent);
     score::os::Channel::instance().MsgDeliverEvent(invalid_id, no_event);
@@ -168,7 +168,7 @@ TEST_F(ChannelMockTest, ConnectClientInfo)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Client Info");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, ConnectClientInfo);
     score::os::Channel::instance().ConnectClientInfo(invalid_scoid, no_client_info, ngroups);
@@ -180,7 +180,7 @@ TEST_F(ChannelMockTest, ConnectAttach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Attach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, ConnectAttach);
     score::os::Channel::instance().ConnectAttach(kAttachId, kInvalidPid, invalid_id, kAttachIndex, kAttachFlags);
@@ -192,7 +192,7 @@ TEST_F(ChannelMockTest, ConnectDetach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Connect Detach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, ConnectDetach);
     score::os::Channel::instance().ConnectDetach(invalid_id);
@@ -204,7 +204,7 @@ TEST_F(ChannelMockTest, MsgRegisterEvent)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Msg Register Event");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(channelmock, MsgRegisterEvent);
     score::os::Channel::instance().MsgRegisterEvent(no_event, invalid_id);
@@ -218,7 +218,7 @@ TEST(ChannelTest, CoverUnhappyPaths)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Cover Unhappy Paths");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& channel = score::os::Channel::instance();
 
@@ -376,7 +376,7 @@ TEST(ChannelTest, CheckHappyFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Happy Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& channel = score::os::Channel::instance();
     auto& dispatch = score::os::Dispatch::instance();
@@ -429,7 +429,7 @@ TEST(ChannelCreateInstance, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Channel::Default(memory_resource);

--- a/score/os/test/qnx/devctl_test.cpp
+++ b/score/os/test/qnx/devctl_test.cpp
@@ -46,7 +46,7 @@ TEST_F(DevctlTestMock, TestFunction_Devctl)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function Devctl");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::array<std::uint8_t, 3> dev_data{1, 2, 3};
     std::int32_t dev_info{};
@@ -76,7 +76,7 @@ TEST_F(DevctlTestMock, TestFunction_Devctlv)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function Devctlv");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::array<std::uint8_t, 3> vec_data_1{1, 2, 3};
     iovec s_vec[1];
@@ -125,7 +125,7 @@ TEST_F(DevctlTestQnx, TestDevctl_GetFlags_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Get Flags Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
     const ModeFlag mode_flags{ModeFlag::kReadUser | ModeFlag::kWriteUser};
@@ -149,7 +149,7 @@ TEST_F(DevctlTestQnx, TestDevctlv_GetFlags_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl:v Get Flags Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
     const ModeFlag mode_flags{ModeFlag::kReadUser | ModeFlag::kWriteUser};
@@ -181,7 +181,7 @@ TEST_F(DevctlTestQnx, TestDevctl_SetGetFlags_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Set Get Flags Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
     const ModeFlag mode_flags{ModeFlag::kReadUser | ModeFlag::kWriteUser};
@@ -209,7 +209,7 @@ TEST_F(DevctlTestQnx, TestDevctl_SetFlagsWrongFd_Fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Set Flags Wrong Fd Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t set_flags{O_APPEND | O_LARGEFILE};
     auto res_devctl = score::os::Devctl::instance().devctl(-1, DCMD_ALL_SETFLAGS, &set_flags, sizeof(set_flags), nullptr);
@@ -222,7 +222,7 @@ TEST_F(DevctlTestQnx, TestDevctlv_SetFlagsWrongFd_Fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl:v Set Flags Wrong Fd Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto res_devctl = score::os::Devctl::instance().devctlv(-1, DCMD_ALL_SETFLAGS, 0, 0, nullptr, nullptr, nullptr);
     ASSERT_FALSE(res_devctl.has_value());
@@ -234,7 +234,7 @@ TEST_F(DevctlTestQnx, TestDevctl_GetFlagsNullptr_Fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Devctl: Get Flags Nullptr Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const OpenFlag open_flags{OpenFlag::kReadOnly | OpenFlag::kNonBlocking | OpenFlag::kCreate};
     const ModeFlag mode_flags{ModeFlag::kReadUser | ModeFlag::kWriteUser};

--- a/score/os/test/qnx/dispatch_impl_test.cpp
+++ b/score/os/test/qnx/dispatch_impl_test.cpp
@@ -40,7 +40,7 @@ TEST_F(DispatchImplFixture, NameOpenCloseFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Open Close Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* const path = "tmp";
     constexpr std::uint32_t flags{0U};
@@ -62,7 +62,7 @@ TEST_F(DispatchImplFixture, dispatch_unblock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Unblock");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -91,7 +91,7 @@ TEST_F(DispatchImplFixture, resmgr_detachReturnsErrorIfPassInvalidId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Detach returns Error If Pass Invalid Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -109,7 +109,7 @@ TEST_F(DispatchImplFixture, thread_pool_create_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Thread Pool Create Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     thread_pool_attr_t pool_attr{};
     auto pool = unit_->thread_pool_create(&pool_attr, POOL_FLAG_EXIT_SELF);
@@ -122,7 +122,7 @@ TEST_F(DispatchImplFixture, select_attach_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Attach Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -146,7 +146,7 @@ TEST_F(DispatchImplFixture, select_attach_frozen_context_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Attach Frozen Context Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t no_chid{-1};
     auto dpp = unit_->dispatch_create_channel(no_chid, DISPATCH_FLAG_NOLOCK);
@@ -177,7 +177,7 @@ TEST_F(DispatchImplFixture, select_detach_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Detach Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -203,7 +203,7 @@ TEST_F(DispatchImplFixture, select_detach_not_attached_fd_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Select Detach Not Attached Fd Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -223,7 +223,7 @@ TEST_F(DispatchImplFixture, pulse_attach_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Attach Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -247,7 +247,7 @@ TEST_F(DispatchImplFixture, pulse_attach_frozen_context_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Attach Frozen Context Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t no_chid{-1};
     auto dpp = unit_->dispatch_create_channel(no_chid, DISPATCH_FLAG_NOLOCK);
@@ -282,7 +282,7 @@ TEST_F(DispatchImplFixture, pulse_detach_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Detach Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -308,7 +308,7 @@ TEST_F(DispatchImplFixture, pulse_detach_not_attached_code_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Pulse Detach Not Attached Code Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = unit_->dispatch_create();
     ASSERT_TRUE(dpp);
@@ -329,7 +329,7 @@ TEST_F(DispatchImplFixture, thread_pool_start_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Thread Pool Start Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     thread_pool_attr_t pool_attr{};
     auto dpp = ::dispatch_create();

--- a/score/os/test/qnx/dispatch_test.cpp
+++ b/score/os/test/qnx/dispatch_test.cpp
@@ -74,7 +74,7 @@ TEST_F(DispatchMockTest, name_attach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Attach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, name_attach);
     score::os::Dispatch::instance().name_attach(kNoDispatch, "path", kAttachFlags);
@@ -86,7 +86,7 @@ TEST_F(DispatchMockTest, name_detach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Detach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, name_detach);
     score::os::Dispatch::instance().name_detach(kNoAttach, kDetachFlags);
@@ -98,7 +98,7 @@ TEST_F(DispatchMockTest, name_open)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Open");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, name_open);
     score::os::Dispatch::instance().name_open("path", kOpenFlags);
@@ -110,7 +110,7 @@ TEST_F(DispatchMockTest, name_close)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Close");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, name_close);
     score::os::Dispatch::instance().name_close(kInvalidId);
@@ -122,7 +122,7 @@ TEST_F(DispatchMockTest, dispatch_create)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Create");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_create);
     score::os::Dispatch::instance().dispatch_create();
@@ -134,7 +134,7 @@ TEST_F(DispatchMockTest, dispatch_create_channel)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Create Channel");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_create_channel);
     score::os::Dispatch::instance().dispatch_create_channel(kInvalidId, DISPATCH_FLAG_NOLOCK);
@@ -146,7 +146,7 @@ TEST_F(DispatchMockTest, dispatch_destroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Destroy");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_destroy);
     score::os::Dispatch::instance().dispatch_destroy(kNoDispatch);
@@ -158,7 +158,7 @@ TEST_F(DispatchMockTest, dispatch_context_alloc)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Context Alloc");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_context_alloc);
     score::os::Dispatch::instance().dispatch_context_alloc(kNoDispatch);
@@ -170,7 +170,7 @@ TEST_F(DispatchMockTest, dispatch_context_free)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Context Free");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_context_free);
     score::os::Dispatch::instance().dispatch_context_free(kNoDispatchContext);
@@ -182,7 +182,7 @@ TEST_F(DispatchMockTest, dispatch_block)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Block");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_block);
     score::os::Dispatch::instance().dispatch_block(kNoDispatchContext);
@@ -194,7 +194,7 @@ TEST_F(DispatchMockTest, dispatch_unblock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Unblock");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_unblock);
     score::os::Dispatch::instance().dispatch_unblock(kNoDispatchContext);
@@ -206,7 +206,7 @@ TEST_F(DispatchMockTest, dispatch_handler)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Handler");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, dispatch_handler);
     score::os::Dispatch::instance().dispatch_handler(kNoDispatchContext);
@@ -218,7 +218,7 @@ TEST_F(DispatchMockTest, resmgr_attach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Attach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, resmgr_attach);
     score::os::Dispatch::instance().resmgr_attach(
@@ -231,7 +231,7 @@ TEST_F(DispatchMockTest, resmgr_detach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Detach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, resmgr_detach);
     score::os::Dispatch::instance().resmgr_detach(kNoDispatch, kInvalidId, _RESMGR_DETACH_ALL);
@@ -243,7 +243,7 @@ TEST_F(DispatchMockTest, resmgr_msgget)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Msgget");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, resmgr_msgget);
     score::os::Dispatch::instance().resmgr_msgget(kNoResmgrContext, kNoMsg, kNoSize, kNoOffset);
@@ -255,7 +255,7 @@ TEST_F(DispatchMockTest, message_connect)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Connect");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(dispatchmock, message_connect);
     score::os::Dispatch::instance().message_connect(kNoDispatch, MSG_FLAG_SIDE_CHANNEL);
@@ -267,7 +267,7 @@ TEST_F(DispatchMockTest, message_attach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Message Attach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t (*const noHandler)(
         message_context_t* ctp, std::int32_t code, std::uint32_t flags, void* handle) noexcept {nullptr};
@@ -284,7 +284,7 @@ TEST(DispatchTest, name_attach_to_invalid_path_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Attach To Invalid Path Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -297,7 +297,7 @@ TEST(DispatchTest, name_detach_from_invalid_id_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Detach From Invalid Id Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -314,7 +314,7 @@ TEST(DispatchTest, name_open_invalid_path_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Open Invalid Path Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -327,7 +327,7 @@ TEST(DispatchTest, name_close_invalid_id_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Name Close Invalid Id Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -340,7 +340,7 @@ TEST(DispatchTest, dispatch_handler_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Handler Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -355,7 +355,7 @@ TEST(DispatchTest, CheckServerHappyFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Server Happy Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -622,7 +622,7 @@ TEST_F(DispatchResourceManagerTest, CheckResourceManagerHappyFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check Resource Manager Happy Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto& dispatch = score::os::Dispatch::instance();
 
@@ -908,7 +908,7 @@ TEST_F(DispatchClientTest, DispatchClientHappyFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Dispatch Client Happy Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // prepare the client setup
     CreateDispatchChannel();
@@ -939,7 +939,7 @@ TEST(DispatchTestFinal, resmgr_attach_without_privileges_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Resmgr Attach Without Privileges Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto dpp = score::os::Dispatch::instance().dispatch_create();
     ASSERT_TRUE(dpp.has_value());
@@ -959,7 +959,7 @@ TEST(DispatchCreateInstance, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Dispatch::Default(memory_resource);

--- a/score/os/test/qnx/fs_crypto_impl_test.cpp
+++ b/score/os/test/qnx/fs_crypto_impl_test.cpp
@@ -51,7 +51,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_add_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_add Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{6};
@@ -69,7 +69,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_set_domain_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_file_set_domain Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent/test";
     std::int32_t domain{6};
@@ -85,7 +85,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_add_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_add Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t bytes_length = 64;
     const char* path = "/persistent/test";
@@ -104,7 +104,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_query_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_query Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{6};
@@ -120,7 +120,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_query_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_query Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent/test";
     std::int32_t domain{-1};
@@ -136,7 +136,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_unlock_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_unlock Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{6};
@@ -152,7 +152,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_unlock_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_unlock Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent/test";
     std::int32_t domain{-1};
@@ -169,7 +169,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_set_domain_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_file_set_domain Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent/test";
     std::int32_t domain{-1};
@@ -185,7 +185,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_remove_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_remove Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent/test";
     std::int32_t domain{-1};
@@ -201,7 +201,7 @@ TEST_F(fsCryptoImplTest, TestFunction_fs_crypto_domain_remove_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function fs_crypto_domain_remove Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{6};

--- a/score/os/test/qnx/fs_crypto_test.cpp
+++ b/score/os/test/qnx/fs_crypto_test.cpp
@@ -31,7 +31,7 @@ TEST(FsCrypto, CreateObjectSuccessful)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Create Object Successful");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto fscrypto = score::os::qnx::FsCrypto::createFsCryptoInstance();
     EXPECT_TRUE(fscrypto);
@@ -65,7 +65,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_remove_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_remove Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -83,7 +83,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_remove_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_remove Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -101,7 +101,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_add_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_add Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t bytes_length = 512;
     const char* path = "/persistent";
@@ -123,7 +123,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_add_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_add Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t bytes_length = 1;
     const char* path = "/persistent";
@@ -145,7 +145,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_query_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_query Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -163,7 +163,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_query_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_query Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -181,7 +181,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_unlock_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_unlock Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -201,7 +201,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_domain_unlock_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_domain_unlock Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -221,7 +221,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_file_set_domain_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_file_set_domain Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};
@@ -239,7 +239,7 @@ TEST_F(fsCryptoMockTest, Test_fs_crypto_file_set_domain_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test fs_crypto_file_set_domain Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* path = "/persistent";
     std::int32_t domain{3};

--- a/score/os/test/qnx/inout_test.cpp
+++ b/score/os/test/qnx/inout_test.cpp
@@ -40,7 +40,7 @@ TEST_F(InoutTestFixture, in8TestToReturnNoErrorIfpassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "In Test To Return No Error Ifpass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->in8(address_);
     EXPECT_TRUE(val.has_value());
@@ -52,7 +52,7 @@ TEST_F(InoutTestFixture, in16ReturnsNoErrorIfPassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "In returns No Error If Pass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->in16(address_);
     EXPECT_TRUE(val.has_value());
@@ -64,7 +64,7 @@ TEST_F(InoutTestFixture, in32ReturnNoErrorIfPassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "In Return No Error If Pass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->in32(address_);
     EXPECT_TRUE(val.has_value());
@@ -76,7 +76,7 @@ TEST_F(InoutTestFixture, out8ReturnNoErrorIfPassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Out Return No Error If Pass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->out8(address_, 0xAA);
     EXPECT_TRUE(val.has_value());
@@ -88,7 +88,7 @@ TEST_F(InoutTestFixture, out16ReturnNoErrorIfPassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Out Return No Error If Pass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->out16(address_, 0xAA);
     EXPECT_TRUE(val.has_value());
@@ -100,7 +100,7 @@ TEST_F(InoutTestFixture, out32ReturnNoErrorIfPassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Out Return No Error If Pass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->out32(address_, 0xAA);
     EXPECT_TRUE(val.has_value());

--- a/score/os/test/qnx/iofunc_test.cpp
+++ b/score/os/test/qnx/iofunc_test.cpp
@@ -55,7 +55,7 @@ TEST(IoFuncTest, InstanceCall)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Instance Call");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // check whether instance() returns injection
     score::os::IoFuncQnx mock{};
@@ -87,7 +87,7 @@ TEST_F(IoFuncMockTest, iofunc_attr_init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Init");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_attr_init);
     unit_->iofunc_attr_init(kNoAttr, kAttrMode, kNoAttr, kNoInfo);
@@ -99,7 +99,7 @@ TEST_F(IoFuncMockTest, iofunc_func_init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Func Init");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_func_init);
     unit_->iofunc_func_init(kFuncNConnect, kNoConnect, kFuncNIo, kNoIo);
@@ -111,7 +111,7 @@ TEST_F(IoFuncMockTest, iofunc_mount_init)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Mount Init");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_mount_init);
     unit_->iofunc_mount_init(kNoMountPoint, kNoSize);
@@ -123,7 +123,7 @@ TEST_F(IoFuncMockTest, iofunc_close_ocb_default)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Close Ocb Default");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_close_ocb_default);
     unit_->iofunc_close_ocb_default(kNoContext, nullptr, kNoOcb);
@@ -135,7 +135,7 @@ TEST_F(IoFuncMockTest, iofunc_devctl_default)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_devctl_default);
     unit_->iofunc_devctl_default(kNoContext, kNoDevctlMsg, kNoOcb);
@@ -147,7 +147,7 @@ TEST_F(IoFuncMockTest, iofunc_write_verify)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Write Verify");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_write_verify);
     unit_->iofunc_write_verify(kNoContext, kNoMsg, kNoOcb, kNoNonBlock);
@@ -159,7 +159,7 @@ TEST_F(IoFuncMockTest, iofunc_read_verify)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Read Verify");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_read_verify);
     unit_->iofunc_read_verify(kNoContext, kNoReadMsg, kNoOcb, kNoNonBlock);
@@ -171,7 +171,7 @@ TEST_F(IoFuncMockTest, iofunc_lseek_default)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Lseek Default");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(iofuncmock, iofunc_lseek_default);
     unit_->iofunc_lseek_default(nullptr, nullptr, nullptr);
@@ -199,7 +199,7 @@ TEST_F(IoFuncFixture, iofunc_close_ocb_default_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Close Ocb Default Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     extended_dev_attr_t attr{};
@@ -215,7 +215,7 @@ TEST_F(IoFuncFixture, iofunc_mount_init_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Mount Init Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iofunc_mount_t mount_point{};
     mount_point.flags = 5U;
@@ -232,7 +232,7 @@ TEST_F(IoFuncFixture, iofunc_mount_init_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Mount Init Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iofunc_mount_t mount_point{};
     mount_point.flags = 5U;
@@ -246,7 +246,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_return_resmgr_default_with_un
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Return Resmgr Default With Unknown Dmcd");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     DevCtl ctl{};
@@ -262,7 +262,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_return_data_with_dcmd_all_get
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Return Data With Dcmd All Getflags");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     DevCtl ctl{};
@@ -279,7 +279,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_fail_with_dcmd_all_setflags_i
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Fail With Dcmd All Setflags Incomplete Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     ctp.size = 0;  // making it explicit
@@ -299,7 +299,7 @@ TEST_F(IoFuncFixture, iofunc_devctl_default_should_succeed_with_dcmd_all_setflag
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Devctl Default Should Succeed With Dcmd All Setflags Complete Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     ctp.size = sizeof(DevCtl);
@@ -319,7 +319,7 @@ TEST_F(IoFuncFixture, iofunc_write_verifyReturnsErrorIfInvalidCtp)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Write Verify returns Error If Invalid Ctp");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     ctp.rcvid = -1;
@@ -336,7 +336,7 @@ TEST_F(IoFuncFixture, iofunc_read_verifyReturnsErrorIfInvalidCtp)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Read Verify returns Error If Invalid Ctp");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     ctp.rcvid = -1;
@@ -353,7 +353,7 @@ TEST_F(IoFuncFixture, iofunc_lseek_defaultReturnsErrorIfInvalidMsg)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Lseek Default returns Error If Invalid Msg");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     io_lseek_t msg{};
@@ -369,7 +369,7 @@ TEST(IoFuncTest, iofunc_write_verify_fails_for_empty_parameters)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Write Verify Fails For Empty Parameters");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     io_write_t msg{};
@@ -387,7 +387,7 @@ TEST(IoFuncCreateInstance, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::IoFunc::Default(memory_resource);
@@ -401,7 +401,7 @@ TEST(IoFuncTest, iofunc_client_info_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Client Info Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     struct _client_info* pinfo{nullptr};
@@ -418,7 +418,7 @@ TEST(IoFuncTest, iofunc_client_info_free_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc client_info_free success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct _client_info* pinfo{nullptr};
 
@@ -434,7 +434,7 @@ TEST(IoFuncTest, iofunc_check_access_failure_client_info_nullptr)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Check Access Failure Client Info Nullptr");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     iofunc_attr_t attr{};
@@ -452,7 +452,7 @@ TEST(IoFuncTest, iofunc_check_access_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Check Access Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     iofunc_attr_t attr{};
@@ -473,7 +473,7 @@ TEST(IoFuncTest, iofunc_attr_lock_failure_invalid_mutex)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Lock Failure Invalid Mutex");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iofunc_attr_t attr{};
     ::pthread_mutex_init(&attr.lock, nullptr);
@@ -492,7 +492,7 @@ TEST(IoFuncTest, iofunc_attr_unlock_failure_invalid_mutex)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Unlock Failure Invalid Mutex");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iofunc_attr_t attr{};
     ::pthread_mutex_init(&attr.lock, nullptr);
@@ -511,7 +511,7 @@ TEST(IoFuncTest, iofunc_attr_lock_unlock_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Attr Lock Unlock Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     iofunc_attr_t attr{};
 
@@ -529,7 +529,7 @@ TEST(IoFuncTest, iofunc_open_failure_both_attr_nullptr)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Open Failure Both Attr Nullptr");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     io_open_t msg{};
@@ -548,7 +548,7 @@ TEST(IoFuncTest, iofunc_open_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Open Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     io_open_t msg{};
@@ -569,7 +569,7 @@ TEST(IoFuncTest, iofunc_ocb_attach_failure_invalid_ctp)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Iofunc Ocb Attach Failure Invalid Ctp");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     resmgr_context_t ctp{};
     io_open_t msg{};

--- a/score/os/test/qnx/mman_test.cpp
+++ b/score/os/test/qnx/mman_test.cpp
@@ -37,7 +37,7 @@ TEST_F(MmanTestFixture, MmapMunmapDeviceIOReturnNoErrorIfPassValidAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Munmap Device Io Return No Error If Pass Valid Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->mmap_device_io(1, address_);
     EXPECT_TRUE(val.has_value());
@@ -54,7 +54,7 @@ TEST_F(MmanTestFixture, ShmCtlFailsWithInvalidPhysicalAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Ctl Fails With Invalid Physical Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto shm_open_result = ::shm_open(shm_name, O_RDWR | O_CREAT | O_EXCL, 0000);
 
@@ -73,7 +73,7 @@ TEST_F(MmanTestFixture, ShmCtlSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Ctl Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "/memory";
 
@@ -96,7 +96,7 @@ TEST_F(MmanTestFixture, MemOffsetFailsWhenPassInvalidVirtualAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Fails When Pass Invalid Virtual Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     off_t physical_addr{};
     const auto result = unit_->mem_offset(nullptr, NOFD, 4095U, &physical_addr, nullptr);
@@ -111,7 +111,7 @@ TEST_F(MmanTestFixture, MemOffsetSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "/memory";
 
@@ -133,7 +133,7 @@ TEST_F(MmanTestFixture, MemOffset64FailsWhenPassInvalidVirtualAddress)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Fails When Pass Invalid Virtual Address");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     off_t physical_addr{};
     const auto result = unit_->mem_offset64(nullptr, NOFD, 4095U, &physical_addr, nullptr);
@@ -148,7 +148,7 @@ TEST_F(MmanTestFixture, MemOffset64Succeeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mem Offset Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* name = "/memory";
 
@@ -170,7 +170,7 @@ TEST_F(MmanTestFixture, ShmOpenSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t oflag = O_CREAT | O_RDWR;
     mode_t mode = 0666;
@@ -187,7 +187,7 @@ TEST_F(MmanTestFixture, ShmOpenFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t oflag = O_RDWR;
     mode_t mode = 0666;
@@ -203,7 +203,7 @@ TEST_F(MmanTestFixture, ShmOpenHandleSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Handle Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t fd = ::shm_open(shm_name, O_CREAT | O_RDWR, 0666);
     ASSERT_NE(fd, -1);
@@ -227,7 +227,7 @@ TEST_F(MmanTestFixture, ShmOpenHandleFailsWithInvalidHandle)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Open Handle Fails With Invalid Handle");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     shm_handle_t invalid_handle = -1;
     std::int32_t flags = O_RDWR;
@@ -244,7 +244,7 @@ TEST_F(MmanTestFixture, ShmCreateHandleSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Create Handle Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t fd = shm_open(shm_name, O_CREAT | O_RDWR, 0666);
     ASSERT_NE(fd, -1);
@@ -266,7 +266,7 @@ TEST_F(MmanTestFixture, ShmCreateHandleFailsWithBadFileDescritor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Shm Create Handle Fails With Bad File Descritor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t invalid_fd = -1;
     pid_t pid = getpid();
@@ -286,7 +286,7 @@ TEST_F(MmanTestFixture, MmapSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t length = 4096;
     const std::int32_t protection = PROT_READ | PROT_WRITE;
@@ -306,7 +306,7 @@ TEST_F(MmanTestFixture, MmapFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t length = 0;
     const std::int32_t protection = PROT_READ | PROT_WRITE;
@@ -326,7 +326,7 @@ TEST_F(MmanTestFixture, Mmap64Succeeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t length = 4096;
     const std::int32_t protection = PROT_READ | PROT_WRITE;
@@ -346,7 +346,7 @@ TEST_F(MmanTestFixture, Mmap64Fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mmap Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t length = 0;
     const std::int32_t protection = PROT_READ | PROT_WRITE;
@@ -366,7 +366,7 @@ TEST_F(MmanTestFixture, MunmapSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Munmap Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t length = 4096;
     const std::int32_t protection = PROT_READ | PROT_WRITE;
@@ -388,7 +388,7 @@ TEST_F(MmanTestFixture, MunmapFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Munmap Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t invalid_length = 0;
 

--- a/score/os/test/qnx/neutrino_impl_test.cpp
+++ b/score/os/test/qnx/neutrino_impl_test.cpp
@@ -30,7 +30,7 @@ TEST_F(NeutrinoImplFixture, ThreadCtlTestReturnsError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Thread Ctl Test returns Error");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t cmd = 0xFFFFFFFF;
     std::int32_t data = 10;
@@ -46,7 +46,7 @@ TEST_F(NeutrinoImplFixture, ThreadCtlGetThreadNme)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Thread Ctl Get Thread Nme");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t valid_cmd{_NTO_TCTL_NAME};
     struct _thread_name thread_name{};
@@ -68,7 +68,7 @@ TEST_F(NeutrinoImplFixture, InterruptAttachAndDetachTest)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Attach And Detach Test");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::uint64_t timeout{0U};
     std::int32_t intr{10};
@@ -98,7 +98,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateDeprecatedSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Deprecated Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::uint32_t valid_flags{0U};
     const auto result = neutrino_.ChannelCreate(valid_flags);
@@ -112,7 +112,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateDeprecatedFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Deprecated Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto invalid_flags{std::numeric_limits<std::uint32_t>::max()};
     const auto result = neutrino_.ChannelCreate(invalid_flags);
@@ -127,7 +127,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = neutrino_.ChannelCreate(Neutrino::ChannelFlag::kDisconnect);
     ASSERT_TRUE(result.has_value());
@@ -139,7 +139,7 @@ TEST_F(NeutrinoImplFixture, ChannelCreateFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result =
         neutrino_.ChannelCreate(static_cast<Neutrino::ChannelFlag>(std::numeric_limits<std::uint32_t>::max()));
@@ -153,7 +153,7 @@ TEST_F(NeutrinoImplFixture, ChannelDestroySuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Destroy Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto channel_id = neutrino_.ChannelCreate(Neutrino::ChannelFlag::kDisconnect);
     ASSERT_TRUE(channel_id.has_value());
@@ -168,7 +168,7 @@ TEST_F(NeutrinoImplFixture, ChannelDestroyFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Destroy Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t failed_channel_id = 0;
     const auto destroy_result = neutrino_.ChannelDestroy(failed_channel_id);
@@ -181,7 +181,7 @@ TEST_F(NeutrinoImplFixture, ClockAdjustSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Adjust Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     clockid_t clockid{CLOCK_REALTIME};
     const auto tick_nsec{500000000};
@@ -203,7 +203,7 @@ TEST_F(NeutrinoImplFixture, ClockAdjust_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Adjust Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     clockid_t invalid_clockid{-1};
     _clockadjust new_adjust{0, 0};
@@ -220,7 +220,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutDeprecatedSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Deprecated Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     clockid_t clockid{CLOCK_REALTIME};
     std::int32_t flags{0};
@@ -255,7 +255,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutDeprecatedFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Deprecated Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     clockid_t clockid{-1};
     std::int32_t flags{0};
@@ -280,7 +280,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::unique_ptr<score::os::SigEvent> signal_event1 = std::make_unique<score::os::SigEventQnxImpl>();
     std::chrono::milliseconds min_sleep{2};
@@ -322,7 +322,7 @@ TEST_F(NeutrinoImplFixture, TimerTimeoutFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test TimerTimeout Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::unique_ptr<score::os::SigEvent> signal_event = nullptr;
     std::chrono::milliseconds ntime{2};
@@ -343,7 +343,7 @@ TEST_F(NeutrinoImplFixture, ClockCyclesMonotonicity)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Cycles Monotonicity");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto start = neutrino_.ClockCycles();
     const auto end = neutrino_.ClockCycles();
@@ -356,7 +356,7 @@ TEST_F(NeutrinoImplFixture, ClockCyclesElapsedTime)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Cycles Elapsed Time");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto start = neutrino_.ClockCycles();
     for (volatile int i = 0; i < 1000000; ++i)
@@ -371,7 +371,7 @@ TEST_F(NeutrinoImplFixture, ClockIdSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     pid_t pid = ::getpid();
     int32_t tid = ::gettid();
 

--- a/score/os/test/qnx/neutrino_showcase_test.cpp
+++ b/score/os/test/qnx/neutrino_showcase_test.cpp
@@ -259,7 +259,7 @@ TEST_F(NeutrinoTest, TimerTimeoutCalledOnMessageSend)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Called On Message Send");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -337,7 +337,7 @@ TEST_F(NeutrinoTest, TimerTimeoutCalledOnMessageSend_1)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Called On Message Send");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -484,7 +484,7 @@ TEST_F(NeutrinoTest, TimerTimeoutCalledOnMessageReply)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Called On Message Reply");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -570,7 +570,7 @@ TEST_F(NeutrinoTest, TimerTimeoutOnMessageReceive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout On Message Receive");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto create_server = CreateNamedServer();
     EXPECT_TRUE(create_server.has_value());
@@ -599,7 +599,7 @@ TEST_F(NeutrinoTest, TimerTimeoutNeverCalledWrongFlag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Never Called Wrong Flag");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -683,7 +683,7 @@ TEST_F(NeutrinoTest, TimerTimeoutNeverCalledChannelUnblockFlag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout Never Called Channel Unblock Flag");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -777,7 +777,7 @@ TEST_F(NeutrinoTest, TestServerPulseOnClientShutdown)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Test Server Pulse On Client Shutdown");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -884,7 +884,7 @@ TEST_F(NeutrinoTest, TestSendErrorOnServerDeath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Test send Error On Server Death");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;
@@ -949,7 +949,7 @@ TEST_F(NeutrinoTest, TestClientPulseOnServerDeath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Test Client Pulse On Server Death");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::mutex client_server_sync_mutex;
     std::condition_variable client_server_sync;

--- a/score/os/test/qnx/neutrino_test.cpp
+++ b/score/os/test/qnx/neutrino_test.cpp
@@ -53,7 +53,7 @@ TEST_F(NeutrinoMockTest, TimerTimeoutRawSigevent)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigevent raw_signal_event;
     EXPECT_CALL(*neutrino_mock_ptr, TimerTimeout(kClockType, _, testing::Matcher<const sigevent*>(_), _, _)).Times(1);
@@ -66,7 +66,7 @@ TEST_F(NeutrinoMockTest, TimerTimeout)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Timeout");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::unique_ptr<score::os::SigEvent> signal_event{std::make_unique<score::os::SigEventQnxImpl>()};
     EXPECT_CALL(*neutrino_mock_ptr,
@@ -81,7 +81,7 @@ TEST_F(NeutrinoMockTest, ClockAdjust)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Clock Adjust");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     _clockadjust adjustment{0, 0};
 
@@ -95,7 +95,7 @@ TEST_F(NeutrinoMockTest, ThreadCtl)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Thread Ctl");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t cmd = _NTO_TCTL_IO;
 
@@ -109,7 +109,7 @@ TEST_F(NeutrinoMockTest, InterruptWait_r)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Wait R");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t flags = 0;
 
@@ -123,7 +123,7 @@ TEST_F(NeutrinoMockTest, InterruptAttachEvent)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Attach Event");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t intr = _NTO_INTR_CLASS_EXTERNAL;
     const unsigned flags = _NTO_INTR_FLAGS_END;
@@ -138,7 +138,7 @@ TEST_F(NeutrinoMockTest, InterruptDetach)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Detach");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t id = 0;
 
@@ -152,7 +152,7 @@ TEST_F(NeutrinoMockTest, InterruptUnmask)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Interrupt Unmask");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t intr = _NTO_INTR_CLASS_EXTERNAL;
     const std::int32_t id = 0;
@@ -167,7 +167,7 @@ TEST_F(NeutrinoMockTest, ChannelCreate)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Create");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto flags{Neutrino::ChannelFlag::kConnectionIdDisconnect};
 
@@ -181,7 +181,7 @@ TEST_F(NeutrinoMockTest, ChannelDestroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Channel Destroy");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     const auto dummy_channel_id = 0;
     EXPECT_CALL(*neutrino_mock_ptr, ChannelDestroy(dummy_channel_id));
     neutrino_ptr->ChannelDestroy(dummy_channel_id);

--- a/score/os/test/qnx/pcap_test.cpp
+++ b/score/os/test/qnx/pcap_test.cpp
@@ -78,7 +78,7 @@ TEST_F(PcapFixture, PcapOpenLiveSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Open Live Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
 }
@@ -89,7 +89,7 @@ TEST_F(PcapFixture, PcapOpenLiveFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Open Live Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = pcap_->pcap_open_live("invalid_device", kSnapLenTooLarge, 1, kPacketBufferDelay, errbuf_.data());
     EXPECT_FALSE(result.has_value());
@@ -101,7 +101,7 @@ TEST_F(PcapFixture, PcapOpenDeadSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Open Dead Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = pcap_->pcap_open_dead(DLT_EN10MB, kSnapLenSmall);
     ASSERT_TRUE(result.has_value());
@@ -114,7 +114,7 @@ TEST_F(PcapFixture, PcapLoopSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Loop Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_loop(good_pcap_, 1, &pcap_handler_func, nullptr);
@@ -127,7 +127,7 @@ TEST_F(PcapFixture, PcapBreakloopSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Breakloop Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_breakloop(good_pcap_);
@@ -140,7 +140,7 @@ TEST_F(PcapFixture, PcapCloseSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Close Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_close(good_pcap_);
@@ -154,7 +154,7 @@ TEST_F(PcapFixture, PcapGeterrSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Geterr Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_geterr(good_pcap_);
@@ -167,7 +167,7 @@ TEST_F(PcapFixture, PcapBreakloopFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Breakloop Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = pcap_->pcap_breakloop(nullptr);
     EXPECT_FALSE(result.has_value());
@@ -179,7 +179,7 @@ TEST_F(PcapFixture, PcapCloseFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Close Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = pcap_->pcap_close(nullptr);
     EXPECT_FALSE(result.has_value());
@@ -191,7 +191,7 @@ TEST_F(PcapFixture, PcapGeterrWithNullPcap)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Geterr With Null Pcap");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = pcap_->pcap_geterr(nullptr);
     EXPECT_FALSE(result.has_value());
@@ -203,7 +203,7 @@ TEST_F(PcapFixture, PcapLoopFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Loop Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     pcap_->pcap_close(good_pcap_);
@@ -218,7 +218,7 @@ TEST_F(PcapFixture, PcapCompileSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     struct bpf_program fp;
@@ -234,7 +234,7 @@ TEST_F(PcapFixture, PcapCompileFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     struct bpf_program fp;
@@ -250,7 +250,7 @@ TEST_F(PcapFixture, PcapCompileFailure2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     bpf_u_int32 net = 0;
@@ -265,7 +265,7 @@ TEST_F(PcapFixture, PcapCompileFailure3)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Compile Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     struct bpf_program fp;
@@ -280,7 +280,7 @@ TEST_F(PcapFixture, PcapSetFilterSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Set Filter Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     struct bpf_program fp;
@@ -298,7 +298,7 @@ TEST_F(PcapFixture, PcapSetFilterFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Set Filter Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     struct bpf_program fp;
@@ -312,7 +312,7 @@ TEST_F(PcapFixture, PcapSetFilterFailure2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Set Filter Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_setfilter(good_pcap_, nullptr);
@@ -325,7 +325,7 @@ TEST_F(PcapFixture, PcapFreeCodeSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Free Code Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     struct bpf_program fp;
@@ -344,7 +344,7 @@ TEST_F(PcapFixture, PcapFreeCodeFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Free Code Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_freecode(nullptr);
@@ -357,7 +357,7 @@ TEST_F(PcapFixture, PcapDumpOpenSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     std::string fname{"/tmp/vlan73.pcap"};
@@ -371,7 +371,7 @@ TEST_F(PcapFixture, PcapDumpOpenFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     std::string fname{"/tmp/vlan73.pcap"};
@@ -385,7 +385,7 @@ TEST_F(PcapFixture, PcapDumpOpenFailure2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_dump_open(good_pcap_, nullptr);
@@ -398,7 +398,7 @@ TEST_F(PcapFixture, PcapDumpOpenFailure3)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Open Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     std::string fname{"root/vlan73.pcap"};
@@ -412,7 +412,7 @@ TEST_F(PcapFixture, PcapDumpSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     std::string fname{"/tmp/vlan73.pcap"};
@@ -442,7 +442,7 @@ TEST_F(PcapFixture, PcapDumpFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     pcap_pkthdr dummyHdr = {};
@@ -467,7 +467,7 @@ TEST_F(PcapFixture, PcapDumpFailure2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     u_char user[5] = {0x11, 0x22, 0x33, 0x44, 0x55};
@@ -488,7 +488,7 @@ TEST_F(PcapFixture, PcapDumpFailure3)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     u_char user[5] = {0x11, 0x22, 0x33, 0x44, 0x55};
@@ -508,7 +508,7 @@ TEST_F(PcapFixture, PcapDumpCloseSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Close Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     std::string fname{"/tmp/vlan73.pcap"};
@@ -523,7 +523,7 @@ TEST_F(PcapFixture, PcapDumpCloseFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pcap Dump Close Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     GetMeADevice();
     auto result = pcap_->pcap_dump_close(nullptr);

--- a/score/os/test/qnx/pci_safety_test.cpp
+++ b/score/os/test/qnx/pci_safety_test.cpp
@@ -34,7 +34,7 @@ TEST_F(PciSafetylTest, pci_device_cfg_rd32_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Cfg Rd Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     std::uint16_t offset{64};
@@ -50,7 +50,7 @@ TEST_F(PciSafetylTest, pci_device_read_did_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Did Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     pci_did_t did;
@@ -65,7 +65,7 @@ TEST_F(PciSafetylTest, pci_device_read_vid_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Vid Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     pci_vid_t vid;

--- a/score/os/test/qnx/pci_test.cpp
+++ b/score/os/test/qnx/pci_test.cpp
@@ -39,7 +39,7 @@ TEST_F(PciTest, pci_device_read_cmd_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Cmd Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     pci_cmd_t cmd;
@@ -54,7 +54,7 @@ TEST_F(PciTest, pci_device_read_cmd_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Cmd Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_cmd_t cmd;
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
@@ -68,7 +68,7 @@ TEST_F(PciTest, pci_device_attach_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Attach Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     std::memset(&bdf, 0, sizeof(pci_bdf_t));
@@ -82,7 +82,7 @@ TEST_F(PciTest, pci_device_read_ba_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Ba Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_devhdl_t hdl;
     std::memset(&hdl, 0, sizeof(pci_bdf_t));
@@ -96,7 +96,7 @@ TEST_F(PciTest, pci_device_read_ba_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Ba Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
     auto attach_res = pci_.pci_device_attach(bdf, pci_attachFlags_MULTI_OWNER);
@@ -118,7 +118,7 @@ TEST_F(PciTest, pci_device_cfg_rd32_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Cfg Rd Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     std::uint16_t offset{64};
@@ -134,7 +134,7 @@ TEST_F(PciTest, pci_device_cfg_rd32_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Cfg Rd Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::uint16_t offset{64U};
     std::uint32_t val = 0U;
@@ -150,7 +150,7 @@ TEST_F(PciTest, pci_device_read_did_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Did Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     pci_did_t did;
@@ -165,7 +165,7 @@ TEST_F(PciTest, pci_device_read_did_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Did Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_did_t did;
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
@@ -179,7 +179,7 @@ TEST_F(PciTest, pci_device_read_vid_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Vid Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf;
     pci_vid_t vid;
@@ -194,7 +194,7 @@ TEST_F(PciTest, pci_device_read_vid_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Read Vid Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_vid_t vid;
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
@@ -208,7 +208,7 @@ TEST_F(PciTest, pci_device_detach_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Detach Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_bdf_t bdf = pci_.pci_bdf(bus_, dev_, func_);
     auto attach_res = pci_.pci_device_attach(bdf, pci_attachFlags_MULTI_OWNER);
@@ -224,7 +224,7 @@ TEST_F(PciTest, pci_device_detach_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Detach Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_devhdl_t hdl = static_cast<pci_devhdl_t>(0);  // Invalid handle
     EXPECT_FALSE(pci_.pci_device_detach(hdl).has_value());
@@ -236,7 +236,7 @@ TEST_F(PciTest, pci_device_find_succeed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Find Succeed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_vid_t vid = 0xFFFF;
     pci_did_t did = 0xFFFF;
@@ -250,7 +250,7 @@ TEST_F(PciTest, pci_device_find_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Pci Device Find Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pci_vid_t vid = 0x1234;
     pci_did_t did = 0x5678;

--- a/score/os/test/qnx/procmgr_test.cpp
+++ b/score/os/test/qnx/procmgr_test.cpp
@@ -43,7 +43,7 @@ TEST_F(ProcMgrMockTest, procmgr_ability)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Ability");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(procmgrmock, procmgr_ability(kCurrentPid, PROCMGR_AID_EOL));
     score::os::ProcMgr::instance().procmgr_ability(kCurrentPid, PROCMGR_AID_EOL);
@@ -55,7 +55,7 @@ TEST(ProcMgrTest, procmgr_subrange_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Subrange Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_FALSE(score::os::ProcMgr::instance().procmgr_ability(kCurrentPid, PROCMGR_AID_EOL | PROCMGR_AOP_SUBRANGE));
 }
@@ -66,7 +66,7 @@ TEST(ProcMgrTest, procmgr_generic_invalid_pid_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Generic Invalid Pid Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_FALSE(score::os::ProcMgr::instance().procmgr_ability(kInvalidPid, PROCMGR_AID_EOL));
 }
@@ -77,7 +77,7 @@ TEST(ProcMgrTest, procmgr_invalid_ability_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Invalid Ability Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_FALSE(score::os::ProcMgr::instance().procmgr_ability(
         kCurrentPid, PROCMGR_ADN_ROOT | PROCMGR_AOP_ALLOW | PROCMGR_AID_PUBLIC_CHANNEL | PROCMGR_AID_UNCREATED));
@@ -89,7 +89,7 @@ TEST(ProcMgrTest, procmgr_generic_succeeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Generic Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_TRUE(score::os::ProcMgr::instance().procmgr_ability(kCurrentPid,
                                                              PROCMGR_ADN_ROOT | PROCMGR_AOP_ALLOW | PROCMGR_AID_EOL));
@@ -101,7 +101,7 @@ TEST(ProcMgrTest, procmgr_specific_succeeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Specific Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_TRUE(score::os::ProcMgr::instance().procmgr_ability(
         kCurrentPid, PROCMGR_ADN_ROOT | PROCMGR_AOP_ALLOW | PROCMGR_AID_PUBLIC_CHANNEL));
@@ -113,7 +113,7 @@ TEST(ProcMgrTest, procmgr_ability_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Ability Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = score::os::ProcMgr::instance().procmgr_ability(
         kCurrentPid,
@@ -131,7 +131,7 @@ TEST(ProcMgrTest, procmgr_ability_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Ability Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result =
         score::os::ProcMgr::instance().procmgr_ability(kInvalidPid, PROCMGR_AID_EOL, 0U, 0U, 0U, PROCMGR_AID_EOL);
@@ -145,7 +145,7 @@ TEST(ProcMgrTest, procmgr_daemon_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Procmgr Daemon Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = score::os::ProcMgr::instance().procmgr_daemon(
         kCurrentPid,

--- a/score/os/test/qnx/pthread_test.cpp
+++ b/score/os/test/qnx/pthread_test.cpp
@@ -24,7 +24,7 @@ TEST(PthreadNameTest, GetNameFailsWhenBufferSizeTooBig)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Get Name Fails When Buffer Size Too Big");
     RecordProperty("TestingTechnique", "T-REQ");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t size_too_big = static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max()) + 1;
     char buffer[4096];  // fails to allocate buffer with `size_too_big` amount on stack. Follow up operation which
@@ -42,7 +42,7 @@ TEST(QnxPthreadTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Pthread::Default(memory_resource);

--- a/score/os/test/qnx/resmgr_test.cpp
+++ b/score/os/test/qnx/resmgr_test.cpp
@@ -23,7 +23,7 @@ TEST(ResMgrTest, ResMgrMsgWriteFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Res Mgr Msg Write Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::ResMgrImpl resmgr;
     resmgr_context_t ctp;

--- a/score/os/test/qnx/secpol_test.cpp
+++ b/score/os/test/qnx/secpol_test.cpp
@@ -29,7 +29,7 @@ TEST(SecpolTest, InstanceCall)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Instance Call");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // check whether instance() returns injection
     score::os::qnx::details::SecpolImpl mock{};
@@ -61,7 +61,7 @@ TEST_F(SecpolFixture, secpol_openOpenNullPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Open Open Null Path");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* const path{nullptr};
 
@@ -77,7 +77,7 @@ TEST_F(SecpolFixture, secpol_openOpenDoubleCallFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Open Open Double Call Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* const path{nullptr};
 
@@ -96,7 +96,7 @@ TEST_F(SecpolFixture, secpol_posix_spawnattr_settypeid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Posix Spawnattr Settypeid");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr{};
     secpol_file_t* handle_null{nullptr};
@@ -113,7 +113,7 @@ TEST_F(SecpolFixture, secpol_transition_type)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Secpol Transition Type");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     secpol_file_t* handle{nullptr};
     const char* const name{nullptr};

--- a/score/os/test/qnx/sigevent_qnx_test.cpp
+++ b/score/os/test/qnx/sigevent_qnx_test.cpp
@@ -44,7 +44,7 @@ TEST_F(SigEventQnxTest, SetUnblock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set unblock");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     signal_event_qnx_->SetUnblock();
 
@@ -58,7 +58,7 @@ TEST_F(SigEventQnxTest, SetPulse)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set pulse");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     signal_event_qnx_->SetPulse(kConnectionId, kPriority, kCode, kSignalEventValue);
 
@@ -76,7 +76,7 @@ TEST_F(SigEventQnxTest, SetSignalThread)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set signal thread");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     signal_event_qnx_->SetSignalThread(kSignalNumber, kSignalEventValue, kThreadId);
 
@@ -92,7 +92,7 @@ TEST_F(SigEventQnxTest, SetSignalCode)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set signal code");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     signal_event_qnx_->SetSignalCode(kSignalNumber, kSignalEventValue, kSignalCode);
 
@@ -109,7 +109,7 @@ TEST_F(SigEventQnxTest, SetMemory)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set memory");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     volatile std::uint32_t dummy_mem = 0;
     constexpr std::int32_t kSize = 4;
@@ -127,7 +127,7 @@ TEST_F(SigEventQnxTest, SetInterrupt)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set interrupt");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     signal_event_qnx_->SetInterrupt();
 
@@ -141,7 +141,7 @@ TEST_F(SigEventQnxTest, SetSignalEventValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest set signal event value");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SigEventErrorCodeDomain errorDomain;
     std::variant<int, void*> signal_event_value;
@@ -176,7 +176,7 @@ TEST_F(SigEventQnxTest, Reset)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest reset sigevent");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = signal_event_qnx_->SetNotificationType(SigEvent::NotificationType::kThread);
     EXPECT_TRUE(result.has_value());
@@ -207,7 +207,7 @@ TEST_F(SigEventQnxTest, Getter)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest getters sigevent");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto&& const_ref = signal_event_qnx_->GetSigevent();
 
@@ -220,7 +220,7 @@ TEST_F(SigEventQnxTest, ModifySigevent)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventQnxTest modify sigevent");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     signal_event_qnx_->ModifySigevent([](sigevent& raw_sigevent) {
         raw_sigevent.sigev_notify = SIGEV_SIGNAL;

--- a/score/os/test/qnx/slog2_test.cpp
+++ b/score/os/test/qnx/slog2_test.cpp
@@ -37,7 +37,7 @@ TEST_F(Slog2ImplFixture, slog2_registerReturnsErrorIfSetNumBuffersToZero)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog Register returns Error If Set Num Buffers To Zero");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     slog2_buffer_set_config_t buffer_config{};
     slog2_buffer_t buffer_handle[2]{};
@@ -62,7 +62,7 @@ TEST_F(Slog2ImplFixture, slog2SetVerbosityFailsWhenInvalidVerbosity)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog Set Verbosity Fails When Invalid Verbosity");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr uint8_t invalid_level = INT8_MAX;
     slog2_buffer_t buffer_handle{};
@@ -76,7 +76,7 @@ TEST_F(Slog2ImplFixture, slog2cReturnsErrorIfNotRegisteredSlog2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog C returns Error If Not Registered Slog");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     slog2_buffer_t buffer_handle[1]{};
     EXPECT_FALSE(unit_->slog2c(buffer_handle[0], 0, SLOG2_INFO, "fails to log"));
@@ -88,7 +88,7 @@ TEST_F(Slog2ImplFixture, slog2fReturnsErrorIfNotRegisteredSlog2)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Slog F returns Error If Not Registered Slog");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     slog2_buffer_t buffer_handle[1]{};
     EXPECT_FALSE(unit_->slog2f(buffer_handle[0], 0, SLOG2_INFO, "formmated: %s", "fails to log"));
@@ -100,7 +100,7 @@ TEST_F(Slog2ImplFixture, RegisterAndLogFlow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Register And Log Flow");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     /*
         This test registers to buffer within slog2. Afterwards trying to log with different severity level
@@ -152,7 +152,7 @@ TEST(Slog2Test, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PMR Default Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::qnx::Slog2::Default(memory_resource);

--- a/score/os/test/qnx/sysctl_test.cpp
+++ b/score/os/test/qnx/sysctl_test.cpp
@@ -50,7 +50,7 @@ TEST_F(SysctlTestMock, TestFunction_sysctl)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctl");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t RETURN_LENGTH = 100;
     std::int32_t sys_name[6] = {1, 2, 3, 4, 5, 6};
@@ -90,7 +90,7 @@ TEST_F(SysctlTestMock, TestFunction_sysctlbyname)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctlbyname");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::size_t RETURN_LENGTH = 100;
     const char* sys_name = "some.dummy.parameter";
@@ -127,7 +127,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctl_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctl Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::array<std::int32_t, 2> sys_name = {
         CTL_KERN,
@@ -147,7 +147,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctl_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctl Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::array<std::int32_t, 6> sys_name = {1, 2, 3, 4, 5, 6};
     std::array<std::int8_t, 1> buf_small{};
@@ -162,7 +162,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlbyname_Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctlbyname Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::size_t sys_len{};
 
@@ -181,7 +181,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlbyname_Failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Function sysctlbyname Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto res = instance_.sysctlbyname("", nullptr, nullptr, nullptr, 0);
     ASSERT_FALSE(res.has_value());
@@ -193,7 +193,7 @@ TEST_F(SysctlTestMock, TestFunction_sysctlnametomib)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "Test Function sysctlnametomib");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* sys_name = "some.dummy.parameter";
     int mib[4] = {0};
@@ -223,7 +223,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlnametomib_Success)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "Test Function sysctlnametomib Success");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     int mib[4] = {0};
     size_t mib_len = 4;
@@ -239,7 +239,7 @@ TEST_F(SysctlImplTest, TestFunction_sysctlnametomib_Failure)
     RecordProperty("ASIL", "QM");
     RecordProperty("Description", "Test Function sysctlnametomib Failure");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     int mib[4] = {0};
     size_t mib_len = 4;

--- a/score/os/test/qnx/thread_ctl_test.cpp
+++ b/score/os/test/qnx/thread_ctl_test.cpp
@@ -41,7 +41,7 @@ TEST_F(ThreadCtlTest, succeed_reading_current_thread_name)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Succeed Reading Current Thread Name");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const pid_t pid{0};
     const int32_t tid{0};
@@ -59,7 +59,7 @@ TEST_F(ThreadCtlTest, fails_on_invalid_pid_tid_combination)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Fails On Invalid Pid Tid Combination");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const pid_t pid{1};
     const int32_t tid{0};

--- a/score/os/test/qnx/timer_test.cpp
+++ b/score/os/test/qnx/timer_test.cpp
@@ -47,7 +47,7 @@ TEST_F(TimerTest, timer_create_succeed_for_realtime_clock_nullptr_event)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Create Succeed For Realtime Clock Nullptr Event");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = timer_->TimerCreate(CLOCK_REALTIME, nullptr);
     EXPECT_TRUE(result.has_value());
@@ -59,7 +59,7 @@ TEST_F(TimerTest, timer_create_succeed_for_realtime_clock_real_struct_event)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Create Succeed For Realtime Clock Real Struct Event");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = timer_->TimerCreate(CLOCK_REALTIME, &event_);
     EXPECT_TRUE(result.has_value());
@@ -71,7 +71,7 @@ TEST_F(TimerTest, timer_create_fail_for_invalid_clock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Create Fail For Invalid Clock");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = timer_->TimerCreate(kInvalidId, &event_);
 
@@ -85,7 +85,7 @@ TEST_F(TimerTest, timer_settime_succeed_for_realtime_clock_nullptr_event)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Settime Succeed For Realtime Clock Nullptr Event");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto timer_id = timer_->TimerCreate(CLOCK_REALTIME, nullptr);
     const auto result = timer_->TimerSettime(timer_id.value(), TIMER_ABSTIME, &expiration_time_, nullptr);
@@ -100,7 +100,7 @@ TEST_F(TimerTest, timer_settime_fail_for_invalid_clock_id)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Settime Fail For Invalid Clock Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = timer_->TimerSettime(kInvalidId, TIMER_ABSTIME, &expiration_time_, nullptr);
 
@@ -114,7 +114,7 @@ TEST_F(TimerTest, timer_destroy_succeed_for_created_monotonic_clock_timer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Destroy Succeed For Created Monotonic Clock Timer");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto timer_id = timer_->TimerCreate(CLOCK_MONOTONIC, nullptr);
     const auto result = timer_->TimerDestroy(timer_id.value());
@@ -129,7 +129,7 @@ TEST_F(TimerTest, timer_destroy_fail_for_invalid_clock_id)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Destroy Fail For Invalid Clock Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = timer_->TimerDestroy(kInvalidId);
 
@@ -143,7 +143,7 @@ TEST_F(TimerTest, timer_settime_fail_after_timer_destroy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Timer Settime Fail After Timer Destroy");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto timer_id = timer_->TimerCreate(CLOCK_REALTIME, nullptr);
     timer_->TimerDestroy(timer_id.value());

--- a/score/os/test/qnx/unistd_test.cpp
+++ b/score/os/test/qnx/unistd_test.cpp
@@ -70,7 +70,7 @@ TEST_F(QnxUnistdImplFixture, SetgroupspidReturnsErrorIfPassInvalidParams)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set groups pid returns Error If Pass Invalid Params");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->setgroupspid(-1, nullptr, 0);
     ASSERT_FALSE(val.has_value());
@@ -82,7 +82,7 @@ TEST_F(QnxUnistdImplFixture, SetgroupspidNewGroupAdded)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set groups pid New Group Added");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ForkAndExpectTrue([]() noexcept {
         score::os::qnx::QnxUnistdImpl unistd_inst{};
@@ -136,7 +136,7 @@ TEST_F(QnxUnistdFixture, SetuidChangesUidIfPassValidId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set uid Changes Uid If Pass Valid Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_EQ(::getuid(), 0);
 
@@ -155,7 +155,7 @@ TEST_F(QnxUnistdFixture, SetGidSetsGidIfPassValidId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test Set Gid Sets Gid If Pass Valid Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_EQ(::getuid(), 0);
 

--- a/score/os/test/sched_test.cpp
+++ b/score/os/test/sched_test.cpp
@@ -39,7 +39,7 @@ TEST_F(SchedImplTest, sched_setparam_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setparam_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param set_params;
     set_params.sched_priority = 2;
@@ -56,7 +56,7 @@ TEST_F(SchedImplTest, sched_getparam_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getparam_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param set_params;
     set_params.sched_priority = 2;
@@ -73,7 +73,7 @@ TEST_F(SchedImplTest, sched_getparam_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getparam_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(sched_.sched_getparam(kInvalidPid, nullptr).has_value());
 }
@@ -84,7 +84,7 @@ TEST_F(SchedImplTest, sched_setscheduler_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setscheduler_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param param;
     param.sched_priority = 50;
@@ -98,7 +98,7 @@ TEST_F(SchedImplTest, sched_setscheduler_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setscheduler_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param params;
     params.sched_priority = 4;
@@ -115,7 +115,7 @@ TEST_F(SchedImplTest, sched_getscheduler_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getscheduler_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param params;
     params.sched_priority = 4;
@@ -132,7 +132,7 @@ TEST_F(SchedImplTest, sched_getscheduler_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_getscheduler_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(sched_.sched_getscheduler(kInvalidPid).has_value());
 }
@@ -143,7 +143,7 @@ TEST_F(SchedImplTest, sched_setparam_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_setparam_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(sched_.sched_setparam(kInvalidPid, nullptr).has_value());
 }
@@ -154,7 +154,7 @@ TEST_F(SchedImplTest, sched_yield_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_yield_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_TRUE(sched_.sched_yield().has_value());
 }
@@ -165,7 +165,7 @@ TEST_F(SchedImplTest, sched_rr_get_interval_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_rr_get_interval_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec ts;
     const auto result = sched_.sched_rr_get_interval(kCurrentPid, &ts);
@@ -180,7 +180,7 @@ TEST_F(SchedImplTest, sched_rr_get_interval_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_rr_get_interval_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(sched_.sched_rr_get_interval(kInvalidPid, nullptr).has_value());
 }
@@ -191,7 +191,7 @@ TEST_F(SchedImplTest, sched_get_priority_max_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_max_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto prio_max = sched_.sched_get_priority_max(kPolicy);
     ASSERT_TRUE(prio_max.has_value());
@@ -208,7 +208,7 @@ TEST_F(SchedImplTest, sched_get_priority_min_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_min_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto prio_min = sched_.sched_get_priority_min(kPolicy);
     ASSERT_TRUE(prio_min.has_value());
@@ -225,7 +225,7 @@ TEST_F(SchedImplTest, sched_get_priority_min_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_min_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(sched_.sched_get_priority_min(kInvalidPolicy).has_value());
 }
@@ -236,7 +236,7 @@ TEST_F(SchedImplTest, sched_get_priority_max_fails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_max_fails");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(sched_.sched_get_priority_max(kInvalidPolicy).has_value());
 }
@@ -247,7 +247,7 @@ TEST(SchedTest, CanGetInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedTest Can Get Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_NO_FATAL_FAILURE(Sched::instance());
 }
@@ -259,7 +259,7 @@ TEST_F(SchedImplTest, sched_get_priority_adjust_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SchedImplTest sched_get_priority_adjust_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t priority = 3;
     constexpr std::int32_t adjust = 4;

--- a/score/os/test/select_test.cpp
+++ b/score/os/test/select_test.cpp
@@ -32,7 +32,7 @@ TEST(SelectTest, selectPass)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SelectTest select Pass");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::SelectImpl select;
     fd_set fds;
@@ -51,7 +51,7 @@ TEST(SelectTest, selectPassInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SelectTest select Pass Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Select& select = score::os::Select::instance();
     fd_set fds;

--- a/score/os/test/semaphore_test.cpp
+++ b/score/os/test/semaphore_test.cpp
@@ -46,7 +46,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemOpen)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Open");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto ret_open_create = unit_.sem_open(m_name_.c_str(),
                                                 Semaphore::OpenFlag::kCreate,
@@ -69,7 +69,7 @@ TEST_F(SemaphoreTestFixture, FailureSemOpen)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Failure Sem Open");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* invalid_path = "/invalid_path";
     const auto ret =
@@ -83,7 +83,7 @@ TEST_F(SemaphoreTestFixture, FailureSemOpenWithoutCreateFlag)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Failure Sem Open Without Create Flag");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* invalid_path = "/invalid_path";
     const auto ret = unit_.sem_open(invalid_path, Semaphore::OpenFlag::kExclusive);
@@ -97,7 +97,7 @@ TEST_F(SemaphoreTestFixture, SuccessGetValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Get Value");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t sval;
     const std::int32_t pshared{0};
@@ -118,7 +118,7 @@ TEST_F(SemaphoreTestFixture, FailureSemPost)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Failure Sem Post");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto valid_sem =
         unit_.sem_open(m_name_.c_str(), Semaphore::OpenFlag::kCreate, Semaphore::ModeFlag::kReadUser, value_);
@@ -139,7 +139,7 @@ TEST_F(SemaphoreTestFixture, SuccessTimedWait)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Timed Wait");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     timespec abs_time{};
     abs_time.tv_sec = 5;
@@ -158,7 +158,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemOpenAllModes)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Open All Modes");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::vector<score::os::Semaphore::ModeFlag> mode_vector = {Semaphore::ModeFlag::kReadUser,
                                                              Semaphore::ModeFlag::kWriteUser,
@@ -187,7 +187,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemWait)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Wait");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto sem = ::sem_open(m_name_.c_str(), O_CREAT, S_IRUSR, value_);
     ASSERT_NE(sem, SEM_FAILED);
@@ -212,7 +212,7 @@ TEST_F(SemaphoreTestFixture, SuccessSemPost)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Sem Post");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto sem = ::sem_open(m_name_.c_str(), O_CREAT, S_IRUSR, value_);
     ASSERT_NE(sem, SEM_FAILED);
@@ -237,7 +237,7 @@ TEST_F(SemaphoreTestFixture, SuccessTimedWaitFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SemaphoreTestFixture Success Timed Wait Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     timespec abs_time{0, -1};
     const auto sem = ::sem_open(m_name_.c_str(), O_CREAT, S_IRUSR, value_);
@@ -253,7 +253,7 @@ TEST(Semaphore, get_instance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Semaphore get_instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_NO_FATAL_FAILURE(Semaphore::instance());
 }

--- a/score/os/test/sigevent_test.cpp
+++ b/score/os/test/sigevent_test.cpp
@@ -35,7 +35,7 @@ TEST_F(SigEventTest, SetNotificationType)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set notification types");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto none_notification = signal_event_->SetNotificationType(SigEvent::NotificationType::kNone);
     ASSERT_TRUE(none_notification.has_value());
@@ -66,7 +66,7 @@ TEST_F(SigEventTest, SetSignalNumber)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set signal number");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SigEventErrorCodeDomain errorDomain;
 
@@ -93,7 +93,7 @@ TEST_F(SigEventTest, SetSignalEventValue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set signal event value");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SigEventErrorCodeDomain errorDomain;
     std::variant<int, void*> signal_event_value;
@@ -133,7 +133,7 @@ TEST_F(SigEventTest, SetThreadCallback)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set thread callback");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SigEventErrorCodeDomain errorDomain;
 
@@ -167,7 +167,7 @@ TEST_F(SigEventTest, SetThreadAttributes)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest set thread attributes");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SigEventErrorCodeDomain errorDomain;
 
@@ -194,7 +194,7 @@ TEST_F(SigEventTest, Reset)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest reset sigevent");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto result = signal_event_->SetNotificationType(SigEvent::NotificationType::kThread);
     EXPECT_TRUE(result.has_value());
@@ -225,7 +225,7 @@ TEST_F(SigEventTest, ModifySigevent)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest modify sigevent positive and negative scenarios");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t kTestSignalValue = 42;
 
@@ -247,7 +247,7 @@ TEST_F(SigEventTest, Getter)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest getter sigevent");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto&& const_ref = signal_event_->GetSigevent();
 
@@ -260,7 +260,7 @@ TEST_F(SigEventTest, DefaultError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SigEventTest default error sigevent");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SigEventErrorCodeDomain errorDomain;
     auto error_msg = errorDomain.MessageFor(static_cast<score::result::ErrorCode>(9999));

--- a/score/os/test/spawn_test.cpp
+++ b/score/os/test/spawn_test.cpp
@@ -47,7 +47,7 @@ TEST_F(SpawnTest, posix_spawnattr_setflags_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setflags_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int16_t set_flags{POSIX_SPAWN_SETSIGDEF};
 
@@ -66,7 +66,7 @@ TEST_F(SpawnTest, posix_spawnattr_getflags_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getflags_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int16_t set_flags{POSIX_SPAWN_SETSIGDEF};
     ASSERT_EQ(::posix_spawnattr_setflags(&attr, set_flags), 0);
@@ -84,7 +84,7 @@ TEST(SpawnImpl, posix_spawnattr_getflags_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getflags_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int16_t set_flags{POSIX_SPAWN_SETSIGDEF};
     posix_spawnattr_t attr;
@@ -105,7 +105,7 @@ TEST_F(SpawnTest, posix_spawnattr_setflags_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setflags_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto invalid_flag{-1};
     const auto result = score::os::Spawn::instance().posix_spawnattr_setflags(&attr, invalid_flag);
@@ -122,7 +122,7 @@ TEST_F(SpawnTest, posix_spawnattr_sigsetdefault_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_sigsetdefault_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -144,7 +144,7 @@ TEST_F(SpawnTest, posix_spawnattr_getsigdefault_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getsigdefault_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -165,7 +165,7 @@ TEST(SpawnImpl, posix_spawnattr_setsigdefault_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setsigdefault_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -185,7 +185,7 @@ TEST(SpawnImpl, posix_spawnattr_getsigdefault_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getsigdefault_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -209,7 +209,7 @@ TEST_F(SpawnTest, posix_spawnattr_setsigmask_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setsigmask_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -231,7 +231,7 @@ TEST_F(SpawnTest, posix_spawnattr_getsigmask_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getsigmask_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -252,7 +252,7 @@ TEST(SpawnImpl, posix_spawnattr_setsigmask_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setsigmask_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -272,7 +272,7 @@ TEST(SpawnImpl, posix_spawnattr_getsigmask_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getsigmask_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -296,7 +296,7 @@ TEST_F(SpawnTest, posix_spawnattr_setpgroup_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setpgroup_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{4};
     ASSERT_EQ(::posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP), 0);
@@ -316,7 +316,7 @@ TEST_F(SpawnTest, posix_spawnattr_getpgroup_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getpgroup_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{4};
     ASSERT_TRUE(score::os::Spawn::instance().posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP).has_value());
@@ -335,7 +335,7 @@ TEST(SpawnImpl, posix_spawnattr_setpgroup_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setpgroup_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{4};
     posix_spawnattr_t attr;
@@ -352,7 +352,7 @@ TEST(SpawnImpl, posix_spawnattr_getpgroup_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getpgroup_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -369,7 +369,7 @@ TEST_F(SpawnTest, posix_spawnattr_setschedparam_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setschedparam_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param set_param;
     set_param.sched_priority = 4;
@@ -388,7 +388,7 @@ TEST_F(SpawnTest, posix_spawnattr_getschedparam_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getschedparam_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct sched_param set_param;
     set_param.sched_priority = 4;
@@ -407,7 +407,7 @@ TEST(SpawnImpl, posix_spawnattr_setschedparam_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setschedparam_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -425,7 +425,7 @@ TEST(SpawnImpl, posix_spawnattr_getschedparam_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getschedparam_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -442,7 +442,7 @@ TEST_F(SpawnTest, posix_spawnattr_setschedpolicy_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setschedpolicy_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t set_policy{1};
     ASSERT_EQ(::posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSCHEDULER), 0);
@@ -462,7 +462,7 @@ TEST_F(SpawnTest, posix_spawnattr_getschedpolicy_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getschedpolicy_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t set_policy{1};
     ASSERT_EQ(::posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSCHEDULER), 0);
@@ -481,7 +481,7 @@ TEST(SpawnImpl, posix_spawnattr_getschedpolicy_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getschedpolicy_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t set_policy{1};
     posix_spawnattr_t attr;
@@ -502,7 +502,7 @@ TEST_F(SpawnTest, posix_spawnattr_setschedpolicy_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setschedpolicy_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t get_policy{};
     ASSERT_EQ(::posix_spawnattr_getschedpolicy(&attr, &get_policy), 0);
@@ -519,7 +519,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_init_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_init_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     const auto result = score::os::Spawn::instance().posix_spawn_file_actions_init(&file_actions);
@@ -535,7 +535,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_destroy_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_destroy_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     ASSERT_EQ(::posix_spawn_file_actions_init(&file_actions), 0);
@@ -551,7 +551,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addclose_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addclose_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     ASSERT_EQ(::posix_spawn_file_actions_init(&file_actions), 0);
@@ -565,7 +565,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addopen_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addopen_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     ASSERT_EQ(::posix_spawn_file_actions_init(&file_actions), 0);
@@ -587,7 +587,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addclose_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addclose_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     ASSERT_EQ(::posix_spawn_file_actions_init(&file_actions), 0);
@@ -606,7 +606,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_addopen_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_addopen_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     const std::int32_t new_fd{3};
@@ -623,7 +623,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_adddup2_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_adddup2_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     ASSERT_EQ(::posix_spawn_file_actions_init(&file_actions), 0);
@@ -645,7 +645,7 @@ TEST(SpawnImpl, posix_spawn_file_actions_adddup2_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawn_file_actions_adddup2_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawn_file_actions_t file_actions;
     const std::int32_t filedes{};
@@ -660,7 +660,7 @@ TEST_F(SpawnTest, Spawn_succcess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawn_succcess");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{0};
     char path[] = "/bin/ls";
@@ -685,7 +685,7 @@ TEST_F(SpawnTest, Spawn_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawn_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{-1};
     char path[] = "/bin/ls";
@@ -704,7 +704,7 @@ TEST_F(SpawnTest, Spawnp_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawnp_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{0};
     char path[] = "/bin/ls";
@@ -729,7 +729,7 @@ TEST_F(SpawnTest, Spawnp_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest Spawnp_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     pid_t pid{-1};
     char path[] = "/bin/ls";
@@ -749,7 +749,7 @@ TEST_F(SpawnTest, posix_spawnattr_setxflags_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setxflags_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_flags{POSIX_SPAWN_SETSIGMASK};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_setxflags(&attr, set_flags);
@@ -767,7 +767,7 @@ TEST_F(SpawnTest, posix_spawnattr_getxflags_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getxflags_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_flags{POSIX_SPAWN_SETSIGMASK};
     ASSERT_EQ(::posix_spawnattr_setxflags(&attr, set_flags), 0);
@@ -785,7 +785,7 @@ TEST(SpawnImpl, posix_spawnattr_setxflags_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setxflags_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_flags{POSIX_SPAWN_SETSIGMASK};
 
@@ -803,7 +803,7 @@ TEST(SpawnImpl, posix_spawnattr_getxflags_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getxflags_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -820,7 +820,7 @@ TEST_F(SpawnTest, posix_spawnattr_getrunmask_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getrunmask_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_runmask{1};
     ASSERT_EQ(::posix_spawnattr_setrunmask(&attr, set_runmask), 0);
@@ -838,7 +838,7 @@ TEST_F(SpawnTest, posix_spawnattr_setrunmask_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setrunmask_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_runmask{1};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_setrunmask(&attr, set_runmask);
@@ -856,7 +856,7 @@ TEST(SpawnImpl, posix_spawnattr_setrunmask_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setrunmask_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_runmask{1};
 
@@ -874,7 +874,7 @@ TEST(SpawnImpl, posix_spawnattr_getrunmask_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getrunmask_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -891,7 +891,7 @@ TEST_F(SpawnTest, posix_spawnattr_setsigignore_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setsigignore_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -916,7 +916,7 @@ TEST_F(SpawnTest, posix_spawnattr_getsigignore_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getsigignore_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t set_sigset;
     ::sigemptyset(&set_sigset);
@@ -940,7 +940,7 @@ TEST(SpawnImpl, posix_spawnattr_setsigignore_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setsigignore_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -959,7 +959,7 @@ TEST(SpawnImpl, posix_spawnattr_getsigignore_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getsigignore_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -977,7 +977,7 @@ TEST_F(SpawnTest, posix_spawnattr_setstackmax_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setstackmax_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_size{1};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_setstackmax(&attr, set_size);
@@ -995,7 +995,7 @@ TEST_F(SpawnTest, posix_spawnattr_getstackmax_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getstackmax_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_size{1};
     ASSERT_EQ(::posix_spawnattr_setstackmax(&attr, set_size), 0);
@@ -1013,7 +1013,7 @@ TEST(SpawnImpl, posix_spawnattr_setstackmax_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setstackmax_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1030,7 +1030,7 @@ TEST(SpawnImpl, posix_spawnattr_getstackmax_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getstackmax_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1049,7 +1049,7 @@ TEST_F(SpawnTest, posix_spawnattr_setnode_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setnode_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_node{1};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_setnode(&attr, set_node);
@@ -1067,7 +1067,7 @@ TEST_F(SpawnTest, posix_spawnattr_getnode_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getnode_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_node{1};
     ASSERT_EQ(::posix_spawnattr_setnode(&attr, set_node), 0);
@@ -1085,7 +1085,7 @@ TEST(SpawnImpl, posix_spawnattr_setnode_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setnode_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1102,7 +1102,7 @@ TEST(SpawnImpl, posix_spawnattr_getnode_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getnode_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1119,7 +1119,7 @@ TEST_F(SpawnTest, posix_spawnattr_setcred_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setcred_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const uid_t set_uid{1};
     const gid_t set_gid{1};
@@ -1140,7 +1140,7 @@ TEST_F(SpawnTest, posix_spawnattr_getcred_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getcred_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const uid_t set_uid{1};
     const gid_t set_gid{1};
@@ -1161,7 +1161,7 @@ TEST(SpawnImpl, posix_spawnattr_setcred_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setcred_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1179,7 +1179,7 @@ TEST(SpawnImpl, posix_spawnattr_getcred_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getcred_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     const uid_t set_uid{1};
@@ -1202,7 +1202,7 @@ TEST_F(SpawnTest, posix_spawnattr_settypeid_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_settypeid_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_type_id{1};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_settypeid(&attr, set_type_id);
@@ -1220,7 +1220,7 @@ TEST_F(SpawnTest, posix_spawnattr_gettypeid_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_gettypeid_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_type_id{1};
     ASSERT_EQ(::posix_spawnattr_settypeid(&attr, set_type_id), 0);
@@ -1238,7 +1238,7 @@ TEST(SpawnImpl, posix_spawnattr_settypeid_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_settypeid_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1255,7 +1255,7 @@ TEST(SpawnImpl, posix_spawnattr_gettypeid_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_gettypeid_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     const std::uint32_t set_type_id{1};
@@ -1275,7 +1275,7 @@ TEST_F(SpawnTest, posix_spawnattr_setasid_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setasid_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t set_asid{1};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_setasid(&attr, set_asid);
@@ -1289,7 +1289,7 @@ TEST(SpawnImpl, posix_spawnattr_setasid_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setasid_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1306,7 +1306,7 @@ TEST_F(SpawnTest, posix_spawnattr_setaslr_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setaslr_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const posix_spawnattr_aslr_t set_aslr = {};
     const auto set_result = score::os::Spawn::instance().posix_spawnattr_setaslr(&attr, set_aslr);
@@ -1324,7 +1324,7 @@ TEST_F(SpawnTest, posix_spawnattr_getaslr_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_getaslr_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const posix_spawnattr_aslr_t set_aslr = {};
     ASSERT_EQ(::posix_spawnattr_setaslr(&attr, set_aslr), 0);
@@ -1342,7 +1342,7 @@ TEST(SpawnImpl, posix_spawnattr_setaslr_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setaslr_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1359,7 +1359,7 @@ TEST(SpawnImpl, posix_spawnattr_getaslr_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_getaslr_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     const posix_spawnattr_aslr_t set_aslr = {};
@@ -1378,7 +1378,7 @@ TEST_F(SpawnTest, posix_spawnattr_setcwd_np_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest posix_spawnattr_setcwd_np_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::int32_t dirfd{1};
     const auto result = score::os::Spawn::instance().posix_spawnattr_setcwd_np(&attr, dirfd);
@@ -1392,7 +1392,7 @@ TEST(SpawnImpl, posix_spawnattr_setcwd_np_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnImpl posix_spawnattr_setcwd_np_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     posix_spawnattr_t attr;
     ASSERT_EQ(::posix_spawnattr_init(&attr), 0);
@@ -1409,7 +1409,7 @@ TEST_F(SpawnTest, spawn_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawn_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t fd_count{0};
     const std::int32_t* fd_map{nullptr};
@@ -1432,7 +1432,7 @@ TEST_F(SpawnTest, spawn_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawn_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char path[] = "/nonexistent/executable";
     std::int32_t fd_count{0};
@@ -1451,7 +1451,7 @@ TEST_F(SpawnTest, spawnp_success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawnp_success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t fd_count{0};
     const std::int32_t* fd_map{nullptr};
@@ -1474,7 +1474,7 @@ TEST_F(SpawnTest, spawnp_failure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpawnTest spawnp_failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char file[] = "/nonexistent/executable";
     std::int32_t fd_count{0};

--- a/score/os/test/stat_test.cpp
+++ b/score/os/test/stat_test.cpp
@@ -29,7 +29,7 @@ TEST(StatImpl, StatRegularFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Stat Regular File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"stat_file"};
     const auto fd = ::open(filename, O_CREAT | O_RDWR, 0644);
@@ -50,7 +50,7 @@ TEST(StatImpl, StatSymbolicLink)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Stat Symbolic Link");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"stat_file"};
     const auto fd = ::open(filename, O_CREAT | O_RDWR, 0644);
@@ -70,7 +70,7 @@ TEST(StatImpl, StatNonExistentFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Stat Non Existent File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* non_existent_file = "nonexistent/file";
     struct StatBuffer buf;
@@ -88,7 +88,7 @@ TEST(StatImpl, fstatSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl fstat Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"stat_file"};
     const auto fd = ::open(filename, O_CREAT | O_RDONLY, 0644);
@@ -106,7 +106,7 @@ TEST(StatImpl, fstatFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl fstat Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto fd = -1;
     struct StatBuffer buf;
@@ -119,7 +119,7 @@ TEST(StatImpl, MkdirFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Mkdir Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* directory = "/hd/src";
     Stat::Mode mode = Stat::Mode::kUnknown;
@@ -138,7 +138,7 @@ TEST(StatImpl, MkdirSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Mkdir Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* directory = "directory";
     Stat::Mode mode = Stat::Mode::kReadWriteExecUser;
@@ -158,7 +158,7 @@ TEST(StatImpl, ChmodSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Chmod Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"stat_test_file"};
     const auto fd = ::open(filename, O_CREAT | O_WRONLY, 0644);
@@ -180,7 +180,7 @@ TEST(StatImpl, ChmodFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Chmod Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{""};
     Stat::Mode mode = Stat::Mode::kUnknown;
@@ -195,7 +195,7 @@ TEST(StatImpl, FchmodSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmod Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"stat_test_file"};
     const auto fd = ::open(filename, O_CREAT | O_WRONLY, 0644);
@@ -217,7 +217,7 @@ TEST(StatImpl, FchmodFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmod Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto fd = -1;
 
@@ -231,7 +231,7 @@ TEST(StatImpl, FchmodatSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmodat Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* file_name = "my_directory";
     int fd = open(file_name, O_CREAT, S_IRWXU | S_IRWXG | S_IRWXO);
@@ -250,7 +250,7 @@ TEST(StatImpl, FchmodatErrorNoFollowSymlinks)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Fchmodat Error No Follow Symlinks");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto filename{"stat_test_file"};
     const auto fd = ::open(filename, O_CREAT | O_RDWR, 0644);
@@ -269,7 +269,7 @@ TEST(StatImpl, DefaultObjectAllocationIsNotNull)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl Default Object Allocation Is Not Null");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = score::os::Stat::Default();
     EXPECT_NE(result, nullptr);
@@ -281,7 +281,7 @@ TEST(StatImpl, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatImpl PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Stat::Default(memory_resource);

--- a/score/os/test/statvfs_test.cpp
+++ b/score/os/test/statvfs_test.cpp
@@ -29,7 +29,7 @@ TEST(StatvfsTest, StatvfsSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatvfsTest Statvfs Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char tmp_dir_template[] = "statvfs_test.XXXXXX";
     char* result = ::mkdtemp(tmp_dir_template);
@@ -60,7 +60,7 @@ TEST(StatvfsTest, StatvfsFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StatvfsTest Statvfs Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct statvfs buf;
     std::string invalid_path = "/invalid/path";

--- a/score/os/test/stdio_test.cpp
+++ b/score/os/test/stdio_test.cpp
@@ -28,7 +28,7 @@ TEST(FOpenTest, ReturnsValidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FOpenTest Returns Valid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"test"};
     const auto mode{"w"};
@@ -43,7 +43,7 @@ TEST(FOpenTest, ReturnsErrorWithWrongMode)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FOpenTest Returns Error With Wrong Mode");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"test"};
     const auto mode{"bs"};
@@ -58,7 +58,7 @@ TEST(FCloseTest, ReturnsBlankValueIfSuccessful)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FCloseTest Returns Blank Value If Successful");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"test"};
     const auto mode{"w"};
@@ -75,7 +75,7 @@ TEST(FCloseTest, ReturnsErrorWithInvalidFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FCloseTest Returns Error With Invalid File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
 #if defined(GTEST_OS_LINUX)
     GTEST_SKIP() << "::fclose() is not POSIX compliant with glibc on Linux - any error causes an abort";
@@ -93,7 +93,7 @@ TEST(RemoveTest, ReturnsBlankValueIfSuccessful)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RemoveTest Returns Blank Value If Successful");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"test"};
     const auto mode{"w"};
@@ -113,7 +113,7 @@ TEST(RemoveTest, ReturnsErrorIfFileDoesNotExist)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RemoveTest Returns Error If File Does Not Exist");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"test-invalid-file"};
     const auto remove_result = score::os::Stdio::instance().remove(filename);
@@ -127,7 +127,7 @@ TEST(RenameTest, ReturnsBlankValueIfSuccessful)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RenameTest Returns Blank Value If Successful");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"test"};
     const auto mode{"w"};
@@ -151,7 +151,7 @@ TEST(RenameTest, ReturnsErrorIfNameInvalid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "RenameTest Returns Error If Name Invalid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto filename{"invalid-test"};
     const auto new_filename{"invalid_test"};
@@ -166,7 +166,7 @@ TEST(POpenTest, ReturnsValidPipe)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "POpenTest Returns Valid Pipe");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto cmd{"echo 1"};
     const auto mode{"r"};
@@ -188,7 +188,7 @@ TEST(POpenTest, ReturnsErrorWithInvalidMode)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "POpenTest Returns Error With Invalid Mode");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto cmd{"echo 1"};
     const auto mode{"x"};
@@ -203,7 +203,7 @@ TEST(PCloseTest, ProvidesReturnCodeOfPipeCommand)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PCloseTest Provides Return Code Of Pipe Command");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto cmd{"exit 1"};
     const auto mode{"r"};
@@ -223,7 +223,7 @@ TEST(FileNoTest, CanTranslateFileDescriptorOfStream)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FileNoTest Can Translate File Descriptor Of Stream");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = score::os::Stdio::instance().fileno(stdin);
     ASSERT_TRUE(result.has_value());
@@ -236,7 +236,7 @@ TEST(FileNoTest, ReturnsErrorForInvalidFileStream)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FileNoTest Returns Error For Invalid File Stream");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
 #if defined(GTEST_OS_LINUX)
     GTEST_SKIP() << "::fileno() is not POSIX compliant with glibc on Linux - any error causes an abort";

--- a/score/os/test/stdlib_impl_test.cpp
+++ b/score/os/test/stdlib_impl_test.cpp
@@ -31,7 +31,7 @@ TEST(StdlibImpl, system_call)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl system_call");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result = score::os::Stdlib::instance().system_call("ls /tmp");
     EXPECT_EQ(result, score::cpp::expected_blank<Error>{});
@@ -43,7 +43,7 @@ TEST(StdlibImpl, system_callFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl system_call Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto result1 = score::os::Stdlib::Default()->system_call("d");
     ASSERT_FALSE(result1.has_value());
@@ -55,7 +55,7 @@ TEST(StdlibImpl, getenv)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl getenv");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(setenv("TEST_ENV", "TEST_VALUE", 0), 0);
     const auto env = score::os::Stdlib::instance().getenv("TEST_ENV");
@@ -69,7 +69,7 @@ TEST(StdlibImpl, realpath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl realpath");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char resolved_path[PATH_MAX];
     auto res = score::os::Stdlib::instance().realpath("/etc", resolved_path);
@@ -84,9 +84,9 @@ TEST(StdlibImpl, realpath)
 TEST(StdlibImpl, calloc_fail)
 {
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     RecordProperty("Verifies", "SCR-109773");
     RecordProperty("ASIL", "B");
     RecordProperty("Description",
@@ -111,7 +111,7 @@ TEST(StdlibImpl, calloc)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl calloc");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto size = 2;
     const auto result = score::os::Stdlib::instance().calloc(size, sizeof(uint16_t));
@@ -132,7 +132,7 @@ TEST(StdlibImpl, free)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl free");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto size = 1;
     std::uint16_t* ptr = static_cast<std::uint16_t*>(::calloc(size, sizeof(uint16_t)));
@@ -147,7 +147,7 @@ TEST(StdlibImpl, mkstemp)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemp");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char path[] = "/tmp/fileXXXXXX";
     auto fd = score::os::Stdlib::instance().mkstemp(path);
@@ -161,7 +161,7 @@ TEST(StdlibImpl, mkstempFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemp Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char path[] = "/tmp/fileXXXX";
     auto fd = score::os::Stdlib::instance().mkstemp(path);
@@ -174,7 +174,7 @@ TEST(StdlibImpl, mkstemps)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemps");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char path[] = "/tmp/fileXXXXXXsuffix";
     auto fd = score::os::Stdlib::instance().mkstemps(path, 6);
@@ -188,7 +188,7 @@ TEST(StdlibImpl, mkstempsFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibImpl mkstemps Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char path[] = "/tmp/fileXXXXXX";
     auto fd = score::os::Stdlib::instance().mkstemps(path, 6);
@@ -201,7 +201,7 @@ TEST(StdlibTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StdlibTest PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Stdlib::Default(memory_resource);

--- a/score/os/test/string_impl_test.cpp
+++ b/score/os/test/string_impl_test.cpp
@@ -29,7 +29,7 @@ TEST(StringImplTest, StrMemcpy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringImplTest Str Memcpy");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     StringImpl str;
     char str1[] = "mem1";
@@ -44,7 +44,7 @@ TEST(StringImplTest, StrStderr)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringImplTest Str Stderr");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     StringImpl str;
     EXPECT_STREQ(str.strerror(EINVAL), "Invalid argument");
@@ -56,7 +56,7 @@ TEST(StringImplTest, StrMemset)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringImplTest Str Memset");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     StringImpl str;
     char str1[20] = "Sample";

--- a/score/os/test/string_test.cpp
+++ b/score/os/test/string_test.cpp
@@ -27,7 +27,7 @@ TEST(StringTest, StringMemcpy)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringTest String Memcpy");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char src[] = "ABCDEFGHIJ";
     char dest[11];
@@ -46,7 +46,7 @@ TEST(StringTest, StringMemset)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringTest String Memset");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char dest[11];
     score::os::String::instance().memset(dest, 'a', 10);
@@ -60,7 +60,7 @@ TEST(StringTest, StringStrError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "StringTest String Str Error");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     for (int i = 0; i < 10; ++i)
     {

--- a/score/os/test/sys_poll_test.cpp
+++ b/score/os/test/sys_poll_test.cpp
@@ -44,7 +44,7 @@ TEST_F(SysPollImplTest, PollSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysPollImplTest Poll Succeeds");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct pollfd fds[1];
     fds[0].fd = pipe_fd[0];
@@ -64,7 +64,7 @@ TEST_F(SysPollImplTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysPollImplTest PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::SysPoll::Default(memory_resource);

--- a/score/os/test/sys_uio_test.cpp
+++ b/score/os/test/sys_uio_test.cpp
@@ -44,7 +44,7 @@ TEST_F(SysUioImplTest, WritevFailsBadFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysUioImplTest Writev Fails Bad Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr std::int32_t kInvalidFd{-1};
     std::array<iovec, 2UL> io{};
@@ -67,7 +67,7 @@ TEST_F(SysUioImplTest, WritevSucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysUioImplTest Writev Succeeds");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::array<iovec, 2UL> io{};
     std::uint8_t byte1{1};
@@ -93,7 +93,7 @@ TEST_F(SysUioImplTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysUioImplTest PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::SysUio::Default(memory_resource);

--- a/score/os/test/sys_wait_impl_test.cpp
+++ b/score/os/test/sys_wait_impl_test.cpp
@@ -52,7 +52,7 @@ TEST(SysWaitImplTest, Wait)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Wait");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::SysWaitImpl syswait;
     pid_t cpid = 0;
@@ -73,7 +73,7 @@ TEST(SysWaitImplTest, WaitFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Wait Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::SysWait& syswait = score::os::SysWait::instance();
     int status;
@@ -87,7 +87,7 @@ TEST(SysWaitImplTest, Waitpid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Waitpid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::SysWait& syswait = score::os::SysWait::instance();
     pid_t cpid = 0;
@@ -108,7 +108,7 @@ TEST(SysWaitImplTest, WaitpidFail)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SysWaitImplTest Waitpid Fail");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::SysWaitImpl syswait;
     pid_t cpid = 0;

--- a/score/os/test/time_test.cpp
+++ b/score/os/test/time_test.cpp
@@ -31,7 +31,7 @@ TEST(TimeImplTest, ClockSettimeFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Settime Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec new_time;
     ::clock_gettime(CLOCK_MONOTONIC, &new_time);
@@ -55,7 +55,7 @@ TEST(TimeImplTest, ClockGetTimeSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Get Time Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec get_time{};
 
@@ -74,7 +74,7 @@ TEST(TimeImplTest, GettimeFailsWithInvalidClockId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Gettime Fails With Invalid Clock Id");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec get_time{};
     constexpr auto kInvalidClockId{-1};
@@ -89,7 +89,7 @@ TEST(TimeImplTest, ClockSettimeSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Settime Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec new_time;
     ::clock_gettime(CLOCK_REALTIME, &new_time);
@@ -115,7 +115,7 @@ TEST(TimeImplTest, ClockGetResSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Get Res Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec get_res{};
 
@@ -134,7 +134,7 @@ TEST(TimeImplTest, ClockGetResFailsWithInvalidClockId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Clock Get Res Fails With Invalid Clock Id");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     struct timespec get_res{};
     constexpr auto kInvalidClockId{-1};
@@ -149,7 +149,7 @@ TEST(TimeImplTest, LocaltimeRSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TimeImplTest Localtime RSuccess");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto current_time = std::chrono::system_clock::now();
     const std::time_t current_time_t{std::chrono::system_clock::to_time_t(current_time)};

--- a/score/os/test/uname_test.cpp
+++ b/score/os/test/uname_test.cpp
@@ -41,7 +41,7 @@ TEST_F(UnameTest, GetUnameSuccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnameTest Get Uname Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(unameMock, UnameWrapper(::testing::_)).WillOnce([](struct utsname* info) {
         std::cout << "Pointer received: " << info << std::endl;
@@ -57,7 +57,7 @@ TEST_F(UnameTest, GetUnameFailure)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnameTest Get Uname Failure");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(unameMock, UnameWrapper(::testing::_)).WillOnce([](struct utsname* info) {
         std::cout << "Pointer received: " << info << std::endl;
@@ -73,7 +73,7 @@ TEST(UnameWrapperTest, Success)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnameWrapperTest Success");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Prepare the expected behavior
     struct utsname info;

--- a/score/os/test/unistdTest.cpp
+++ b/score/os/test/unistdTest.cpp
@@ -132,7 +132,7 @@ TEST_F(UnistdFixture, CloseFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Close File Descriptor");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some file
     constexpr auto path = "close_test_file";
@@ -155,7 +155,7 @@ TEST_F(UnistdFixture, UnlinkRemovesFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unlink Removes File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some file without a reference count
     constexpr auto path = "unlink_test_file";
@@ -177,7 +177,7 @@ TEST_F(UnistdFixture, UnlinkReturnsErrorIfNonExistingPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unlink Returns Error If Non Existing Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some non-existing file
     constexpr auto path = "/tmp/some_non_existing_file";
@@ -194,7 +194,7 @@ TEST_F(UnistdFixture, PipeOpensWithoutError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Pipe Opens Without Error");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     int32_t fds[2] = {};
     const auto val = unit_->pipe(&fds[0]);
@@ -212,7 +212,7 @@ TEST_F(UnistdFixture, DupReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->dup(kInvalidFd);
     EXPECT_FALSE(val.has_value());
@@ -224,7 +224,7 @@ TEST_F(UnistdFixture, DupReturnsNoErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup Returns No Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t fds = 1;
     const auto val = unit_->dup(fds);
@@ -238,7 +238,7 @@ TEST_F(UnistdFixture, Dup2ReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup2Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->dup2(kInvalidFd, kInvalidFd);
     EXPECT_FALSE(val.has_value());
@@ -250,7 +250,7 @@ TEST_F(UnistdFixture, ReadReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr size_t buf_size = 32;
     char buf[buf_size] = {};
@@ -265,7 +265,7 @@ TEST_F(UnistdFixture, PReadReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PRead Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr size_t buf_size = 32;
     char buf[buf_size] = {};
@@ -280,7 +280,7 @@ TEST_F(UnistdFixture, PReadReturnsNonErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PRead Returns Non Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr size_t buf_size = 32;
     char buf[buf_size] = {};
@@ -300,7 +300,7 @@ TEST_F(UnistdFixture, WriteReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Write Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr size_t buf_size = 32;
     char buf[buf_size] = {};
@@ -315,7 +315,7 @@ TEST_F(UnistdFixture, PWriteReturnsNonErrorIfPassPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PWrite Returns Non Error If Pass Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr size_t buf_size = 32;
     char buf[buf_size] = {};
@@ -335,7 +335,7 @@ TEST_F(UnistdFixture, PWriteReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture PWrite Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr size_t buf_size = 32;
     char buf[buf_size] = {};
@@ -350,7 +350,7 @@ TEST_F(UnistdFixture, LSeekReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture LSeek Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->lseek(kInvalidFd, 0, 0);
     EXPECT_FALSE(val.has_value());
@@ -362,7 +362,7 @@ TEST_F(UnistdFixture, LSeekReturnsNonErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture LSeek Returns Non Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "lseek_test_file";
 
@@ -380,7 +380,7 @@ TEST_F(UnistdFixture, FTruncateReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FTruncate Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->ftruncate(-1, 0);
     EXPECT_FALSE(val.has_value());
@@ -392,7 +392,7 @@ TEST_F(UnistdFixture, FTruncateNonErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FTruncate Non Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "ftruncate_test_file";
     const OpenFileGuard file_guard{path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR};
@@ -409,7 +409,7 @@ TEST_F(UnistdFixture, GetUiIdMatchSystemGetuid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Ui Id Match System Getuid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(unit_->getuid(), ::getuid());
 }
@@ -420,7 +420,7 @@ TEST_F(UnistdFixture, GetGidMatchSystemGetGid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Gid Match System Get Gid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(unit_->getgid(), ::getgid());
 }
@@ -431,7 +431,7 @@ TEST_F(UnistdFixture, GetPidMatchSystemGetPid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Pid Match System Get Pid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(unit_->getpid(), ::getpid());
 }
@@ -442,7 +442,7 @@ TEST_F(UnistdFixture, GetPpidMatchSystemGetPpid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Get Ppid Match System Get Ppid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(unit_->getppid(), ::getppid());
 }
@@ -453,7 +453,7 @@ TEST_F(UnistdFixture, SetuidNotChangesUidIfPassInvalidId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Setuid Not Changes Uid If Pass Invalid Id");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ForkAndExpectTrue([this]() noexcept {
 #if defined(__QNX__)
@@ -471,7 +471,7 @@ TEST_F(UnistdFixture, SetGidNotChangesGidIfPassInvalidId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Set Gid Not Changes Gid If Pass Invalid Id");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ForkAndExpectTrue([this]() noexcept {
         const gid_t expected_gid{::getgid()};
@@ -491,7 +491,7 @@ TEST_F(UnistdFixture, ReadLinkReturnsErrorIfPassEmptyPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Link Returns Error If Pass Empty Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char buf[4096] = {};
     const auto val = unit_->readlink("", &buf[0], sizeof(buf));
@@ -506,7 +506,7 @@ TEST_F(UnistdFixture, ReadLinkReturnsNoErrorIfPassValidPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Link Returns No Error If Pass Valid Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* target = "/etc/passwd";
     const char* symlinkPath = "test_symlink";
@@ -536,7 +536,7 @@ TEST_F(UnistdFixture, FSyncReturnsErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FSync Returns Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->fsync(-1);
     EXPECT_FALSE(val.has_value());
@@ -548,7 +548,7 @@ TEST_F(UnistdFixture, FSyncReturnsNonErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FSync Returns Non Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "fsync_test_file";
     const OpenFileGuard file_guard{path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR};
@@ -565,7 +565,7 @@ TEST_F(UnistdFixture, FDataSyncReturnsNonErrorIfPassInvalidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FData Sync Returns Non Error If Pass Invalid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->fdatasync(-1);
     EXPECT_FALSE(val.has_value());
@@ -577,7 +577,7 @@ TEST_F(UnistdFixture, FDataSyncReturnsNonErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture FData Sync Returns Non Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "fdata_sync_test_file";
     const OpenFileGuard file_guard{path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR};
@@ -594,7 +594,7 @@ TEST_F(UnistdFixture, NanosleepReturnsNonErrorIfPassValidSleepParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Nanosleep Returns Non Error If Pass Valid Sleep Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     timespec req{0, 10};
     const auto val = unit_->nanosleep(&req, nullptr);
@@ -608,7 +608,7 @@ TEST_F(UnistdFixture, NanosleepReturnsErrorIfPassInvalidSleepParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Nanosleep Returns Error If Pass Invalid Sleep Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     timespec req{0, -10};
     const auto val = unit_->nanosleep(&req, nullptr);
@@ -621,7 +621,7 @@ TEST_F(UnistdFixture, SysconfReturnsErrorIfPassInvalidParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Sysconf Returns Error If Pass Invalid Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->sysconf(kInvalidFd);
     EXPECT_FALSE(val.has_value());
@@ -633,7 +633,7 @@ TEST_F(UnistdFixture, SysconfReturnsNonErrorIfPassValidParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Sysconf Returns Non Error If Pass Valid Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->sysconf(_SC_ARG_MAX);
     EXPECT_TRUE(val.has_value());
@@ -645,7 +645,7 @@ TEST_F(UnistdFixture, LinkReturnsErrorIfPassEmptyPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Link Returns Error If Pass Empty Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->link("", "");
     EXPECT_FALSE(val.has_value());
@@ -657,7 +657,7 @@ TEST_F(UnistdFixture, LinkReturnsNonErrorIfPassValidPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Link Returns Non Error If Pass Valid Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "link_test_file";
     constexpr auto path_link = "link_test_file_link";
@@ -675,7 +675,7 @@ TEST_F(UnistdFixture, SymlinkReturnsErrorIfPassEmptyPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Symlink Returns Error If Pass Empty Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->symlink("", "");
     EXPECT_FALSE(val.has_value());
@@ -687,7 +687,7 @@ TEST_F(UnistdFixture, SymlinkReturnsNonErrorIfPassValidPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Symlink Returns Non Error If Pass Valid Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path_link = "symlink_test_file_link";
     // create file
@@ -705,7 +705,7 @@ TEST_F(UnistdFixture, ChdirReturnsErrorIfPassEmptyPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chdir Returns Error If Pass Empty Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->chdir("");
     EXPECT_FALSE(val.has_value());
@@ -717,7 +717,7 @@ TEST_F(UnistdFixture, ChdirReturnsNonErrorIfPassValidPath)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chdir Returns Non Error If Pass Valid Path");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->chdir(".");
     EXPECT_TRUE(val.has_value());
@@ -729,7 +729,7 @@ TEST_F(UnistdFixture, ChownReturnsErrorIfPassInvalidParams)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chown Returns Error If Pass Invalid Params");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->chown("", 0, 0);
     EXPECT_FALSE(val.has_value());
@@ -741,7 +741,7 @@ TEST_F(UnistdFixture, ChownReturnsNonErrorIfPassValidParams)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Chown Returns Non Error If Pass Valid Params");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const OpenFileGuard file_guard{"chown_test_file", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR};
     ASSERT_EQ(file_guard.Stat(), 0);
@@ -759,7 +759,7 @@ TEST_F(UnistdFixture, GetcwdReturnsErrorIfPassNullBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Getcwd Returns Error If Pass Null Buffer");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char buffer{};
     const auto val = unit_->getcwd(&buffer, 0);
@@ -772,7 +772,7 @@ TEST_F(UnistdFixture, GetcwdReturnsNonErrorIfPassAllocatedBuffer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Getcwd Returns Non Error If Pass Allocated Buffer");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     char buf[4096] = {};
     const auto val = unit_->getcwd(buf, sizeof(buf));
@@ -785,7 +785,7 @@ TEST_F(UnistdFixture, AccessMatchesReadWriteAccessForExistingFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Access Matches Read Write Access For Existing File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some file
     constexpr auto path = "access_test_file";
@@ -813,7 +813,7 @@ TEST_F(UnistdFixture, AccessReturnsErrorIfPassNonExistingFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Access Returns Error If Pass Non Existing File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some non existing file
     constexpr auto path = "non_existing_file";
@@ -837,7 +837,7 @@ TEST_F(UnistdFixture, AccessReturnsNonErrorForExistingFileWithReadWriteAccess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Access Returns Non Error For Existing File With Read Write Access");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some file
     constexpr auto path = "unistd_access_file";
@@ -865,7 +865,7 @@ TEST_F(UnistdFixture, UnistdAccessReturnsErrorIfPassNonExistingFile)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Access Returns Error If Pass Non Existing File");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // Given some non existing file
     constexpr auto path = "non_existent_file";
@@ -889,7 +889,7 @@ TEST_F(UnistdFixture, UnistdGettidReturnsPositiveTid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Gettid Returns Positive Tid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_GT(unit_->gettid(), 0);
 }
@@ -900,7 +900,7 @@ TEST_F(UnistdFixture, UnistdAlarmSetsAndReportsPendingAlarm)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Alarm Sets And Reports Pending Alarm");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t seconds = 10;
     EXPECT_EQ(unit_->alarm(seconds), 0);
@@ -915,7 +915,7 @@ TEST_F(UnistdFixture, UnistdAlarmTriggersInExpectedTime)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Unistd Alarm Triggers In Expected Time");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const std::uint32_t seconds = 1;
     static bool triggered = false;
@@ -937,7 +937,7 @@ TEST(Unistd, DefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Unistd Default Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto default_instance = score::os::Unistd::Default();
     ASSERT_TRUE(default_instance != nullptr);
@@ -950,7 +950,7 @@ TEST_F(UnistdFixture, CloseReturnsErrIfPassInvalidParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Close Returns Err If Pass Invalid Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto val = unit_->close(kInvalidFd);
     EXPECT_FALSE(val.has_value());
@@ -963,7 +963,7 @@ TEST_F(UnistdFixture, Dup2ReturnsNoErrorIfPassValidParam)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Dup2Returns No Error If Pass Valid Param");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t fds[2] = {1, 2};
     const auto val_1 = unit_->pipe(&fds[0]);
@@ -983,7 +983,7 @@ TEST_F(UnistdFixture, ReadReturnsNoErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Read Returns No Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     // first write something to the file
 
@@ -1022,7 +1022,7 @@ TEST_F(UnistdFixture, WriteReturnNoErrorIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Write Return No Error If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "write_test_file";
     const auto fd_write = ::open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
@@ -1055,7 +1055,7 @@ TEST_F(UnistdFixture, SetuidReturnsErrorIfPassInvalidUid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Setuid Returns Error If Pass Invalid Uid");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const uid_t uid_before_set = unit_->getuid();
     const uid_t invalid_id = UINT_MAX;
@@ -1072,7 +1072,7 @@ TEST_F(UnistdFixture, SetuidReturnsNoErrorIfPassValidID)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Setuid Returns No Error If Pass Valid ID");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
 #if defined __QNX__
     ForkAndExpectTrue([this]() noexcept {
@@ -1092,7 +1092,7 @@ TEST_F(UnistdFixture, WriteReturnNoErrorAndSyncIfPassValidFd)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "UnistdFixture Write Return No Error And Sync If Pass Valid Fd");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto path = "write_test_file";
     const auto fd_write = ::open(path, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
@@ -1126,7 +1126,7 @@ TEST(Unistd, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Unistd PMRDefault Shall Return Impl Instance");
     RecordProperty("TestType", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto default_instance = score::os::Unistd::Default(memory_resource);

--- a/score/os/utils/test/abortable_blocking_reader_test.cpp
+++ b/score/os/utils/test/abortable_blocking_reader_test.cpp
@@ -83,7 +83,7 @@ TEST_F(NonBlockingFileDescriptorTest, DefaultConstructionSetsUnderlyingFileDescr
         "Description",
         "NonBlockingFileDescriptorTest Default Construction Sets Underlying File Descriptor To Invalid Value");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     NonBlockingFileDescriptor non_blocking_file_descriptor{};
     EXPECT_EQ(non_blocking_file_descriptor.GetUnderlying(), -1);
@@ -97,7 +97,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryWhenNonBlockingFlagI
                    "NonBlockingFileDescriptorTest Construction Via Factory When Non Blocking Flag Is Present In File "
                    "Descriptor Flags");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto expected_flags{existing_flags_ | Fcntl::Open::kNonBlocking};
     EXPECT_CALL(fcntl_mock_, fcntl(file_descriptor_, Fcntl::Command::kFileGetStatusFlags))
@@ -116,7 +116,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryAddsNonBlockingFlagT
         "Description",
         "NonBlockingFileDescriptorTest Construction Via Factory Adds Non Blocking Flag To File Descriptor Flags");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::testing::InSequence sequence{};
 
@@ -139,7 +139,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryFailsIfCannotGetFlag
         "Description",
         "NonBlockingFileDescriptorTest Construction Via Factory Fails If Cannot Get Flags Of File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::testing::InSequence sequence{};
 
@@ -161,7 +161,7 @@ TEST_F(NonBlockingFileDescriptorTest, ConstructionViaFactoryFailsIfCannotSetFlag
         "Description",
         "NonBlockingFileDescriptorTest Construction Via Factory Fails If Cannot Set Flags Of File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto expected_flags{existing_flags_ | Fcntl::Open::kNonBlocking};
     ON_CALL(fcntl_mock_, fcntl(file_descriptor_, Fcntl::Command::kFileSetStatusFlags, expected_flags))
@@ -178,7 +178,7 @@ TEST_F(NonBlockingFileDescriptorTest, DestructionClosesUnderlyingFileDescriptor)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingFileDescriptorTest Destruction Closes Underlying File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
     ASSERT_TRUE(non_blocking_file_descriptor.has_value());
@@ -193,7 +193,7 @@ TEST_F(NonBlockingFileDescriptorTest, DestructionTerminatesIfItFailsToCloseUnder
         "Description",
         "NonBlockingFileDescriptorTest Destruction Terminates If It Fails To Close Underlying File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_DEATH(
         {
@@ -214,7 +214,7 @@ TEST_F(NonBlockingFileDescriptorTest, MoveAssignmentTerminatesIfItFailsToCloseUn
         "Description",
         "NonBlockingFileDescriptorTest Move Assignment Terminates If It Fails To Close Underlying File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_DEATH(
         [this] {
@@ -238,7 +238,7 @@ TEST_F(NonBlockingFileDescriptorTest, DestructionDoesNotTryToCloseInvalidUnderly
         "Description",
         "NonBlockingFileDescriptorTest Destruction Does Not Try To Close Invalid Underlying File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const auto invalid_file_descriptor{-1};
     auto non_blocking_file_descriptor =
@@ -256,7 +256,7 @@ TEST_F(NonBlockingFileDescriptorTest, MoveConstructedFromInstanceDoesNotCloseMov
         "Description",
         "NonBlockingFileDescriptorTest Move Constructed From Instance Does Not Close Moved Underlying File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
     ASSERT_TRUE(non_blocking_file_descriptor.has_value());
@@ -275,7 +275,7 @@ TEST_F(NonBlockingFileDescriptorTest, MoveAssignedFromInstanceDoesNotCloseMovedU
         "Description",
         "NonBlockingFileDescriptorTest Move Assigned From Instance Does Not Close Moved Underyling File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     constexpr auto other_filepath{"/tmp/non_blocking_file_descriptor_test_other"};
     auto expected_other_file_descriptor = FcntlImpl{}.open(other_filepath, open_flags_, mode_);
@@ -305,7 +305,7 @@ TEST_F(NonBlockingFileDescriptorTest, GetUnderlyingReturnsUnderlyingFileDescript
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingFileDescriptorTest Get Underlying Returns Underlying File Descriptor");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
     ASSERT_TRUE(non_blocking_file_descriptor.has_value());
@@ -318,7 +318,7 @@ TEST_F(NonBlockingFileDescriptorTest, CanImplicitlyCastToInt32T)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "NonBlockingFileDescriptorTest Can Implicitly Cast To Int32T");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto non_blocking_file_descriptor = NonBlockingFileDescriptor::Make(file_descriptor_, fcntl_mock_, unistd_mock_);
     ASSERT_TRUE(non_blocking_file_descriptor.has_value());
@@ -415,7 +415,7 @@ TEST(AbortableBlockingReaderTestDefaultConstructor, CreatesNewPipeWhenConstructe
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTestDefaultConstructor Creates New Pipe When Constructed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     AbortableBlockingReader reader{};
     ASSERT_TRUE(reader.IsValid());
@@ -427,7 +427,7 @@ TEST_F(AbortableBlockingReaderTest, CreatesNewPipeWhenConstructed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Creates New Pipe When Constructed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*unistd_mock_, pipe(::testing::_));
 
@@ -442,7 +442,7 @@ TEST_F(AbortableBlockingReaderTest, MarkedInvalidIfPipeCreationFailedDuringConst
     RecordProperty("Description",
                    "AbortableBlockingReaderTest Marked Invalid If Pipe Creation Failed During Construction");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*unistd_mock_, pipe(::testing::_))
         .WillOnce(::testing::Return(score::cpp::make_unexpected(Error::createFromErrno(EPERM))));
@@ -460,7 +460,7 @@ TEST_F(AbortableBlockingReaderTest, MarkedInvalidIfFirstPipeFileDescriptorCanNot
         "Description",
         "AbortableBlockingReaderTest Marked Invalid If First Pipe File Descriptor Can Not Be Made Non Blocking");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*fcntl_mock_, fcntl(::testing::_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Return(score::cpp::make_unexpected(Error::createFromErrno(EPERM))));
@@ -478,7 +478,7 @@ TEST_F(AbortableBlockingReaderTest, MarkedInvalidIfSecondPipeFileDescriptorCanNo
         "Description",
         "AbortableBlockingReaderTest Marked Invalid If Second Pipe File Descriptor Can Not Be Made Non Blocking");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*fcntl_mock_, fcntl(::testing::_, ::testing::_, ::testing::_))
         .WillOnce(::testing::DoDefault())
@@ -495,7 +495,7 @@ TEST_F(AbortableBlockingReaderTest, ClosesPipeWhenDestructed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Closes Pipe When Destructed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::int32_t signaled_fd;
     std::int32_t signaling_fd;
@@ -516,7 +516,7 @@ TEST_F(AbortableBlockingReaderTest, CanOnlyCallReadIfMarkedValid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Can Only Call Read If Marked Valid");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*unistd_mock_, pipe(::testing::_))
         .WillOnce(::testing::Return(score::cpp::make_unexpected(Error::createFromErrno(EPERM))));
@@ -535,7 +535,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsOnceDataBecomesAvailable)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Once Data Becomes Available");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<void> unblock_promise{};
     EXPECT_CALL(*syspoll_mock_, poll(::testing::_, ::testing::_, ::testing::_))
@@ -569,7 +569,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfSelectFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If Select Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*syspoll_mock_, poll(::testing::_, ::testing::_, ::testing::_))
         .WillOnce(::testing::Return(score::cpp::make_unexpected(Error::createFromErrno(EPERM))));
@@ -589,7 +589,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfFileDescriptorIsInvalid)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If File Descriptor Is Invalid");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     AbortableBlockingReader reader{fcntl_mock_, syspoll_mock_, unistd_mock_};
     ASSERT_TRUE(reader.IsValid());
@@ -607,7 +607,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsWhenReaderIsDestructed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns When Reader Is Destructed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::future<void> read_future{};
 
@@ -643,7 +643,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsWhenStopCalled)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns When Stop Called");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<void> unblock_promise{};
     EXPECT_CALL(*syspoll_mock_, poll(::testing::_, ::testing::_, ::testing::_))
@@ -678,7 +678,7 @@ TEST_F(AbortableBlockingReaderTest, StopIsInvokedUntilReaderReleasesTheMutex)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Stop Is Invoked Until Reader Releases The Mutex");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<void> unblock_promise{};
     EXPECT_CALL(*syspoll_mock_, poll(::testing::_, ::testing::_, ::testing::_))
@@ -712,7 +712,7 @@ TEST_F(AbortableBlockingReaderTest, DestructorTerminatesOnUnexpectedError)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Destructor Terminates On Unexpected Error");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     auto stop_reader = [this] {
         EXPECT_CALL(*unistd_mock_, write(testing::_, testing::_, testing::_))
@@ -729,7 +729,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfAlreadyStopped)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If Already Stopped");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     AbortableBlockingReader reader{fcntl_mock_, syspoll_mock_, unistd_mock_};
     ASSERT_TRUE(reader.IsValid());
@@ -748,7 +748,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsErrorIfReadFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "AbortableBlockingReaderTest Read Returns Error If Read Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_CALL(*unistd_mock_, read(file_descriptor_1_.GetUnderlying(), ::testing::_, ::testing::_))
         .WillOnce(::testing::Return(score::cpp::make_unexpected(Error::createFromErrno(EPERM))));
@@ -772,7 +772,7 @@ TEST_F(AbortableBlockingReaderTest, ReadReturnsDataForMultipleFileDescriptorsSim
     RecordProperty("Description",
                    "AbortableBlockingReaderTest Read Returns Data For Multiple File Descriptors Simultaneously");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::promise<void> unblock_promise_1{};
     std::promise<void> unblock_promise_2{};
@@ -823,7 +823,7 @@ TEST_F(AbortableBlockingReaderTest, WillUnblockReadsForMultipleFileDescriptorsSi
         "Description",
         "AbortableBlockingReaderTest Will Unblock Reads For Multiple File Descriptors Simultaneously On Destruction");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::future<void> read_future_1{};
     std::future<void> read_future_2{};

--- a/score/os/utils/test/detect_os_test.cpp
+++ b/score/os/utils/test/detect_os_test.cpp
@@ -41,7 +41,7 @@ TEST_F(DetectOsTest, IsEmpty)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Empty");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ::score::cpp::optional<SystemInfo> retVal{};
     EXPECT_CALL(unameMock, GetUname()).WillRepeatedly(Return(retVal));
@@ -55,7 +55,7 @@ TEST_F(DetectOsTest, IsLinux)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Linux");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SystemInfo info{};
     info.sysname = "Linux";
@@ -71,7 +71,7 @@ TEST_F(DetectOsTest, IsQnx)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Qnx");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SystemInfo info{};
     info.sysname = "QNX";
@@ -87,7 +87,7 @@ TEST_F(DetectOsTest, IsWindows)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "DetectOsTest Is Windows");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     SystemInfo info{};
     info.sysname = "Windows";

--- a/score/os/utils/test/high_resolution_steady_clock_test.cpp
+++ b/score/os/utils/test/high_resolution_steady_clock_test.cpp
@@ -26,7 +26,7 @@ TEST(HighResolutionSteadyClock, UnderlyingClock)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description",
                    "This test ensures that the underlying clock of "
@@ -56,7 +56,7 @@ TEST(HighResolutionSteadyClock, now)
     RecordProperty("ParentRequirement", "SCR-46010294");
     RecordProperty("ASIL", "B");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     RecordProperty("Description",
                    "This test ensures that the values returned by HighResolutionSteadyClock's "

--- a/score/os/utils/test/machine_test.cpp
+++ b/score/os/utils/test/machine_test.cpp
@@ -28,7 +28,7 @@ TEST(MachineImpl, instance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MachineImpl instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Machine& obj = score::os::Machine::instance();
     ASSERT_TRUE(&obj);
@@ -40,7 +40,7 @@ TEST(MachineImpl, is_qemu)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MachineImpl is_qemu");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
 #ifdef MACHINE_QEMU
     ASSERT_TRUE(score::os::Machine::instance().is_qemu());
@@ -55,7 +55,7 @@ TEST(Machine, is_sctf)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Machine is_sctf");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_TRUE(setenv("SCTF", "TRUE", 1) == 0);
     ASSERT_TRUE(is_sctf());
@@ -68,7 +68,7 @@ TEST(Machine, is_sctf_false)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Machine is_sctf_false");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     ASSERT_FALSE(is_sctf());
 }

--- a/score/os/utils/test/mqueueintegration_test.cpp
+++ b/score/os/utils/test/mqueueintegration_test.cpp
@@ -123,7 +123,7 @@ TEST_F(FixtureMQueueShould, sendACharPointerToOtherProcess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould send AChar Pointer To Other Process");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const char* msg = "020223456"; /* TODO : create tests with different formats of the msg, for better check */
     std::thread test_tr([&msg = msg]() {
@@ -148,7 +148,7 @@ TEST_F(FixtureMQueueShould, sendAStringToOtherProcess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould send AString To Other Process");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string msg{std::to_string(0x01)};
     std::thread test_tr([&msg = msg]() {
@@ -168,7 +168,7 @@ TEST_F(FixtureMQueueMaxMsgSizeShould, SendALongStringToOtherProzess)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueMaxMsgSizeShould Send ALong String To Other Prozess");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::thread test_tr([&msg = msg]() {
         MQueue sender{name, AccessMode::kUse};
@@ -188,7 +188,7 @@ TEST_F(FixtureMQueueMaxMsgSizeShould, ReopenOnlyWithId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueMaxMsgSizeShould Reopen Only With Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     size_t id = queue.get_id();
 
@@ -209,7 +209,7 @@ TEST(MQueue, TryOpenNotExistingMQqueue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue Try Open Not Existing MQqueue");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue test{"blah", AccessMode::kUse};
     EXPECT_EQ(test.get_id(), kNonExistingQueueNameHash);
@@ -222,7 +222,7 @@ TEST(MQueue, shouldReturnId)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue should Return Id");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
     std::size_t n = queue.get_id();
@@ -236,7 +236,7 @@ TEST(MQueue, ShouldGetEmtpyMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue Should Get Emtpy Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreateNonBlocking};
     std::string msg = queue.receive();
@@ -250,7 +250,7 @@ TEST_F(FixtureMQueueShould, timedBlockEmptyQueue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould timed Block Empty Queue");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::pair<std::string, bool> result = queue.timed_receive(std::chrono::milliseconds(100));
     EXPECT_EQ(result.first, "");
@@ -263,7 +263,7 @@ TEST(MQueue, timedNonBlockEmptyQueue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue timed Non Block Empty Queue");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreateNonBlocking};
     std::pair<std::string, bool> result = queue.timed_receive(std::chrono::milliseconds(100));
@@ -278,7 +278,7 @@ TEST_F(FixtureMQueueShould, timedBlockSendMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueShould timed Block Send Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::string msg{"thunder"};
     std::thread test_tr1([&msg = msg]() {
@@ -297,7 +297,7 @@ TEST_F(FixtureMQueueStringShould, timedBlockCharArrayMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueStringShould timed Block Char Array Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::thread test_tr1([]() {
         char smsg[] = {'0', '2', '0', '2', '2', '3', '4', '5', '6', '\0'};
@@ -321,7 +321,7 @@ TEST_F(FixtureMQueueStringShould, timedBlockDeffectedCharArrayMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueStringShould timed Block Deffected Char Array Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::thread test_tr1([]() {
         uint8_t send_arr[9] = {0x00, 0x02, 0x00, 0x02, 0x02, 0x03, 0x04, 0x05, 0x06};
@@ -343,7 +343,7 @@ TEST_F(FixtureMQueueStringShould, timedBlockMessage)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "FixtureMQueueStringShould timed Block Message");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::thread test_tr1([]() {
         uint8_t send_arr[9] = {0x00, 0x02, 0x00, 0x02, 0x02, 0x03, 0x04, 0x05, 0x06};

--- a/score/os/utils/test/mqunit_test.cpp
+++ b/score/os/utils/test/mqunit_test.cpp
@@ -46,7 +46,7 @@ TEST_F(MQueueFixture, shouldConfigureNonBlock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue should configure non block");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite |
                                       score::os::Mqueue::OpenFlag::kNonBlocking;
@@ -60,7 +60,7 @@ TEST_F(MQueueFixture, shouldConfigureBlock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue should configure block");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
     EXPECT_CALL(mqueue_mock, mq_open(_, flags, _, _)).WillOnce(Return(1));
@@ -74,7 +74,7 @@ TEST_F(MQueueFixture, shouldUnlinkDefinedQueue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mqueue should Unlink Defined Queue");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
 
@@ -88,7 +88,7 @@ TEST_F(MQueueFixture, shouldUnlinkUndefinedQueue)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mqueue should Unlink Undefined Queue");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
 
@@ -108,7 +108,7 @@ TEST_F(MQueueFixture, shouldFaileToUnlink)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "mqueue should Faile To Unlink");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
 
@@ -126,7 +126,7 @@ TEST(MQueue, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueue shall PMR Default Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Mqueue::Default(memory_resource);
@@ -140,7 +140,7 @@ TEST_F(MQueueFixture, shouldFailToReceive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Receive");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
 
@@ -157,7 +157,7 @@ TEST_F(MQueueFixture, shouldFailToReceiveTwice)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Receive Twice");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     MQueue queue{"some_name", AccessMode::kCreate};
 
@@ -175,7 +175,7 @@ TEST_F(MQueueFixture, shouldFailToSend)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Send");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     uint8_t send_arr[9] = {0x00, 0x02, 0x00, 0x02, 0x02, 0x03, 0x04, 0x05, 0x06};
     char* smsg = reinterpret_cast<char*>(send_arr);
@@ -193,7 +193,7 @@ TEST_F(MQueueFixture, shouldFailToSendDueInteruptSignal)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Fail To Send Due Interupt Signal");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     uint8_t send_arr[9] = {0x00, 0x02, 0x00, 0x02, 0x02, 0x03, 0x04, 0x05, 0x06};
     char* smsg = reinterpret_cast<char*>(send_arr);
@@ -212,7 +212,7 @@ TEST_F(MQueueFixture, shouldConfigurekExistUseOthCreate)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Configurek Exist Use Oth Create");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
     EXPECT_CALL(mqueue_mock, mq_open(_, flags, _, _)).Times(2).WillRepeatedly(Return(1));
@@ -226,7 +226,7 @@ TEST_F(MQueueFixture, shouldCallSend)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Call Send");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
     std::string msg{"msg"};
@@ -243,7 +243,7 @@ TEST_F(MQueueFixture, shouldCallReceive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Call Receive");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
     std::string msg{"msg"};
@@ -260,7 +260,7 @@ TEST_F(MQueueFixture, shouldReturnErrorWhenOpenFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Return Error When Open Failed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::Mqueue::OpenFlag flags = score::os::Mqueue::OpenFlag::kCreate | score::os::Mqueue::OpenFlag::kReadWrite;
     EXPECT_CALL(mqueue_mock, mq_open(_, flags, _, _))
@@ -274,7 +274,7 @@ TEST_F(MQueueFixture, shouldReturnErrorWhenSetPermissionsFailed)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture should Return Error When Set Permissions Failed");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::StatMock stat_mock;
     score::os::Stat::set_testing_instance(stat_mock);
@@ -290,7 +290,7 @@ TEST_F(MQueueFixture, failOnGetQueuePermissions)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "MQueueFixture fail On Get Queue Permissions");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const score::cpp::expected_blank<Error> error = score::cpp::make_unexpected(Error::createFromErrno(5));
     score::os::StatMock stat_mock;
@@ -310,7 +310,7 @@ TEST(Mqueue, shouldOpenReadAndWrite)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mqueue should Open Read And Write");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::MqueueMock mqueue_mock;
     score::os::Mqueue::set_testing_instance(mqueue_mock);
@@ -326,7 +326,7 @@ TEST(Mqueue, failOnGetQueueAttributes)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Mqueue fail On Get Queue Attributes");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::MqueueMock mqueue_mock;
     score::os::Mqueue::set_testing_instance(mqueue_mock);

--- a/score/os/utils/test/path_test.cpp
+++ b/score/os/utils/test/path_test.cpp
@@ -31,7 +31,7 @@ TEST(get_base_name, man_page_examples)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_base_name man_page_examples");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(Path::instance().get_base_name("usr"), "usr");
     EXPECT_EQ(Path::instance().get_base_name("usr/"), "usr");
@@ -51,7 +51,7 @@ TEST(get_exec_path, returns_non_empty)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_non_empty");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const score::cpp::expected<std::string, score::os::Error> result{Path::Default()->get_exec_path()};
     ASSERT_TRUE(result.has_value());
@@ -65,7 +65,7 @@ TEST(get_exec_path, returns_length_lessthan_zero)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_length_lessthan_zero");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     UnistdMock mock_instance;
     Unistd::set_testing_instance(mock_instance);
@@ -84,7 +84,7 @@ TEST(get_exec_path, returns_length_equalto_pathmax)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_length_equalto_pathmax");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     UnistdMock mock_instance;
     Unistd::set_testing_instance(mock_instance);
@@ -103,7 +103,7 @@ TEST(get_exec_path, returns_length_greaterthan_pathmax)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_exec_path returns_length_greaterthan_pathmax");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     UnistdMock mock_instance;
     Unistd::set_testing_instance(mock_instance);
@@ -124,7 +124,7 @@ TEST(get_parent_dir, ManPageExamples)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "get_parent_dir Man Page Examples");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(Path::instance().get_parent_dir("/foo/bar"), "/foo");
     EXPECT_EQ(Path::instance().get_parent_dir("foo"), ".");
@@ -141,7 +141,7 @@ TEST(PathTest, PMRDefaultShallReturnImplInstance)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "PathTest PMRDefault Shall Return Impl Instance");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::cpp::pmr::memory_resource* memory_resource = score::cpp::pmr::get_default_resource();
     const auto instance = score::os::Path::Default(memory_resource);

--- a/score/os/utils/test/pmutexTest.cpp
+++ b/score/os/utils/test/pmutexTest.cpp
@@ -29,7 +29,7 @@ TEST(InterprocessMutex, locks)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex locks");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::InterprocessMutex unit{};
 
@@ -44,7 +44,7 @@ TEST(InterprocessMutex, LocksAndFrees)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex Locks And Frees");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::InterprocessMutex unit{};
 
@@ -58,7 +58,7 @@ TEST(InterprocessMutex, DoubleTryLockFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex Double Try Lock Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::InterprocessMutex unit{};
 
@@ -73,7 +73,7 @@ TEST(InterprocessMutex, FulfillsBasicLockableRequirements)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "InterprocessMutex Fulfills Basic Lockable Requirements");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     score::os::InterprocessMutex unit{};
 

--- a/score/os/utils/test/signal_test.cpp
+++ b/score/os/utils/test/signal_test.cpp
@@ -80,7 +80,7 @@ TEST_F(SignalTest, handler_should_be_called)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest handler_should_be_called");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGUSR1, [](int) {
@@ -98,7 +98,7 @@ TEST_F(SignalTest, is_not_a_member_works)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest is_not_a_member_works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     const auto val = unit_->is_member(SIGUSR1, sigset);
@@ -111,7 +111,7 @@ TEST_F(SignalTest, check_if_sig_set_is_empty_works)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest check_if_sig_set_is_empty_works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     auto val = unit_->sigaddset(&sigset, SIGUSR1);
@@ -128,7 +128,7 @@ TEST_F(SignalTest, get_current_blocked_signals)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest get_current_blocked_signals");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     block_signal(SIGUSR1);
@@ -144,7 +144,7 @@ TEST_F(SignalTest, is_signal_blocked)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest is_signal_blocked");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     block_signal(SIGUSR1);
     auto val = unit_->is_signal_block(SIGUSR1);
@@ -158,7 +158,7 @@ TEST_F(SignalTest, pthread_sig_mask)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest pthread_sig_mask");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGUSR1, [](int) {
@@ -186,7 +186,7 @@ TEST_F(SignalTest, send_self_sig_term)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest send_self_sig_term");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGTERM, [](int) {
@@ -204,7 +204,7 @@ TEST_F(SignalTest, sig_action)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest sig_action");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     struct sigaction sig_handler;
@@ -233,7 +233,7 @@ TEST_F(SignalTest, kill)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest kill");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGTERM, [](int) {
@@ -250,7 +250,7 @@ TEST_F(SignalTest, sig_fill_set_works)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest sig_fill_set_works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     auto val = unit_->sigfillset(&sigset);
@@ -265,7 +265,7 @@ TEST_F(SignalTest, add_termination_signal_works)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest add_termination_signal_works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     auto val = unit_->add_termination_signal(sigset);
@@ -279,7 +279,7 @@ TEST_F(SignalTest, isNotAMemberWorks)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest is Not AMember Works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     const auto val = unit_->SigIsMember(sigset, SIGUSR1);
@@ -293,7 +293,7 @@ TEST_F(SignalTest, CheckIfSigSetIsEmptyWorks)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Check If Sig Set Is Empty Works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     auto val = unit_->SigAddSet(sigset, SIGUSR1);
@@ -314,7 +314,7 @@ TEST_F(SignalTest, GetCurrentBlockedSignals)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Get Current Blocked Signals");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     BlockSignal(SIGUSR1);
 
@@ -333,7 +333,7 @@ TEST_F(SignalTest, IsSignalBlocked)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Is Signal Blocked");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     BlockSignal(SIGUSR1);
 
@@ -350,7 +350,7 @@ TEST_F(SignalTest, PthreadSigMask)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Pthread Sig Mask");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGUSR1, [](int) {
@@ -385,7 +385,7 @@ TEST_F(SignalTest, PthreadSigMaskReturnsOldSet)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Pthread Sig Mask Returns Old Set");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGUSR1, [](int) {
@@ -422,7 +422,7 @@ TEST_F(SignalTest, SendSelfSigTerm)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Send Self Sig Term");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGTERM, [](int) {
@@ -440,7 +440,7 @@ TEST_F(SignalTest, SigAction)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Sig Action");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     struct sigaction sig_handler;
@@ -471,7 +471,7 @@ TEST_F(SignalTest, Kill)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Kill");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     static bool triggered = false;
     unit_->signal(SIGTERM, [](int) {
@@ -488,7 +488,7 @@ TEST_F(SignalTest, SigFillSetWorks)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Sig Fill Set Works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     auto val = unit_->SigFillSet(sigset);
@@ -505,7 +505,7 @@ TEST_F(SignalTest, AddTerminationSignalWorks)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SignalTest Add Termination Signal Works");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     sigset_t sigset{};
     auto val = unit_->AddTerminationSignal(sigset);

--- a/score/os/utils/test/spinlocktest.cpp
+++ b/score/os/utils/test/spinlocktest.cpp
@@ -59,7 +59,7 @@ TEST(SpinlockTest, ConcIntManipulation)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpinlockTest Conc Int Manipulation");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Spinlock lk;
     std::uint32_t val1, val2, loopCount;
@@ -85,7 +85,7 @@ TEST(SpinlockTest, TryLock)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpinlockTest Try Lock");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Spinlock lk;
 
@@ -108,7 +108,7 @@ TEST(SpinlockTest, LockGuardSupport)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "SpinlockTest Lock Guard Support");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     Spinlock spinlock;
 

--- a/score/os/utils/test/tcp_keep_alive_test.cpp
+++ b/score/os/utils/test/tcp_keep_alive_test.cpp
@@ -41,7 +41,7 @@ TEST_F(TcpKeepAliveTest, TcpKeepAlive)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "TcpKeepAliveTest Tcp Keep Alive");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     int socketfd = 0;
     EXPECT_CALL(socketMock, setsockopt(socketfd, _, _, _, _)).WillRepeatedly(Return(score::cpp::expected_blank<Error>{}));

--- a/score/os/utils/test/thread_test.cpp
+++ b/score/os/utils/test/thread_test.cpp
@@ -105,7 +105,7 @@ TEST_F(ThreadNameTest, SetNameFails)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ThreadNameTest Set Name Fails");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     const size_t name_length = 200U;
     std::string thread_name(name_length, 'a');
@@ -128,7 +128,7 @@ TEST(ThreadAffinityTest, SetAffinitySucceeds)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "ThreadAffinityTest Set Affinity Succeeds");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_TRUE(set_thread_affinity(0));
 }

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_serializer_visitor.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_serializer_visitor.cpp
@@ -206,7 +206,7 @@ TEST(serializer_visitor, serialized)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization for different data type.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_EQ(check_serialized<char>(), sizeof(char));
     EXPECT_EQ(check_serialized<uint8_t>(), sizeof(uint8_t));
     EXPECT_EQ(check_serialized<uint16_t>(), sizeof(uint16_t));
@@ -263,7 +263,7 @@ TEST(serializer_visitor, serializer)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization and deserialization for different data type.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using namespace ::score::common::visitor;
     using s = serializer_t<real_alloc_t>;
     std::uint8_t buffer[1024];
@@ -519,7 +519,7 @@ TEST(serializer_visitor, custom)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization and deserialization for steady clock time_point.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using s = ::score::common::visitor::serializer_t<real_alloc_t>;
     char buffer[1024];
 
@@ -553,7 +553,7 @@ TEST(serializer_visitor, serialize_unit)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the serialization and deserialization for a struct type.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using s = ::score::common::visitor::serializer_t<real_alloc_t>;
     char buffer[1024];
 
@@ -654,7 +654,7 @@ TEST_F(serializer_visitor_overflows, basic__no_overflow)
                    "The serialization and deserialization for a normal struct shall success when providing the "
                    "serialized and the deserialized buffers with the same sizes.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 2048, 2048);
     EXPECT_EQ(result.first.operator bool(), true);
     EXPECT_EQ(result.second, true);
@@ -668,7 +668,7 @@ TEST_F(serializer_visitor_overflows, basic__serializer_overflow)
                    "The serialization and deserialization for a normal struct shall overflow and reach zero offset "
                    "when deserialize more data than the serialized one.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 100, 2048);
     EXPECT_EQ(result.first.getZeroOffset(), true);
     EXPECT_EQ(result.second, false);
@@ -682,7 +682,7 @@ TEST_F(serializer_visitor_overflows, basic__derserializer_overflow)
                    "The serialization and deserialization for a normal struct shall overflow for reaching out of "
                    "bounds when deserialize less data than the serialized one.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 2048, 100);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
     EXPECT_EQ(result.second, false);
@@ -696,7 +696,7 @@ TEST_F(serializer_visitor_overflows, basic_deserializer_overflow_const)
                    "The serialization and deserialization for a normal struct shall overflow for reaching out of "
                    "bounds when deserialize less data than the serialized one - const type.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     constexpr auto size_in = 2048UL;
     constexpr auto size_out = 100UL;
     result_type result =
@@ -714,7 +714,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part__no_overflow)
         "The serialization and deserialization for a struct with a huge dynamic part shall success when providing the "
         "serialized and the deserialized buffers with the same sizes when allocate a dynamic part.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     structureWithHugeDynamicPart.dynamicPart.resize(100);
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, 4096, 4096);
     EXPECT_EQ(result.first.operator bool(), true);
@@ -730,7 +730,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part__serializer_overflow)
         "The serialization and deserialization for a struct with a huge dynamic part shall overflow when providing the "
         "serialized and the deserialized buffers with the same sizes but without allocating a dynamic part.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     constexpr auto size_in_out = 4096UL;
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, size_in_out, size_in_out);
     EXPECT_EQ(result.first.getZeroOffset(), true);
@@ -745,7 +745,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part_serializer_overflow_too_small_
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization and handle subsize overflows returning the ZeroOffset status.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     constexpr auto size_in_out = 4096UL;
     result_type result =
         ThereAndBackWithErrorCheck<subsize_too_small_alloc_t>(structureWithHugeDynamicPart, size_in_out, size_in_out);
@@ -761,7 +761,7 @@ TEST_F(serializer_visitor_overflows, dynamic_part__deserilizer_overflow)
                    "The serialization and deserialization for a struct with a huge dynamic part shall overflow for "
                    "reaching out of bounds when deserialize less data than the serialized one.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, 8192, 4096);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
     EXPECT_EQ(result.second, false);
@@ -775,7 +775,7 @@ TEST_F(serializer_visitor_overflows, string__no_overflow)
                    "The serialization and deserialization for a string data shall success when providing the "
                    "serialized and the deserialized buffers with the same sizes.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 4096, 4096);
     EXPECT_EQ(result.first.operator bool(), true);
     EXPECT_EQ(result.second, true);
@@ -789,7 +789,7 @@ TEST_F(serializer_visitor_overflows, string__serialization_overflow)
                    "The serialization and deserialization for a string data shall overflow and reach zero offset when "
                    "deserialize more data than the serialized one.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 2048, 4096);
     EXPECT_EQ(result.first.getZeroOffset(), true);
     EXPECT_EQ(result.second, false);
@@ -803,7 +803,7 @@ TEST_F(serializer_visitor_overflows, string_deserialization_overflow)
                    "The serialization and deserialization for a string data shall overflow for reaching out of bounds "
                    "when deserialize less data than the serialized one.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 4096, 2048);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
     EXPECT_EQ(result.second, false);
@@ -815,7 +815,7 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_overflow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the inability of logger_type_info API to copy data bigger than the size.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     constexpr auto cmpr = std::numeric_limits<char>::is_signed ? 0x7f : 0xff;
     constexpr auto array_size = 64UL;
     std::array<char, array_size> buffer;
@@ -840,7 +840,7 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_not_fit)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the inability of logger_type_info API to copy data that does not fit size.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     constexpr auto array_size = 64UL;
     std::array<char, array_size> buffer;
@@ -864,7 +864,7 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_fits)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Test the ability of logger_type_info to copy data.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     constexpr auto array_size = 64UL;
     std::array<char, array_size> buffer{0};
@@ -895,7 +895,7 @@ TEST(logging_serializer_test, serialize_int_data_with_big_miss_match_size)
                    "Verify the inability of serialize integer data by providing a size bigger than"
                    "the original data size.");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::tuple<int, int> tuple_instance{1, 2};
     std::uint8_t buffer[1024];
@@ -912,7 +912,7 @@ TEST(logging_serializer_test, deserialize_int_data_with_big_miss_match_size)
                    "Verify the inability of deserialize integer data by providing a size bigger than"
                    "the original data size.");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     std::tuple<int, int> tuple_instance_in{1, 2};
     std::tuple<int, int> tuple_instance_out;
@@ -935,7 +935,7 @@ TEST(logging_serializer_test, deserialize_byte_data_with_miss_match_size)
                    "Verify the inability of deserialize byte data by providing a size bigger than"
                    "the original data size.");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     test::StructOneSigned struct_one_signed_out;
     char serialized_buffer[1024];
@@ -964,7 +964,7 @@ TEST(clear_functionality_test, test_that_clear_function_can_clear_vector_of_int3
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Verify the inability of clearing vector of int32.");
     RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "Generation and analysis of equivalence classes");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     VectorWrapper vector_wrapper_instance{};
     score::common::visitor::detail::clear(vector_wrapper_instance);

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_size_visitor.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_size_visitor.cpp
@@ -302,7 +302,7 @@ TYPED_TEST_P(SizeVisitorFixture, whenDataSerializedAndThenDeserializedDataShould
                                     "logging library shall provide an annotation mechanism for data structures to "
                                     "support automatic serialization/deserialization.");
     ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
-    ::testing::Test::RecordProperty("DerivationTechnique", "Analysis of requirements");
+    ::testing::Test::RecordProperty("DerivationTechnique", "requirements-analysis");
 
     using s = serializer_t<real_alloc_t>;
     using ssize = serialized_size_t<real_alloc_t>;

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_skip_deserialize.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_skip_deserialize.cpp
@@ -72,7 +72,7 @@ TEST(serializer_visitor, skip_deserialize)
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // S has an "added" std::vector member compared to S3;, it should be detected as incompatible
     EXPECT_FALSE((::score::common::visitor::is_payload_compatible<test::S3s, test::S>()));
 
@@ -106,7 +106,7 @@ TEST(serializer_visitor, skip_deserialize_test_overflow)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Skip deserialization in case the data to be serialized is bigger than the buffer.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     std::array<char, 4> buffer;
     using serializer = ::score::common::visitor::logging_serializer;

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_visitor_type_traits.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_visitor_type_traits.cpp
@@ -34,7 +34,7 @@ TEST(vistor_type_traits, is_vector_serializable)
         "Logging library shall provide an annotation mechanism for data structures to support automatic "
         "serialization/deserialization, So, we are checking some data types to be treated for vector serialization.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     using test::clearable_container;
     using std_basic_string = std::basic_string<char, std::char_traits<char>, std::allocator<char>>;
@@ -59,7 +59,7 @@ TEST(vistor_type_traits, is_not_vector_serializable)
                    "serialization/deserialization. So, we are checking those some data types shouldn't be treated as "
                    "vector serialization.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     using test::unserializable_container;
     static_assert(!is_vector_serializable<std::array<int, 3>>::value,

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_detail.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_detail.cpp
@@ -38,7 +38,7 @@ TEST(detail, extract_type)
                    "Logging library shall provide an annotation mechanism for data structures to support automatic "
                    "serialization/deserialization.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     const auto& likely_format = "static constexpr auto& test::struct_visitable_impl<test::S1>::namedata()";
     const auto type_string = ::score::common::visitor::detail::visitor_extract_type<std::string>(likely_format);
     EXPECT_STREQ(type_string.c_str(), "test::S1");
@@ -60,7 +60,7 @@ TEST(detail, skip_trailing_space)
                    "Verifies that 'strip_trailing_spaces' API shall return the value of the last parameter provided if "
                    "it gets a value out of range or a value zero for parameter 'end'.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     constexpr std::size_t expected_out_of_bounds_end_value = 16;
     constexpr std::size_t expected_zero_output_when_zero_input_end_value = 0;
     auto& simple_text = "simple text";

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_struct_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_struct_visitor.cpp
@@ -180,7 +180,7 @@ TEST(struct_visitor, struct_visitable)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability of different structures.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     EXPECT_TRUE(check_visitable<test::S1>("test::S1", 1));
     EXPECT_TRUE(check_visitable<test::S2>("test::S2", 2));
@@ -210,7 +210,7 @@ TEST(struct_visitor, visit_as)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability of different structures fields.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S1{}), 1);
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S2{}), 2);
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S3{}), 3);
@@ -279,7 +279,7 @@ TEST(struct_visitor, namespaces)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability fields.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using namespace ::score::common::visitor;
     EXPECT_EQ(struct_visitable<S1>::field_name(0), "x1");
     EXPECT_EQ(struct_visitable<test::S1>::field_name(0), "f1");
@@ -306,7 +306,7 @@ TEST(struct_visitor, TemplatedStructShallNotContainTrailingWhitespace)
                    "Verifies that the templated structs shall not contain trailing whaitspace."
                    "serialization/deserialization.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using namespace ::score::common::visitor;
 
     // GCC inserts a trailing whitespace for templated structs in __PRETTY__FUNCTION__.

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_visitor.cpp
@@ -55,7 +55,7 @@ TEST(visitor, visitable_and_nonvisitable)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the visitability and the non-visitability.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     test_visitable_t v1;
     test_nonvisitable_t nv1;
     EXPECT_EQ(::score::common::visitor::visit(test_visitor_t{}, v1), 123);
@@ -136,7 +136,7 @@ TEST(visitor, namespaces)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check visitability equality from different namespaces.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(ns1::test_visitor_t{}, ns1::test_visitable_t{}), 11);
     EXPECT_EQ(visit(ns1::test_visitor_t{}, ns2::test_visitable_t{}), 12);
@@ -177,7 +177,7 @@ TEST(visitor, overloads)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the int and float overloads for 'visit' API.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(test_visitor_t{}, 42.0), 42.0);
     EXPECT_EQ(visit(test_visitor_t{}, 42), 6 * 9);
@@ -203,7 +203,7 @@ TEST(visitor, conversions)
     RecordProperty("ASIL", "B");
     RecordProperty("Description", "Check the convertible argument passing to 'visit' API.");
     RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(test_visitor_derived_t{}, test_int_convertible_t{42}), 6 * 9);
 }


### PR DESCRIPTION
While the derivation technique mostly name the right technique out of the pool of available options in the process description the actual derivation method name do not follow the process_description and platform management plan guideline. This PR fixes the terminology for existing derivation techniques.

The "DerivationTechnique" called "Analyzing architecture and design" is kept untouched in this PR as this is not in the list of derivation techniques of S-CORE.

Fixes #64