### PR TITLE
const correctness for public interfaces in MemoryManagedResource

### DIFF
--- a/score/analysis/tracing/common/interface_types/shared_memory_location_helpers.h
+++ b/score/analysis/tracing/common/interface_types/shared_memory_location_helpers.h
@@ -62,7 +62,7 @@ auto GetPointerFromLocation(SharedMemoryLocation memory_location, ResourcePointe
     // coverity[autosar_cpp14_m5_0_17_violation]
     // coverity[autosar_cpp14_a5_2_4_violation]
     // coverity[autosar_cpp14_m5_2_8_violation]
-    return reinterpret_cast<T*>(static_cast<std::uint8_t*>(resource_ptr->getBaseAddress()) + memory_location.offset_);// NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-pro-bounds-pointer-arithmetic): Tolerated see above
+    return reinterpret_cast<T*>(const_cast<std::uint8_t*>(static_cast<const std::uint8_t*>(resource_ptr->getBaseAddress())) + memory_location.offset_); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-pro-bounds-pointer-arithmetic): Tolerated see above
     // clang-format on
 }
 
@@ -84,7 +84,7 @@ score::Result<std::size_t> GetOffsetFromPointer(T* pointer, ResourcePointer memo
     // coverity[autosar_cpp14_a5_2_4_violation]
     // coverity[autosar_cpp14_m5_2_8_violation]
     // coverity[autosar_cpp14_m5_0_9_violation]
-    return static_cast<std::size_t>(reinterpret_cast<std::uint8_t*>(pointer) - static_cast<std::uint8_t*>(memory_resource->getBaseAddress()));// NOLINT(cppcoreguidelines-pro-type-reinterpret-cast): Tolerated
+    return static_cast<std::size_t>(reinterpret_cast<const std::uint8_t*>(pointer) - static_cast<const std::uint8_t*>(memory_resource->getBaseAddress())); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast): Tolerated
     // clang-format on
 }
 

--- a/score/memory/shared/fake/my_bounded_memory_resource.cpp
+++ b/score/memory/shared/fake/my_bounded_memory_resource.cpp
@@ -82,7 +82,7 @@ MyBoundedMemoryResource::~MyBoundedMemoryResource()
 {
     if (should_free_memory_on_destruction_)
     {
-        std::free(baseAddress_);
+        std::free(const_cast<void*>(baseAddress_));
     }
     MemoryResourceRegistry::getInstance().remove_resource(memoryResourceId_);
 }
@@ -118,7 +118,7 @@ void MyBoundedMemoryResource::do_deallocate(void* /*memory*/, const std::size_t 
     deallocatedMemory_ += bytes;
 }
 
-MemoryResourceProxy* MyBoundedMemoryResource::AllocateMemoryResourceProxy(const std::uint64_t memory_resource_id)
+const MemoryResourceProxy* MyBoundedMemoryResource::AllocateMemoryResourceProxy(const std::uint64_t memory_resource_id)
 {
     // We allocate the MemoryResourceProxy using worst case alignment so that any further allocations will start at an
     // aligned memory address. This is important so that GetUserAllocatedBytes() is never affected by the allocation of

--- a/score/memory/shared/fake/my_bounded_memory_resource.h
+++ b/score/memory/shared/fake/my_bounded_memory_resource.h
@@ -45,12 +45,12 @@ class MyBoundedMemoryResource final : public ManagedMemoryResource
     MyBoundedMemoryResource& operator=(const MyBoundedMemoryResource&) noexcept = default;
     MyBoundedMemoryResource& operator=(MyBoundedMemoryResource&&) noexcept = default;
 
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return manager_;
     }
 
-    void* getBaseAddress() const noexcept override
+    const void* getBaseAddress() const noexcept override
     {
         return baseAddress_;
     }
@@ -105,18 +105,18 @@ class MyBoundedMemoryResource final : public ManagedMemoryResource
         return false;
     }
 
