### PR TITLE
replaced score::cpp with std

### DIFF
--- a/score/analysis/tracing/common/flexible_circular_allocator/BUILD
+++ b/score/analysis/tracing/common/flexible_circular_allocator/BUILD
@@ -33,7 +33,6 @@ cc_library(
         "@score_baselibs//score/analysis/tracing/common/flexible_circular_allocator/error_codes/flexible_circular_allocator:error_code",
         "@score_baselibs//score/analysis/tracing/common/interface_types:generic_trace_api_types",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
-        "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
     ],
 )
@@ -60,7 +59,6 @@ cc_library(
         "@score_baselibs//score/analysis/tracing/common/interface_types:generic_trace_api_types",
         "@score_baselibs//score/analysis/tracing/common/utilities:tracing_utils",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
-        "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
     ],
 )

--- a/score/analysis/tracing/common/flexible_circular_allocator/lockless_flexible_circular_allocator.cpp
+++ b/score/analysis/tracing/common/flexible_circular_allocator/lockless_flexible_circular_allocator.cpp
@@ -12,7 +12,6 @@
  ********************************************************************************/
 #include "score/analysis/tracing/common/flexible_circular_allocator/lockless_flexible_circular_allocator.h"
 
-#include <score/utility.hpp>
 #include <memory>
 namespace score
 {

--- a/score/analysis/tracing/common/shared_list/shared_list.h
+++ b/score/analysis/tracing/common/shared_list/shared_list.h
@@ -146,7 +146,7 @@ class alignas(std::max_align_t) List
         {
             if (flexible_allocator_)  // LCOV_EXCL_BR_LINE not testable see comment above.
             {
-                score::cpp::ignore = flexible_allocator_->Deallocate(static_cast<void*>(node), sizeof(Node));
+                std::ignore = flexible_allocator_->Deallocate(static_cast<void*>(node), sizeof(Node));
             }
         }
     }

--- a/score/analysis/tracing/common/shared_list/test/shared_list_test.cpp
+++ b/score/analysis/tracing/common/shared_list/test/shared_list_test.cpp
@@ -290,7 +290,7 @@ TEST_F(SharedListFixture, IteratorDereferenceAllocateSuccessfully)
     shared::List<std::uint8_t>::iterator iterator(&list, nullptr);
 
     auto value = *iterator;
-    score::cpp::ignore = value;
+    std::ignore = value;
 
     free(allocated_memory);
 }
@@ -305,7 +305,7 @@ TEST_F(SharedListFixture, IteratorDereferenceFailToAllocate)
     shared::List<std::uint8_t>::iterator iterator(&list, nullptr);
 
     auto value = *iterator;
-    score::cpp::ignore = value;
+    std::ignore = value;
 }
 
 TEST_F(SharedListFixture, SharedMemoryChunk)
@@ -343,7 +343,7 @@ TEST_F(SharedListFixture, SharedMemoryChunk)
             if (!emplace_result.has_value())
             {
                 list.clear();
-                score::cpp::ignore = flexible_allocator->Deallocate(vector_shm_raw_pointer, sizeof(ShmChunkVector));
+                std::ignore = flexible_allocator->Deallocate(vector_shm_raw_pointer, sizeof(ShmChunkVector));
                 std::cout << "ErrorCode::kNotEnoughMemoryRecoverable" << std::endl;
             }
         }

--- a/score/analysis/tracing/generic_trace_library/interface_types/BUILD
+++ b/score/analysis/tracing/generic_trace_library/interface_types/BUILD
@@ -26,7 +26,6 @@ cc_library(
         ":meta_info",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/chunk_list",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
-        "@score_baselibs//score/language/futurecpp",
     ],
 )
 
@@ -43,7 +42,6 @@ cc_library(
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/chunk_list",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
         "@score_baselibs//score/concurrency",
-        "@score_baselibs//score/language/futurecpp",
     ],
 )
 
