### PR TITLE
result library fully nodiscard

### DIFF
--- a/score/concurrency/thread_pool_test.cpp
+++ b/score/concurrency/thread_pool_test.cpp
@@ -44,7 +44,7 @@ TEST(ThreadPool, ConstructionWithCustomName)
     });
 
     // Then the task is executed
-    f.Get();
+    score::cpp::ignore = f.Get();
     ASSERT_EQ(counter, 1U);
 }
 

--- a/score/json/internal/parser/vajson/unit_test/ut_depth_counter.cpp
+++ b/score/json/internal/parser/vajson/unit_test/ut_depth_counter.cpp
@@ -35,8 +35,8 @@ namespace unit_test
 TEST(UT__DepthCounter, MoveAssignment)
 {
     internal::DepthCounter dc{};
-    dc.AddArray();
-    dc.AddValue();
+    score::cpp::ignore = dc.AddArray();
+    score::cpp::ignore = dc.AddValue();
     auto result = dc.CheckEndOfFile();
     ASSERT_EQ(result.error(), JsonErrc::kInvalidJson);
     ASSERT_EQ(result.error().UserMessage(),
@@ -62,8 +62,8 @@ TEST(UT__DepthCounter, MoveAssignment)
 TEST(UT__DepthCounter, MoveConstruction)
 {
     internal::DepthCounter dc{};
-    dc.AddArray();
-    dc.AddValue();
+    score::cpp::ignore = dc.AddArray();
+    score::cpp::ignore = dc.AddValue();
 
     const auto result = dc.CheckEndOfFile();
     ASSERT_EQ(result.error(), JsonErrc::kInvalidJson);

--- a/score/json/internal/parser/vajson/unit_test/ut_json_ops.cpp
+++ b/score/json/internal/parser/vajson/unit_test/ut_json_ops.cpp
@@ -158,7 +158,7 @@ TEST(UT__JsonOps, ReadStringAbortsOnEmpty)
 {
     TestStream ts{"Does not matter"};
 
-    ASSERT_DEATH(ts.ops.ReadString(""), "JsonOps::ReadString: Cannot check for empty string");
+    ASSERT_DEATH(score::cpp::ignore = ts.ops.ReadString(""), "JsonOps::ReadString: Cannot check for empty string");
 }
 
 /*!

--- a/score/result/details/expected/expected.h
+++ b/score/result/details/expected/expected.h
@@ -76,7 +76,7 @@ template <typename E>
 // copy assignment operators.
 // NOLINTBEGIN(cppcoreguidelines-special-member-functions): shall be implicitly declared as per the C++23 standard.
 // coverity[autosar_cpp14_a12_0_1_violation]
-class unexpected : impl::base_unexpected
+class [[nodiscard]] unexpected : impl::base_unexpected
 // NOLINTEND(cppcoreguidelines-special-member-functions): shall be implicitly declared as per the C++23 standard.
 {
   public:
@@ -115,16 +115,16 @@ class unexpected : impl::base_unexpected
     // NOLINTNEXTLINE(performance-noexcept-move-constructor) qualification from the move assignment operator of E.
     constexpr unexpected& operator=(unexpected&&) = default;
 
-    constexpr const E& error() const& noexcept
+    [[nodiscard]] constexpr const E& error() const& noexcept
     {
         return value_;
     }
-    constexpr E& error() & noexcept
+    [[nodiscard]] constexpr E& error() & noexcept
     {
         // coverity[autosar_cpp14_a9_3_1_violation] by design
         return value_;
     }
-    constexpr const E&& error() const&& noexcept
+    [[nodiscard]] constexpr const E&& error() const&& noexcept
     {
         // Suppress AUTOSAR C++14 A18-9-3" rule violations. The rule states "The std::move shall not be used on objects
         // declared const or const&." the move operation on a const object does not cause unintended behavior it ensures
@@ -132,7 +132,7 @@ class unexpected : impl::base_unexpected
         // coverity[autosar_cpp14_a18_9_3_violation]
         return std::move(value_);
     }
-    constexpr E&& error() && noexcept
+    [[nodiscard]] constexpr E&& error() && noexcept
     {
         return std::move(value_);
     }
@@ -208,7 +208,7 @@ unexpected(E) -> unexpected<E>;
 #endif
 
 template <typename T, typename E>
-class SPP_EXPECTED_NODISCARD expected : impl::base_expected
+class [[nodiscard]] expected : impl::base_expected
 {
     // Suppress "AUTOSAR C++14 A5-1-7" rule finding. This rule states: "A lambda shall not be an operand to decltype or
     // typeid". False-positive, at this point "decltype" is not used with lambda.
@@ -1031,7 +1031,7 @@ class SPP_EXPECTED_NODISCARD expected : impl::base_expected
 };
 
 template <typename E>
-class SPP_EXPECTED_NODISCARD expected<void, E> : impl::base_expected
+class [[nodiscard]] expected<void, E> : impl::base_expected
 {
     // Suppress "AUTOSAR C++14 A5-1-7" rule finding. This rule states: "A lambda shall not be an operand to decltype or
     // typeid". False-positive, at this point "decltype" is not used with lambda.

--- a/score/result/details/expected/expected.h
+++ b/score/result/details/expected/expected.h
@@ -76,7 +76,7 @@ template <typename E>
 // copy assignment operators.
 // NOLINTBEGIN(cppcoreguidelines-special-member-functions): shall be implicitly declared as per the C++23 standard.
 // coverity[autosar_cpp14_a12_0_1_violation]
-class unexpected : impl::base_unexpected
+class [[nodiscard]] unexpected : impl::base_unexpected
 // NOLINTEND(cppcoreguidelines-special-member-functions): shall be implicitly declared as per the C++23 standard.
 {
   public:
@@ -115,16 +115,16 @@ class unexpected : impl::base_unexpected
     // NOLINTNEXTLINE(performance-noexcept-move-constructor) qualification from the move assignment operator of E.
     constexpr unexpected& operator=(unexpected&&) = default;
 
-    constexpr const E& error() const& noexcept
+    [[nodiscard]] constexpr const E& error() const& noexcept
     {
         return value_;
     }
-    constexpr E& error() & noexcept
+    [[nodiscard]] constexpr E& error() & noexcept
     {
         // coverity[autosar_cpp14_a9_3_1_violation] by design
         return value_;
     }
-    constexpr const E&& error() const&& noexcept
+    [[nodiscard]] constexpr const E&& error() const&& noexcept
     {
         // Suppress AUTOSAR C++14 A18-9-3" rule violations. The rule states "The std::move shall not be used on objects
         // declared const or const&." the move operation on a const object does not cause unintended behavior it ensures
@@ -132,7 +132,7 @@ class unexpected : impl::base_unexpected
         // coverity[autosar_cpp14_a18_9_3_violation]
         return std::move(value_);
     }
-    constexpr E&& error() && noexcept
+    [[nodiscard]] constexpr E&& error() && noexcept
     {
         return std::move(value_);
     }
@@ -189,26 +189,8 @@ class unexpected : impl::base_unexpected
 template <class E>
 unexpected(E) -> unexpected<E>;
 
-// Suppress "AUTOSAR C++14 A16-0-1" rule findings. This rule stated: "The pre-processor shall only be used for
-// unconditional and conditional file inclusion and include guards, and using the following directives: (1) #ifndef,
-// #ifdef, (3) #if, (4) #if defined, (5) #elif, (6) #else, (7) #define, (8) #endif, (9) #include.".
-// Suppress "AUTOSAR C++14 M16-0-2" rule findings. This rule stated: "Macros shall only be #define’d or #undef’d in
-// the global namespace".
-// Tolerated by project to enable/disable enforce and expected nodiscard.
-// coverity[autosar_cpp14_a16_0_1_violation]
-#ifdef SPP_ENFORCE_NODISCARD
-// coverity[autosar_cpp14_a16_0_1_violation]
-#define SPP_EXPECTED_NODISCARD [[nodiscard]]
-// coverity[autosar_cpp14_a16_0_1_violation]
-#else
-// coverity[autosar_cpp14_m16_0_2_violation]
-// coverity[autosar_cpp14_a16_0_1_violation]
-#define SPP_EXPECTED_NODISCARD
-// coverity[autosar_cpp14_a16_0_1_violation]
-#endif
-
 template <typename T, typename E>
-class SPP_EXPECTED_NODISCARD expected : impl::base_expected
+class [[nodiscard]] expected : impl::base_expected
 {
     // Suppress "AUTOSAR C++14 A5-1-7" rule finding. This rule states: "A lambda shall not be an operand to decltype or
     // typeid". False-positive, at this point "decltype" is not used with lambda.
@@ -1031,7 +1013,7 @@ class SPP_EXPECTED_NODISCARD expected : impl::base_expected
 };
 
 template <typename E>
-class SPP_EXPECTED_NODISCARD expected<void, E> : impl::base_expected
+class [[nodiscard]] expected<void, E> : impl::base_expected
 {
     // Suppress "AUTOSAR C++14 A5-1-7" rule finding. This rule states: "A lambda shall not be an operand to decltype or
     // typeid". False-positive, at this point "decltype" is not used with lambda.


### PR DESCRIPTION
Make result fully nodiscard to prevent ignored return values.