### PR TITLE
build: make interprocess_mutex visibility public

### DIFF
--- a/score/os/utils/interprocess/BUILD
+++ b/score/os/utils/interprocess/BUILD
@@ -21,12 +21,7 @@ cc_library(
     hdrs = ["interprocess_mutex.h"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
-    visibility = [
-        "@score_baselibs//score/concurrency:__pkg__",
-        "@score_baselibs//score/memory/shared:__pkg__",
-        "@score_baselibs//score/memory/shared/test/sct:__pkg__",
-        "@score_baselibs//score/os/utils/test:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         "@score_baselibs//score/language/futurecpp",
     ],


### PR DESCRIPTION
interprocess_notification in the same package is already public and depends on interprocess_mutex, so the mutex is effectively accessible transitively. Making it explicitly public enables cross-repo consumers that need direct access to the mutex API.