@@ -68,7 +66,6 @@ cc_library(
     ],
     deps = [
         ":type_definitions",
-        "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory:string_literal",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/interface_types/ara_com_properties.cpp
+++ b/score/analysis/tracing/generic_trace_library/interface_types/ara_com_properties.cpp
@@ -20,7 +20,7 @@ namespace tracing
 {
 AraComProperties::AraComProperties(const TracePointType trace_point_type,
                                    const ServiceInstanceElement service_instance_element,
-                                   score::cpp::optional<TracePointDataId> opt_trace_point_data_id)
+                                   std::optional<TracePointDataId> opt_trace_point_data_id)
     : trace_point_id{trace_point_type, service_instance_element}, trace_point_data_id{opt_trace_point_data_id}
 {
 }

--- a/score/analysis/tracing/generic_trace_library/interface_types/ara_com_properties.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/ara_com_properties.h
@@ -15,7 +15,8 @@
 
 #include "service_instance_element.h"
 #include "trace_point_type.h"
-#include <score/optional.hpp>
+#include <optional>
+#include <utility>
 
 namespace score
 {
@@ -37,11 +38,11 @@ class AraComProperties
     TracePointIdentification trace_point_id;
     // No harm from not declaring private members here
     // coverity[autosar_cpp14_m11_0_1_violation]
-    score::cpp::optional<TracePointDataId> trace_point_data_id;
+    std::optional<TracePointDataId> trace_point_data_id;
 
     AraComProperties(const TracePointType trace_point_type,
                      const ServiceInstanceElement service_instance_element,
-                     score::cpp::optional<TracePointDataId> opt_trace_point_data_id);
+                     std::optional<TracePointDataId> opt_trace_point_data_id);
 };
 bool operator==(const AraComProperties& lhs, const AraComProperties& rhs) noexcept;
 

