### PR TITLE
Ignore examples from bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+examples


### PR DESCRIPTION
Exclude examples from repository-wide Bazel patterns because it is a separate Bazel module and may cause  symlink recursion or external dependency resolution issues when building all targets (//...).