-    MemoryResourceProxy* AllocateMemoryResourceProxy(const std::uint64_t memory_resource_id);
+    const MemoryResourceProxy* AllocateMemoryResourceProxy(const std::uint64_t memory_resource_id);
 
     static std::uint64_t instanceId;
     static std::size_t memoryResourceProxyAllocationSize_;
 
-    void* baseAddress_;
-    void* endAddress_;
+    const void* baseAddress_;
+    const void* endAddress_;
     std::size_t virtual_address_space_to_reserve_;
     std::size_t already_allocated_bytes_;
     std::size_t deallocatedMemory_;
     std::uint64_t memoryResourceId_;
-    MemoryResourceProxy* manager_;
+    const MemoryResourceProxy* manager_;
     bool should_free_memory_on_destruction_;
 };
 

--- a/score/memory/shared/fake/my_bounded_memory_resource.h
+++ b/score/memory/shared/fake/my_bounded_memory_resource.h
@@ -45,7 +45,7 @@ class MyBoundedMemoryResource final : public ManagedMemoryResource
     MyBoundedMemoryResource& operator=(const MyBoundedMemoryResource&) noexcept = default;
     MyBoundedMemoryResource& operator=(MyBoundedMemoryResource&&) noexcept = default;
 
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return manager_;
     }

--- a/score/memory/shared/fake/my_bounded_shared_memory_resource.h
+++ b/score/memory/shared/fake/my_bounded_shared_memory_resource.h
@@ -54,7 +54,7 @@ class MyBoundedSharedMemoryResource final : public ISharedMemoryResource
         return false;
     }
 
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return resource_.getMemoryResourceProxy();
     }

--- a/score/memory/shared/fake/my_bounded_shared_memory_resource.h
+++ b/score/memory/shared/fake/my_bounded_shared_memory_resource.h
@@ -54,12 +54,12 @@ class MyBoundedSharedMemoryResource final : public ISharedMemoryResource
         return false;
     }
 
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return resource_.getMemoryResourceProxy();
     }
 
-    void* getBaseAddress() const noexcept override
+    const void* getBaseAddress() const noexcept override
     {
         return resource_.getBaseAddress();
     }

--- a/score/memory/shared/fake/my_memory_resource.h
+++ b/score/memory/shared/fake/my_memory_resource.h
@@ -44,7 +44,7 @@ class MyMemoryResource : public ManagedMemoryResource
     {
     }
 
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         MemoryResourceRegistry::getInstance().clear();
         score::cpp::ignore = MemoryResourceRegistry::getInstance().insert_resource(

--- a/score/memory/shared/fake/my_memory_resource.h
+++ b/score/memory/shared/fake/my_memory_resource.h
@@ -44,14 +44,15 @@ class MyMemoryResource : public ManagedMemoryResource
     {
     }
 
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         MemoryResourceRegistry::getInstance().clear();
-        score::cpp::ignore = MemoryResourceRegistry::getInstance().insert_resource({memoryResourceId_, this});
+        score::cpp::ignore = MemoryResourceRegistry::getInstance().insert_resource(
+            {memoryResourceId_, const_cast<MyMemoryResource*>(this)});
         return &this->manager_;
     }
 
-    void* getBaseAddress() const noexcept override
+    const void* getBaseAddress() const noexcept override
     {
         return baseAddress_;
     }

--- a/score/memory/shared/managed_memory_resource.h
+++ b/score/memory/shared/managed_memory_resource.h
@@ -65,19 +65,11 @@ class ManagedMemoryResource : public ::score::cpp::pmr::memory_resource
     ~ManagedMemoryResource() noexcept override = default;
 
     /**
-<<<<<<< HEAD
-=======
      * We need to return a raw pointer, since we need to convert this
      * pointer into an OffsetPtr if it shall be stored in shared memory.
      * @return MemoryResourceProxy* that identifies _this_ memory_resource.
      */
