### PR TITLE
chore(ci): pin cicd-workflows reusable workflows to commit SHA

### DIFF
--- a/.github/workflows/build_qnx.yml
+++ b/.github/workflows/build_qnx.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         bazel-config: [bl-x86_64-qnx, bl-aarch64-qnx]
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -21,4 +21,4 @@ on:
     types: [checks_requested]
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ on:
     types: [checks_requested]
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
   clang-format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -26,7 +26,7 @@ on:
     types: [checks_requested]
 jobs:
   docs-verify:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     permissions:
       pull-requests: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
   # TODO skipping tests as we don't integrate test results in docs anyways
   docs-build:
     needs: [docs-verify]
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@main
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
This PR is part of a large-scale CI refactoring across all S-CORE repositories.

See the tracking issue:
https://github.com/eclipse-score/cicd-workflows/issues/75

It updates reusable workflow references from `eclipse-score/cicd-workflows`
to the pinned commit SHA (tagged as `v0.0.0`):

`c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0`

Only the `@ref` part of workflow calls is changed, for workflows under:

`eclipse-score/cicd-workflows/.github/workflows/*`

Pinning reusable workflows to a commit SHA ensures stable and reproducible CI
behavior instead of relying on a moving branch reference.

Part of eclipse-score/cicd-workflows#75
