### PR TITLE
remove unnecessary lock in SharedMemoryResource::do_deallocate

### DIFF
--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -836,7 +836,6 @@ auto SharedMemoryResource::IsShmInTypedMemory() const noexcept -> bool
 // coverity[autosar_cpp14_a0_1_3_violation] false-positive: part of the public API
 auto SharedMemoryResource::do_deallocate(void*, std::size_t, std::size_t) -> void
 {
-    std::lock_guard<score::os::InterprocessMutex> lock(this->control_block_->mutex);
     /**
      * For the proof of concept we agreed to use a monotonic allocation algorithm.
      * Thus, no deallocation will be performed.


### PR DESCRIPTION
### Summary

This PR removes an unnecessary `std::lock_guard` from the `SharedMemoryResource::do_deallocate` method.

### Problem

The `SharedMemoryResource` implements a monotonic (Arena) allocation strategy, where `deallocate` is a no-op. The current implementation acquires a heavyweight `InterprocessMutex` before doing nothing, which introduces unnecessary performance overhead on every deallocation call.

### Solution

The `std::lock_guard` is removed from the function. Since no shared state is read or modified, no lock is required.

### Benefits

-   **Performance:** Eliminates a costly and unnecessary system call, making deallocation a true zero-cost operation as expected from a monotonic allocator.
-   **Clarity:** The code now more accurately reflects the no-op nature of the function.