-
-    /// \todo: getMemoryResourceProxy should not return a non const pointer and the method should also be marked const.
-    /// This issue will be investigated and fixed in Ticket-146625"
-    virtual const MemoryResourceProxy* getMemoryResourceProxy() const noexcept = 0;
-
     /**
->>>>>>> 8a2efcd (const correctness for public interfaces in MemoryManagedResource)
      * @brief Construct T allocating underlying MemoryResource
      * @tparam T The type that shall be constructed
      * @tparam Args The argument types

--- a/score/memory/shared/managed_memory_resource.h
+++ b/score/memory/shared/managed_memory_resource.h
@@ -65,6 +65,19 @@ class ManagedMemoryResource : public ::score::cpp::pmr::memory_resource
     ~ManagedMemoryResource() noexcept override = default;
 
     /**
+<<<<<<< HEAD
+=======
+     * We need to return a raw pointer, since we need to convert this
+     * pointer into an OffsetPtr if it shall be stored in shared memory.
+     * @return MemoryResourceProxy* that identifies _this_ memory_resource.
+     */
+
+    /// \todo: getMemoryResourceProxy should not return a non const pointer and the method should also be marked const.
+    /// This issue will be investigated and fixed in Ticket-146625"
+    virtual const MemoryResourceProxy* getMemoryResourceProxy() const noexcept = 0;
+
+    /**
+>>>>>>> 8a2efcd (const correctness for public interfaces in MemoryManagedResource)
      * @brief Construct T allocating underlying MemoryResource
      * @tparam T The type that shall be constructed
      * @tparam Args The argument types
@@ -96,7 +109,7 @@ class ManagedMemoryResource : public ::score::cpp::pmr::memory_resource
      * @brief Get the start address of the memory region that this memory resource is managing
      * @return void* start address of memory resource (e.g. mmap result)
      */
