### PR TITLE
Change nlohmann_json dependency to point to s-core bazel registry

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -131,7 +131,7 @@ deb(
     visibility = ["//visibility:public"],
 )
 
-bazel_dep(name = "nlohmann_json", version = "3.11.3")
+bazel_dep(name = "score_nlohmann_json", version = "3.11.3")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 
 #############################################################


### PR DESCRIPTION
As described in https://github.com/eclipse-score/baselibs/issues/242