### PR TITLE
Fixing some of the diagrams in the mw/log section

### DIFF
--- a/score/mw/log/design/README.md
+++ b/score/mw/log/design/README.md
@@ -48,7 +48,7 @@ While the idea of lock-free data structures is not new, the specific rules for t
 Starting from this basic idea, the static design is divided into four main parts:
 
 1. `Formatter`
-   Support different kind of logging formats. The most major one is the [DLT format](<broken_link_g/swh/safe-posix-platform/blob/master/score/mw/log/README.md#dlt-formatted-payload>).
+   Support different kind of logging formats. The most major one is the [DLT format](../README.md#dlt-formatted-payload).
    Another one is the raw format (no special formatting applied). A future extension with other formats will be easy,
    separating this concern from the others mentioned below.
 2. `Backend`
@@ -69,13 +69,13 @@ Starting from this basic idea, the static design is divided into four main parts
 This design allows that any content streamed by the user into a `LogStream`, will directly end up in the respective slot
 implementation.
 
-![Verbose Logging class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/verbose_logging_static.uxf)
+![Verbose Logging class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/verbose_logging_static.puml)
 
-![Verbose Logging sequence diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/verbose_logging_sequence.uxf)
+![Verbose Logging sequence diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/verbose_logging_sequence.puml)
 
-![Non-Verbose Logging class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/non_verbose_logging_static.uxf)
+![Non-Verbose Logging class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/non_verbose_logging_static.puml)
 
-![ErrorDomain class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/error_domain.uxf)
+![ErrorDomain class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/error_domain.puml)
 
 ### Types of recorders
 
@@ -88,28 +88,17 @@ Following recorders are supported:
 5. EmptyRecoder - used when logging is off.
 Because of the similarity between TextRecorder and FileRecorder it is decided to use the common Backend for both.
 
-![Recorders class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/mw_log_recorders.uxf)
-
-![DataRouterRecorder class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/mw_log_datarouter_recorder.uxf)
-
-### WriterFactory Design
-
-![WriterFactory Design](./write_factory_design.puml)
+![Recorders class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/mw_log_recorders.puml)
 
 ### High Level Component Diagram - Remote Logging
-![Remote logging](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/remote_logging.plantuml)
+
+![Remote logging](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/remote_logging.puml)
 
 ### Activity diagrams
 
-![CircularAllocator::AcquireSlotToWrite Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/circular_buffer_allocator_acquireslottowrite.uxf)
+![CircularAllocator::AcquireSlotToWrite Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/circular_buffer_allocator_acquireslottowrite.puml)
 
-![DatarouterMessageClientImpl::ConnectToDatarouter Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/datarouter_message_client_impl_connecttodatarouter.uxf)
-
-![SharedMemoryReader::Read Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/shared_memory_reader_read.uxf)
-
-![SharedMemoryReader::AllocAndWrite Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/shared_memory_writer_allocandwrite.uxf)
-
-![WaitFreeStack::TryPush Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/wait_free_stack_trypush.uxf)
+![WaitFreeStack::TryPush Activity diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/wait_free_stack_trypush.puml)
 
 ### User-Facing APIs
 

--- a/score/mw/log/design/circular_buffer_allocator_acquireslottowrite.puml
+++ b/score/mw/log/design/circular_buffer_allocator_acquireslottowrite.puml
@@ -1,0 +1,19 @@
+@startuml circular_buffer_allocator_acquireslottowrite
+title Circular Buffer Allocator Acquire Slot To Write
+start
+:Loop Counter = 0;
+repeat :Increment loop counter;
+    :Atomically
+    Get slot
+    Increment next slot index;
+    :Slot index = claimed slot % circular buffer capacity;
+    if (Loop counter > circular buffer size) then (Yes)
+        :Return empty;
+        stop
+    else (No)
+    endif
+repeat while (Slot in use?) is (Yes) not (No);
+:Mark Slot as in use;
+:Return Slot index;
+stop
+@enduml

--- a/score/mw/log/design/configuration_design.md
+++ b/score/mw/log/design/configuration_design.md
@@ -37,7 +37,7 @@ the verbose logging configuration and omit the non-verbose aspect.
 
 The use case diagram below shows three typical use cases supported by the design:
 
-![Use Case Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/configuration_use_cases.uxf)
+![Use Case Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/configuration_use_cases.puml)
 
 ## Class Diagram
 
@@ -46,7 +46,7 @@ from the original `mw::log` [design document](README.md). We omit the details
 for the `Recorder` and `Runtime` classes, and focus on the new classes
 introduced in this design:
 
-![Class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/configuration_static.uxf)
+![Class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/configuration_static.puml)
 
 The design is centered around the `RecorderFactory` class, which contains three
 static methods for each major use case. By default for on-target logging the
@@ -89,7 +89,7 @@ file discoverer.
 The sequence diagram below depicts the initialization that takes place once when
 the user makes the first invokes `mw::log`:
 
-![Class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/configuration_sequence.uxf)
+![Class diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/configuration_sequence.puml)
 
 In the diagram, the user calls `mw::log::Error()` to send the first log message
 of the program. The `LogStreamFactory` then calls `GetRecorder()` on the

--- a/score/mw/log/design/configuration_sequence.puml
+++ b/score/mw/log/design/configuration_sequence.puml
@@ -1,0 +1,108 @@
+@startuml configuration_sequence
+title Configuration Sequence
+
+participant "App" as App
+participant "Logger" as LOG
+participant "LogStreamFactory" as LSF
+participant "Runtime" as RT
+participant "RecorderFactory" as RF
+participant "TargetConfigReader" as TCR
+participant "ConfigurationFileDiscoverer" as CFD
+participant "JSON" as JSON
+participant "OS" as OS
+
+activate App
+
+App -> LOG **: CreateLogger(...)
+note right of LOG
+The initialization of the runtime is triggered by the first log call.
+endnote
+
+activate LOG
+
+App -> LOG: LogError()
+
+LOG -> LSF: GetStream(LogLevel)
+
+LSF -> RT: GetRecorder()
+
+alt Runtime instance has not been created
+    RT -> RT: Constructor
+    activate RT
+end
+
+RT -> RF **: CreateRecorderFactory()
+
+activate RF
+
+RT -> RF: CreateFromConfiguration()
+
+
+RF -> CFD **: make_unique<ConfigurationFileDiscoverer>(...)
+activate CFD
+
+RF -> TCR **: make_unique<TargetConfigReader>(ConfigurationFileDiscoverer)
+activate TCR
+
+
+RF -> TCR: ReadConfig()
+
+TCR -> CFD: FindConfigurationFiles()
+
+note right of CFD
+  Find and return the existing
+  config files.
+end note
+
+CFD -> OS: access(/etc/ecu_logging_config.json)
+alt MW_LOG_CONFIG_FILE is defined
+  CFD -> OS: access(MW_LOG_CONFIG_FILE)
+else MW_LOG_CONFIG_FILE is undefined
+  CFD -> OS: access(<cwd>/etc/logging.json)
+  CFD -> OS: access(<cwd>/logging.json)
+  CFD -> OS: access(<binary path>/../etc/logging.json)
+end
+
+CFD -> TCR: Return global and environmental or application config file paths.
+
+TCR -> JSON: FromFile(global_file_path)
+JSON -> TCR: 
+
+alt MW_LOG_CONFIG_FILE is defined
+  TCR -> JSON: FromFile(<environmental file path>)
+  JSON -> TCR: 
+else MW_LOG_CONFIG_FILE is undefined
+  TCR -> JSON: FromFile(<app_file_path>)
+  JSON -> TCR: 
+end
+
+note right of TCR
+  Overwrite global configiuration
+  with environmental or application config file paths.
+end note
+
+TCR -> RF: Return Configuration instance
+
+alt "Console only recorder (compile option)"
+
+Create "TextRecorder" as TR
+RF -> TR: Create instance with configuration
+
+RF -> ER: if logmode other than KConsole is provided.
+
+else "Datarouter (compile option)"
+
+Create "CompositeRecorder" as CR
+
+RF -> CR
+note left of CR
+  Recorder setup depends on the datarouter configuration.
+endnote
+end
+
+RF -> RT: Store returned instance
+
+RT -> LSF: Return Recorder reference
+LSF -> LOG: LogStream with Recorder
+
+@enduml

--- a/score/mw/log/design/configuration_use_case.puml
+++ b/score/mw/log/design/configuration_use_case.puml
@@ -1,0 +1,26 @@
+@startuml configuration_use_cases
+left to right direction
+title Configuration Use Cases
+
+actor "Developer\nDebug application\ndeployed on target" as Dev1
+
+actor "Developer,\nUnit testing" as Dev2  
+actor "Performance\nEngineer" as PerfEng
+
+usecase "ECU wide configuration\n--\nECUID = MPP1\nLogLevel = kError" as UC1_ECU
+usecase "Application configuration\n--\nAPPID = Para\nLogMode = kRemote | kConsole\nLogLevel = kDebug" as UC1_App
+
+usecase "Print the logs on the console for\nanalysis of unit test failures." as UC2_Console
+usecase "No logging.json files" as UC2_Default
+
+usecase "Disable logging completely\nMeasure performance impact of logging" as UC3_Performance
+
+Dev1 --> UC1_ECU : "Use case 1"
+Dev1 --> UC1_App : "Use case 1"
+
+Dev2 --> UC2_Console : "Use case 2"
+Dev2 --> UC2_Default : "Use case 2"
+
+PerfEng --> UC3_Performance : "Use case 3"
+
+@enduml

--- a/score/mw/log/design/dependency_graph.md
+++ b/score/mw/log/design/dependency_graph.md
@@ -5,7 +5,7 @@ implementation details of the backends. Applying the component principles from
 [1] the goal here is to structure the dependencies in a way that instable
 components depend on stable components.
 
-![Use Case Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/frontend_dependency_graph.uxf)
+![Use Case Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/frontend_dependency_graph.puml)
 
 The `mw::log` component is divided in a stable frontend and the backends with
 the implementation details. The frontend shall be API compatible to the ara::log

--- a/score/mw/log/design/file_output_backend.md
+++ b/score/mw/log/design/file_output_backend.md
@@ -31,17 +31,17 @@ or onto the console.
 `MessageBuilder` is responsible for serving data in correct order of flushing
 into file or console and stores some of common parts of the header.
 
-![Static Design](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/mw_log_file_backend.uxf)
+![Static Design](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/mw_log_file_backend.puml)
 
 `SlotDrainer` is responsible for storing and disposal of already serialized
 data. First data gets inserted into circular buffer. After that step program
 flow enters a loop that iterates over available slots in ring buffer and then
 by means of `NonBlockingWriter` iterates over all spans of each message.
 
-![Sequence Design](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/slot_drainer_sequence_design.uxf)
+![Sequence Design](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/slot_drainer_sequence_design.puml)
 
 Flush procedure exits whenever all available data is written to the file or
 writing procedure would block i.e. write operation reports that number of bytes
 written is less then requested.
 
-![Action Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/swh/safe-posix-platform/score/mw/log/design/slot_drainer_action_diagram_design.uxf)
+![Action Diagram](https://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/eclipse-score/baselibs/refs/heads/main/score/mw/log/design/slot_drainer_action_diagram_design.puml)

--- a/score/mw/log/design/frontend_dependency_graph.puml
+++ b/score/mw/log/design/frontend_dependency_graph.puml
@@ -1,0 +1,56 @@
+@startuml frontend_dependency_graph
+title Frontend Dependency Graph
+
+package "mw::log frontend" as frontend {
+  class score::mw::log::Logger {
+    +Includes classes and free functions
+  }
+  class score::mw::log::detail::LogStreamFactory
+  class score::mw::log::LogStream
+  class score::mw::log::detail::Runtime
+  class score::mw::log::LoggerContainer
+  class score::mw::log::LogTypes
+  abstract score::mw::log::Recorder
+  abstract score::mw::log::IRecorderFactory
+}
+
+package "mw::log implementation details" as details {
+  class score::mw::log::detail::Configuration {}
+  class score::mw::log::detail::TargetConfigReader {}
+
+  class score::mw::log::detail::ConsoleRecorder {}
+  class score::mw::log::detail::ConsoleRecorderFactory {}
+  class score::mw::log::detail::EmptyRecorder {}
+
+  class score::mw::log::detail::RecorderFactory {}
+}
+
+
+note top of frontend
+  Frontend contains the public user API,
+  and the necessary classes to interface
+  with the recorder interface.
+end note
+
+note bottom of details
+  Instable components shall
+  depend on stable classes.
+end note
+
+score::mw::log::detail::LogStreamFactory ..> score::mw::log::LogStream
+score::mw::log::detail::Runtime o-- score::mw::log::LoggerContainer
+score::mw::log::detail::Runtime --> score::mw::log::Recorder
+score::mw::log::detail::Runtime o-- score::mw::log::Recorder
+score::mw::log::detail::Runtime --> score::mw::log::detail::Configuration
+score::mw::log::detail::Configuration --> score::mw::log::detail::TargetConfigReader
+score::mw::log::Recorder <|-- score::mw::log::detail::EmptyRecorder
+
+score::mw::log::Recorder <|-- score::mw::log::detail::ConsoleRecorder
+score::mw::log::IRecorderFactory <|-- score::mw::log::detail::ConsoleRecorderFactory
+score::mw::log::detail::ConsoleRecorderFactory ..> score::mw::log::detail::ConsoleRecorder
+
+score::mw::log::LogStream --> score::mw::log::Recorder
+score::mw::log::Logger ..> score::mw::log::LogStream
+score::mw::log::LoggerContainer o-- score::mw::log::Logger
+
+@enduml

--- a/score/mw/log/design/slot_drainer_sequence_design.puml
+++ b/score/mw/log/design/slot_drainer_sequence_design.puml
@@ -1,0 +1,71 @@
+@startuml slot_drainer_sequence_design
+title "SlotDrainer Sequence Design"
+
+participant "Backend" as Backend
+participant "SlotDrainer" as SlotDrainer
+participant "NonBlockingWriter" as NonBlockingWriter
+participant "CircularBuffer" as CircularBuffer
+participant "MessageBuilder" as MessageBuilder
+participant "SlotAllocator<LogRecord>" as SlotAllocator
+
+note over SlotDrainer : Slot Drainer Flush Sequence
+
+activate SlotDrainer
+activate Backend
+activate NonBlockingWriter
+activate CircularBuffer
+activate SlotAllocator
+activate MessageBuilder
+
+group "First Slot"
+Backend -> SlotDrainer : Flush()
+
+SlotDrainer -> MessageBuilder : GetNextSpan(log_record)
+
+SlotDrainer -> CircularBuffer : empty()
+CircularBuffer -> SlotDrainer: false
+
+SlotDrainer -> CircularBuffer : front()
+SlotDrainer -> CircularBuffer : pop_front()
+
+SlotDrainer -> CircularBuffer : empty()
+CircularBuffer -> SlotDrainer: false
+SlotDrainer -> CircularBuffer : front()
+
+SlotDrainer -> SlotAllocator : GetUnderlyingBufferFor(slot)
+SlotDrainer -> MessageBuilder : SetNextMessage(log_record)
+
+SlotDrainer -> NonBlockingWriter : FlushIntoFile()
+NonBlockingWriter -> SlotDrainer: kDone
+SlotDrainer -> SlotAllocator: ReleaseSlot(slot) 
+
+
+SlotDrainer -> MessageBuilder : GetNextSpan()
+end
+
+group "Last Slot"
+
+SlotDrainer -> MessageBuilder : GetNextSpan()
+
+SlotDrainer -> NonBlockingWriter : FlushIntoFile()
+NonBlockingWriter -> SlotDrainer: kDone
+
+SlotDrainer -> MessageBuilder : GetNextSpan()
+
+SlotDrainer -> CircularBuffer : empty()
+CircularBuffer -> SlotDrainer: true
+
+Backend <-- SlotDrainer
+end
+
+group "Error Case"
+
+Backend -> SlotDrainer : Flush()
+SlotDrainer -> NonBlockingWriter : FlushIntoFile()
+NonBlockingWriter -> SlotDrainer: kWouldBlock
+note left of SlotDrainer : SlotDrainer ignores errors
+Backend <--- SlotDrainer
+
+end
+
+@enduml

--- a/score/mw/log/design/wait_free_stack_trypush.puml
+++ b/score/mw/log/design/wait_free_stack_trypush.puml
@@ -1,0 +1,22 @@
+@startuml wait_free_stack_trypush
+title "Wait Free Stack TryPush"
+
+start
+if (Stack capacity is full?) then (Yes)
+else (No)
+    :Atomically
+    Current write index = write index
+    Increment write index;
+    if (Current write index >= number of elements in stack) then (Yes)
+        :Stack capacity full = true;
+    else (No)
+    :Push element to stack;
+    :Memory Fence (Release);
+    :Mark element as writen;
+    :Return Reference to element value;
+    stop
+    endif
+endif
+    :Return nullopt;
+stop
+@enduml


### PR DESCRIPTION
* Diagrams were taken from https://github.com/eclipse-score/inc_mw_log and converted from uxf to puml.
* Also fixed the links to embed the new diagrams in the markdown.
    * Note: the links will work after the diagrams are merged to main.