### PR TITLE
memory/shared: Extend flag visibility

### DIFF
--- a/score/memory/shared/flags/BUILD
+++ b/score/memory/shared/flags/BUILD
@@ -26,5 +26,6 @@ config_setting(
     visibility = [
         "@score_baselibs//score/memory/shared/typedshm/typedshm_wrapper:__subpackages__",
         "@score_baselibs//score/memory/shared/typedshm/utils:__subpackages__",
+        "@score_communication//score/mw/com/impl:__subpackages__",
     ],
 )


### PR DESCRIPTION
config_use_typedshmd is now visible for
score_communication//score/mw/com/impl