-    virtual void* getBaseAddress() const noexcept = 0;
+    virtual const void* getBaseAddress() const noexcept = 0;
 
     /**
      * @brief Get the start address of the region available to a user of this memory resource.

--- a/score/memory/shared/memory_resource_proxy_test.cpp
+++ b/score/memory/shared/memory_resource_proxy_test.cpp
@@ -148,12 +148,8 @@ TEST_F(BoundCheckedMemoryResourceProxyTest, AllocationIsPossibleWhenProxyInBound
 {
     // Given a registered memory resource and its respective MemoryResourceProxy
     // When allocating memory on the MemoryResourceProxy
-<<<<<<< HEAD
     ManagedMemoryResourceTestAttorney attorney(memoryResource);
     const MemoryResourceProxy* proxy = attorney.getMemoryResourceProxy();
-=======
-    const MemoryResourceProxy* proxy = memoryResource.getMemoryResourceProxy();
->>>>>>> 8a2efcd (const correctness for public interfaces in MemoryManagedResource)
 
     // Align the memory since that will be done before allocating the new memory
     const auto initial_number_allocated_bytes = memoryResource.getAllocatedMemory();

--- a/score/memory/shared/memory_resource_proxy_test.cpp
+++ b/score/memory/shared/memory_resource_proxy_test.cpp
@@ -148,8 +148,12 @@ TEST_F(BoundCheckedMemoryResourceProxyTest, AllocationIsPossibleWhenProxyInBound
 {
     // Given a registered memory resource and its respective MemoryResourceProxy
     // When allocating memory on the MemoryResourceProxy
+<<<<<<< HEAD
     ManagedMemoryResourceTestAttorney attorney(memoryResource);
     const MemoryResourceProxy* proxy = attorney.getMemoryResourceProxy();
+=======
+    const MemoryResourceProxy* proxy = memoryResource.getMemoryResourceProxy();
+>>>>>>> 8a2efcd (const correctness for public interfaces in MemoryManagedResource)
 
     // Align the memory since that will be done before allocating the new memory
     const auto initial_number_allocated_bytes = memoryResource.getAllocatedMemory();

--- a/score/memory/shared/memory_resource_registry.cpp
+++ b/score/memory/shared/memory_resource_registry.cpp
@@ -66,7 +66,7 @@ auto score::memory::shared::MemoryResourceRegistry::insert_resource(
     // If we successfully inserted the ID into the registry, add the memory_range to known_regions.
     if (!input.second->IsOffsetPtrBoundsCheckBypassingEnabled() && result.second)
     {
-        void* const memory_range_start = resource->getBaseAddress();
+        const void* const memory_range_start = resource->getBaseAddress();
         const void* const memory_range_end = resource->getEndAddress();
 
         if ((memory_range_start == nullptr) || (memory_range_end == nullptr))

--- a/score/memory/shared/memory_resource_registry_test.cpp
+++ b/score/memory/shared/memory_resource_registry_test.cpp
@@ -48,7 +48,7 @@ class BasicMemoryResource : public ManagedMemoryResource
           end_address_{reinterpret_cast<void*>(memory_range.second)}
     {
     }
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return nullptr;
     }
@@ -97,7 +97,7 @@ class BoundsCheckBypassingMemoryResource : public ManagedMemoryResource
           end_address_{reinterpret_cast<void*>(memory_range.second)}
     {
     }
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return nullptr;
     }

--- a/score/memory/shared/memory_resource_registry_test.cpp
+++ b/score/memory/shared/memory_resource_registry_test.cpp
@@ -48,11 +48,11 @@ class BasicMemoryResource : public ManagedMemoryResource
           end_address_{reinterpret_cast<void*>(memory_range.second)}
     {
     }
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return nullptr;
     }
-    void* getBaseAddress() const noexcept override
+    const void* getBaseAddress() const noexcept override
     {
         return base_address_;
     }
@@ -97,11 +97,11 @@ class BoundsCheckBypassingMemoryResource : public ManagedMemoryResource
           end_address_{reinterpret_cast<void*>(memory_range.second)}
     {
     }
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return nullptr;
     }
-    void* getBaseAddress() const noexcept override
+    const void* getBaseAddress() const noexcept override
     {
         return base_address_;
     }

--- a/score/memory/shared/new_delete_delegate_resource.cpp
+++ b/score/memory/shared/new_delete_delegate_resource.cpp
@@ -61,7 +61,7 @@ NewDeleteDelegateMemoryResource::~NewDeleteDelegateMemoryResource()
     }
 }
 
-void* NewDeleteDelegateMemoryResource::getBaseAddress() const noexcept
+const void* NewDeleteDelegateMemoryResource::getBaseAddress() const noexcept
 {
     // Suppress "AUTOSAR C++14 A5-2-4" rule finding: "reinterpret_cast shall not be used.".
     // This class holds no real memory, it only has a made-up buffer.
@@ -76,7 +76,7 @@ void* NewDeleteDelegateMemoryResource::getBaseAddress() const noexcept
 
 void* NewDeleteDelegateMemoryResource::getUsableBaseAddress() const noexcept
 {
-    return getBaseAddress();
+    return const_cast<void*>(getBaseAddress());
 }
 
 const void* NewDeleteDelegateMemoryResource::getEndAddress() const noexcept
@@ -92,7 +92,7 @@ const void* NewDeleteDelegateMemoryResource::getEndAddress() const noexcept
     // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): see above
 }
 
-const MemoryResourceProxy* NewDeleteDelegateMemoryResource::getMemoryResourceProxy() noexcept
+const MemoryResourceProxy* NewDeleteDelegateMemoryResource::getMemoryResourceProxy() const noexcept
 {
     // Suppress "AUTOSAR C++14 A9-3-1" rule finding: "Member functions shall not return non-const “raw” pointers or
     // references to private or protected data owned by the class.".

--- a/score/memory/shared/new_delete_delegate_resource.cpp
+++ b/score/memory/shared/new_delete_delegate_resource.cpp
@@ -92,7 +92,7 @@ const void* NewDeleteDelegateMemoryResource::getEndAddress() const noexcept
     // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): see above
 }
 
-const MemoryResourceProxy* NewDeleteDelegateMemoryResource::getMemoryResourceProxy() const noexcept
+const MemoryResourceProxy* NewDeleteDelegateMemoryResource::getMemoryResourceProxy() noexcept
 {
     // Suppress "AUTOSAR C++14 A9-3-1" rule finding: "Member functions shall not return non-const “raw” pointers or
     // references to private or protected data owned by the class.".

--- a/score/memory/shared/new_delete_delegate_resource.h
+++ b/score/memory/shared/new_delete_delegate_resource.h
@@ -52,7 +52,7 @@ class NewDeleteDelegateMemoryResource : public score::memory::shared::ManagedMem
 
     ~NewDeleteDelegateMemoryResource() override;
 
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override;
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override;
     const void* getBaseAddress() const noexcept override;
     void* getUsableBaseAddress() const noexcept override;
 

--- a/score/memory/shared/new_delete_delegate_resource.h
+++ b/score/memory/shared/new_delete_delegate_resource.h
@@ -52,8 +52,8 @@ class NewDeleteDelegateMemoryResource : public score::memory::shared::ManagedMem
 
     ~NewDeleteDelegateMemoryResource() override;
 
-    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override;
-    void* getBaseAddress() const noexcept override;
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override;
+    const void* getBaseAddress() const noexcept override;
     void* getUsableBaseAddress() const noexcept override;
 
     std::size_t GetUserAllocatedBytes() const noexcept override;

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -677,7 +677,7 @@ auto SharedMemoryResource::GetLockFilePath(const std::string& input_path) noexce
 }
 
 // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-auto SharedMemoryResource::getMemoryResourceProxy() const noexcept -> const MemoryResourceProxy*
+auto SharedMemoryResource::getMemoryResourceProxy() noexcept -> const MemoryResourceProxy*
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(this->control_block_ != nullptr,
                            "Control block containing MemoryResourceProxy has not yet been created.");

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -677,7 +677,7 @@ auto SharedMemoryResource::GetLockFilePath(const std::string& input_path) noexce
 }
 
 // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-auto SharedMemoryResource::getMemoryResourceProxy() noexcept -> const MemoryResourceProxy*
+auto SharedMemoryResource::getMemoryResourceProxy() const noexcept -> const MemoryResourceProxy*
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(this->control_block_ != nullptr,
                            "Control block containing MemoryResourceProxy has not yet been created.");
@@ -731,7 +731,7 @@ auto SharedMemoryResource::do_allocate(const std::size_t bytes, const std::size_
     return new_address_aligned;
 }
 
-auto SharedMemoryResource::getBaseAddress() const noexcept -> void*
+auto SharedMemoryResource::getBaseAddress() const noexcept -> const void*
 {
     // Suppress "AUTOSAR C++14 A9-3-1" rule finding: "Member functions shall not return non-const “raw” pointers or
     // references to private or protected data owned by the class.".

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -60,14 +60,13 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     SharedMemoryResource(SharedMemoryResource&& other) = delete;
     SharedMemoryResource& operator=(SharedMemoryResource&&) = delete;
 
-    // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override;
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override;
 
     /**
      * @brief Get the start address of the memory region that this memory resource is managing
      * @return void* start address of memory resource (e.g. mmap result)
      */
