### PR TITLE
Replace obsoleted std::result_of_t

### DIFF
--- a/score/concurrency/delayed_task.h
+++ b/score/concurrency/delayed_task.h
@@ -240,7 +240,7 @@ class DelayedTaskFactory
   private:
     template <typename Clock, typename CallableType, typename... ArgumentTypes>
     using result_type =
-        std::result_of_t<CallableType && (score::cpp::stop_token, typename Clock::time_point, ArgumentTypes&&...)>;
+        std::invoke_result_t<CallableType && (score::cpp::stop_token, typename Clock::time_point, ArgumentTypes&&...)>;
 
   public:
     /**

--- a/score/concurrency/periodic_task.h
+++ b/score/concurrency/periodic_task.h
@@ -308,7 +308,7 @@ class PeriodicTaskFactory
     template <typename Clock,
               typename CallableType,
               typename std::enable_if_t<
-                  std::is_same<std::result_of_t<CallableType(const score::cpp::stop_token&, const typename Clock::time_point)>,
+                  std::is_same<std::invoke_result_t<CallableType(const score::cpp::stop_token&, const typename Clock::time_point)>,
                                bool>::value,
                   bool> = true>
     static auto WrapReturnValue(CallableType&& callable)
@@ -325,7 +325,7 @@ class PeriodicTaskFactory
         typename Clock,
         typename CallableType,
         typename std::enable_if_t<
-            !std::is_same<std::result_of_t<CallableType(const score::cpp::stop_token&, const typename Clock::time_point)>,
+            !std::is_same<std::invoke_result_t<CallableType(const score::cpp::stop_token&, const typename Clock::time_point)>,
                           bool>::value,
             bool> = true>
     // overload resolution is unambiguous due to sfinae

--- a/score/concurrency/simple_task.h
+++ b/score/concurrency/simple_task.h
@@ -163,7 +163,7 @@ class SimpleTaskFactory final
 {
   private:
     template <typename CallableType, typename... ArgumentTypes>
-    using result_type = std::result_of_t<CallableType && (score::cpp::stop_token, ArgumentTypes&&...)>;
+    using result_type = std::invoke_result_t<CallableType && (score::cpp::stop_token, ArgumentTypes&&...)>;
 
   public:
     /**

--- a/score/concurrency/timed_executor/delayed_task.h
+++ b/score/concurrency/timed_executor/delayed_task.h
@@ -172,7 +172,7 @@ class DelayedTaskFactory
   private:
     template <typename Clock, typename CallableType, typename... ArgumentTypes>
     using ResultType =
-        std::result_of_t<CallableType && (score::cpp::stop_token, typename Clock::time_point, ArgumentTypes&&...)>;
+        std::invoke_result_t<CallableType && (score::cpp::stop_token, typename Clock::time_point, ArgumentTypes&&...)>;
 
   public:
     /**

--- a/score/concurrency/timed_executor/periodic_task.h
+++ b/score/concurrency/timed_executor/periodic_task.h
@@ -251,7 +251,7 @@ class PeriodicTaskFactory
     // coverity[autosar_cpp14_a0_1_3_violation] false-positive: is used
     constexpr static bool IsReturnOfBoolType()
     {
-        return std::is_same<std::result_of_t<CallableType(const score::cpp::stop_token&, const typename Clock::time_point)>,
+        return std::is_same<std::invoke_result_t<CallableType(const score::cpp::stop_token&, const typename Clock::time_point)>,
                             bool>::value;
     }
 

--- a/score/language/safecpp/safe_math/details/floating_point_environment.h
+++ b/score/language/safecpp/safe_math/details/floating_point_environment.h
@@ -40,7 +40,7 @@ class FloatingPointEnvironment
     /// \tparam F Type of calculation
     /// \param calculation The calculation to perform
     /// \return The result or error
-    template <class F, class T = std::result_of_t<F()>>
+    template <class F, class T = std::invoke_result_t<F()>>
     static score::Result<T> CalculateAndVerify(const F& calculation) noexcept
     {
         FloatingPointEnvironment floating_point_environment{};

--- a/score/language/safecpp/scoped_function/details/scope_state.h
+++ b/score/language/safecpp/scoped_function/details/scope_state.h
@@ -55,7 +55,7 @@ class ScopeState final
 
     void Expire() noexcept;
 
-    template <class Callable, class ReturnType = std::result_of_t<Callable()>>
+    template <class Callable, class ReturnType = std::invoke_result_t<Callable()>>
     [[nodiscard]] score::cpp::optional<ReturnType> InvokeIfNotExpired(Callable& callable)
     {
         // Suppress "AUTOSAR C++14 M0-1-9" rule finding. This rule states: "There shall be no dead code.".


### PR DESCRIPTION
C++17 obsoletes `std::result_of_t` as it had some issues:
1. Inconsistent behavior with function objects and member functions
2. Didn't respect SFINAE properly in all cases
3. Didn't align with std::invoke semantics introduced in C++17

Instead of it, one should use `std::invoke_result_t`.

See the following documents for more details:
* https://en.cppreference.com/w/cpp/types/result_of
* https://en.cppreference.com/w/cpp/types/invoke_result
* http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0604r0.html

Note: In the context of my work, I'd need the change applied only to: score/language/safecpp/safe_math/details/floating_point_environment.h

However, as it's a simple fix, I proposed it to all places where we will evt. need to do the replacement, so we do it once and for all.

Issue: SWP-238375