--- a/score/analysis/tracing/generic_trace_library/interface_types/chunk_list/BUILD
+++ b/score/analysis/tracing/generic_trace_library/interface_types/chunk_list/BUILD
@@ -37,7 +37,6 @@ cc_library(
         "@score_baselibs//score/analysis/tracing/common/interface_types:shared_memory_location_helpers",
         "@score_baselibs//score/analysis/tracing/common/shared_list",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
-        "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory/shared:types",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/interface_types/chunk_list/shm_data_chunk_list.cpp
+++ b/score/analysis/tracing/generic_trace_library/interface_types/chunk_list/shm_data_chunk_list.cpp
@@ -152,7 +152,7 @@ score::Result<SharedMemoryLocation> ShmDataChunkList::SaveToSharedMemory(
     auto list_data = vector->GetData();
     if (!list_data.has_value())
     {
-        score::cpp::ignore = flexible_allocator->Deallocate(vector_shm_raw_pointer_result.value(), sizeof(ShmChunkVector));
+        std::ignore = flexible_allocator->Deallocate(vector_shm_raw_pointer_result.value(), sizeof(ShmChunkVector));
         return score::MakeUnexpected(ErrorCode::kMemoryCorruptionDetectedFatal);
     }
     auto& list = list_data.value().get();
@@ -171,7 +171,7 @@ score::Result<SharedMemoryLocation> ShmDataChunkList::SaveToSharedMemory(
         if (!emplace_result.has_value())
         {
             list.clear();
-            score::cpp::ignore = flexible_allocator->Deallocate(vector_shm_raw_pointer_result.value(), sizeof(ShmChunkVector));
+            std::ignore = flexible_allocator->Deallocate(vector_shm_raw_pointer_result.value(), sizeof(ShmChunkVector));
             return score::MakeUnexpected(ErrorCode::kNotEnoughMemoryRecoverable);
         }
     }

--- a/score/analysis/tracing/generic_trace_library/interface_types/error_code/BUILD
+++ b/score/analysis/tracing/generic_trace_library/interface_types/error_code/BUILD
@@ -28,7 +28,6 @@ cc_library(
         "@score_baselibs//score/analysis:__subpackages__",
     ],
     deps = [
-        "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/interface_types/error_code/error_code.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/error_code/error_code.h
@@ -14,7 +14,6 @@
 #define SCORE_ANALYSIS_TRACING_GENERIC_TRACE_LIBRARY_INTERFACE_TYPES_ERROR_CODE_ERROR_CODE_H
 
 #include "score/result/error.h"
-#include <score/string_view.hpp>
 
 namespace score
 {

--- a/score/analysis/tracing/generic_trace_library/interface_types/meta_info.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/meta_info.h
@@ -14,7 +14,6 @@
 #define SCORE_ANALYSIS_TRACING_GENERIC_TRACE_LIBRARY_INTERFACE_TYPES_META_INFO_H
 
 #include "ara_com_properties.h"
-#include <score/optional.hpp>
 #include <bitset>
 #include <cstdint>
 #include <type_traits>

--- a/score/analysis/tracing/generic_trace_library/interface_types/meta_info_variants.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/meta_info_variants.h
@@ -15,7 +15,7 @@
 
 #include "ara_com_meta_info.h"
 #include "dlt_meta_info.h"
-#include <score/variant.hpp>
+#include <variant>
 
 namespace score
 {
@@ -29,7 +29,7 @@ class MetaInfoVariants
 {
   public:
     /// @brief Datatype used to store meta info data in std::variant
-    using Type = score::cpp::variant<AraComMetaInfo, DltMetaInfo>;
+    using Type = std::variant<AraComMetaInfo, DltMetaInfo>;
 };
 
 }  // namespace tracing

--- a/score/analysis/tracing/generic_trace_library/interface_types/service_instance_element.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/service_instance_element.h
@@ -13,8 +13,8 @@
 #ifndef SCORE_ANALYSIS_TRACING_GENERIC_TRACE_LIBRARY_INTERFACE_TYPES_SERVICE_INSTANCE_ELEMENT_H
 #define SCORE_ANALYSIS_TRACING_GENERIC_TRACE_LIBRARY_INTERFACE_TYPES_SERVICE_INSTANCE_ELEMENT_H
 
-#include <score/utility.hpp>
-#include <score/variant.hpp>
+#include <cstdint>
+#include <variant>
 
 namespace score
 {
@@ -31,10 +31,37 @@ class ServiceInstanceElement
   public:
     using ServiceIdType = std::uint32_t;   ///< Type used to store Service Id
     using InstanceIdType = std::uint32_t;  ///< Type used to store Instance Id
-    using EventIdType = std::uint32_t;     ///< Type used to store Event Id
-    using FieldIdType = std::uint32_t;     ///< Type used to store Field Id
-    using MethodIdType = std::uint32_t;    ///< Type used to store Method Id
-    using VariantType = score::cpp::variant<EventIdType, FieldIdType, MethodIdType>;
+
+    /// @brief Type used to store Event Id (distinct struct for type-safe variant)
+    struct EventIdType
+    {
+        std::uint32_t value;
+        bool operator==(const EventIdType& rhs) const
+        {
+            return value == rhs.value;
+        }
+    };
+    /// @brief Type used to store Field Id (distinct struct for type-safe variant)
+    struct FieldIdType
+    {
+        std::uint32_t value;
+        bool operator==(const FieldIdType& rhs) const
+        {
+            return value == rhs.value;
+        }
+    };
+    /// @brief Type used to store Method Id (distinct struct for type-safe variant)
+    struct MethodIdType
+    {
+        std::uint32_t value;
+        bool operator==(const MethodIdType& rhs) const
+        {
+            return value == rhs.value;
+        }
+    };
+
+    using VariantType = std::variant<EventIdType, FieldIdType, MethodIdType>;
+
     // No harm to declare the members as public
     //  coverity[autosar_cpp14_m11_0_1_violation]
     ServiceIdType service_id;
@@ -53,11 +80,13 @@ class ServiceInstanceElement
 
     // No harm from defining the == operator as member function
     // coverity[autosar_cpp14_a13_5_5_violation]
-    bool operator==(const ServiceInstanceElement& other) const
+    bool operator==(const ServiceInstanceElement& rhs) const
     {
-        return ((((service_id == other.service_id) && (major_version == other.major_version)) &&
-                 ((minor_version == other.minor_version) && (instance_id == other.instance_id))) &&
-                (element_id == other.element_id));
+        // No harm as there are already parenthesis around the logical operators
+        // coverity[autosar_cpp14_a5_2_6_violation]
+        return ((((service_id == rhs.service_id) && (major_version == rhs.major_version)) &&
+                 ((minor_version == rhs.minor_version) && (instance_id == rhs.instance_id))) &&
+                (element_id == rhs.element_id));
     }
 };
 

--- a/score/analysis/tracing/generic_trace_library/stub_implementation/BUILD
+++ b/score/analysis/tracing/generic_trace_library/stub_implementation/BUILD
@@ -25,6 +25,5 @@ cc_library(
     deps = [
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api_header",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:trace_library_interface",
-        "@score_baselibs//score/language/futurecpp",
     ],
 )


### PR DESCRIPTION
This PR migrates tracing and related components from  score::cpp types to standard C++17 std equivalents.