-    void* getBaseAddress() const noexcept override;
+    const void* getBaseAddress() const noexcept override;
 
     /**
      * @brief Get the start address of the region available to a user of this SharedMemoryResource.

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -60,7 +60,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     SharedMemoryResource(SharedMemoryResource&& other) = delete;
     SharedMemoryResource& operator=(SharedMemoryResource&&) = delete;
 
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override;
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override;
 
     /**
      * @brief Get the start address of the memory region that this memory resource is managing

--- a/score/memory/shared/shared_memory_resource_heap_allocator_mock.h
+++ b/score/memory/shared/shared_memory_resource_heap_allocator_mock.h
@@ -28,7 +28,7 @@ class SharedMemoryResourceHeapAllocatorMock : public ISharedMemoryResource
   public:
     explicit SharedMemoryResourceHeapAllocatorMock(const std::uint64_t mem_res_id) : resource_{mem_res_id} {}
 
-    MOCK_METHOD(void*, getBaseAddress, (), (const, noexcept, override));
+    MOCK_METHOD(const void*, getBaseAddress, (), (const, noexcept, override));
 
     MOCK_METHOD(void*, getUsableBaseAddress, (), (const, noexcept, override));
 
@@ -46,7 +46,7 @@ class SharedMemoryResourceHeapAllocatorMock : public ISharedMemoryResource
 
     MOCK_METHOD(std::string_view, GetIdentifier, (), (const, noexcept, override));
 
-    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return resource_.getMemoryResourceProxy();
     }

--- a/score/memory/shared/shared_memory_resource_heap_allocator_mock.h
+++ b/score/memory/shared/shared_memory_resource_heap_allocator_mock.h
@@ -46,7 +46,7 @@ class SharedMemoryResourceHeapAllocatorMock : public ISharedMemoryResource
 
     MOCK_METHOD(std::string_view, GetIdentifier, (), (const, noexcept, override));
 
-    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return resource_.getMemoryResourceProxy();
     }

--- a/score/memory/shared/shared_memory_resource_mock.h
+++ b/score/memory/shared/shared_memory_resource_mock.h
@@ -25,9 +25,9 @@ namespace score::memory::shared
 class SharedMemoryResourceMock : public ISharedMemoryResource
 {
   public:
-    MOCK_METHOD(MemoryResourceProxy*, getMemoryResourceProxy, (), (noexcept, override));
+    MOCK_METHOD(const MemoryResourceProxy*, getMemoryResourceProxy, (), (const, noexcept, override));
 
-    MOCK_METHOD(void*, getBaseAddress, (), (const, noexcept, override));
+    MOCK_METHOD(const void*, getBaseAddress, (), (const, noexcept, override));
 
     MOCK_METHOD(void*, getUsableBaseAddress, (), (const, noexcept, override));
 

--- a/score/memory/shared/shared_memory_resource_mock.h
+++ b/score/memory/shared/shared_memory_resource_mock.h
@@ -25,7 +25,7 @@ namespace score::memory::shared
 class SharedMemoryResourceMock : public ISharedMemoryResource
 {
   public:
-    MOCK_METHOD(const MemoryResourceProxy*, getMemoryResourceProxy, (), (const, noexcept, override));
+    MOCK_METHOD(const MemoryResourceProxy*, getMemoryResourceProxy, (), (noexcept, override));
 
     MOCK_METHOD(const void*, getBaseAddress, (), (const, noexcept, override));
 


### PR DESCRIPTION
**Description**

This pull request **solves this issue** (https://github.com/eclipse-score/communication/issues/84) and improves the API safety and robustness of the score::memory::shared library by enforcing const-correctness on key methods. **The primary goal is to prevent accidental modification of internal bookkeeping data within shared memory segments, which could lead to memory corruption.**

The following key changes have been implemented:

**const Return Types and Methods:**

**ManagedMemoryResource::getBaseAddress()** now returns const void*. This protects the underlying ControlBlock from being modified by external callers.
**ManagedMemoryResource::getMemoryResourceProxy()** now returns const MemoryResourceProxy* and is a const method. This ensures the integrity of the proxy's identifier.

**Derived Class and Mock Updates:**

All classes inheriting from ManagedMemoryResource or ISharedMemoryResource (including SharedMemoryResource, NewDeleteDelegateMemoryResource, and all test mocks/fakes) have been updated to correctly override the new const-correct signatures.

**Call Site Adjustments:**

All call sites that invoke getBaseAddress() or getMemoryResourceProxy() have been updated to correctly handle the const return types.
const_cast has been used in a few specific, controlled instances (primarily in test fakes interacting with the MemoryResourceRegistry) to maintain compatibility with older APIs that were not yet const-aware. This was a pragmatic choice to limit the scope of the refactoring while still achieving the primary safety goal.

**How to Test**

**Build the score/memory library and its dependencies:**
bash
`bazel build --config=bl-x86_64-linux //score/memory/...`
**Run all associated tests to ensure no regressions have been introduced:**
bash
`bazel test --config=bl-x86_64-linux //score/memory/...`
All tests should pass, confirming that the const-correctness changes have been applied consistently and correctly throughout the library and its test suite.