### PR TITLE
Update CI workflows for `eclipse-score/cicd-workflows` and `setup-bazel`

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.job }}_${{ matrix.bazel-config }}

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
-        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7e109c9e97670ec621adaea1c21721c18212a96d
+        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/build_qnx.yml
+++ b/.github/workflows/build_qnx.yml
@@ -46,7 +46,7 @@ jobs:
               -//score/memory/shared:shared_memory_resource_open_test
               -//score/os/utils/inotify:unit_test
             extra-bazel-test-flags: "--test_timeout=120,600,1800,7200" # Increase test timeout due to QEMU emulation
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@ac25d669e392955be86ac87cc7ce3a56e2a6b838
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@7b265b4accb24997dcb0de449c34d23853709f57
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -23,4 +23,4 @@ on:
     types: [checks_requested]
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@7b265b4accb24997dcb0de449c34d23853709f57

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -16,9 +16,6 @@ permissions:
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - main
   merge_group:
     types: [checks_requested]
 jobs:

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y lcov
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.job }}

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
-        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7e109c9e97670ec621adaea1c21721c18212a96d
+        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Install lcov
         run: |
           sudo apt-get update

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.job }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,9 +16,6 @@ permissions:
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - main
   merge_group:
     types: [checks_requested]
 jobs:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ on:
     types: [checks_requested]
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@7b265b4accb24997dcb0de449c34d23853709f57
   clang-format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.job }}

--- a/.github/workflows/sanitizers_linux.yml
+++ b/.github/workflows/sanitizers_linux.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
-        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7e109c9e97670ec621adaea1c21721c18212a96d
+        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/sanitizers_linux.yml
+++ b/.github/workflows/sanitizers_linux.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.job }}

--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -26,7 +26,7 @@ on:
     types: [checks_requested]
 jobs:
   docs-verify:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@7b265b4accb24997dcb0de449c34d23853709f57
     permissions:
       pull-requests: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
   # TODO skipping tests as we don't integrate test results in docs anyways
   docs-build:
     needs: [docs-verify]
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@7b265b4accb24997dcb0de449c34d23853709f57
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use newer versions of shared workflow and action dependencies, as well as Bazel setup actions. The main focus is on keeping CI infrastructure up to date and consistent across different workflows.

  - Updated references to `eclipse-score/cicd-workflows` actions and workflows in all workflow files to use commit `7b265b4accb24997dcb0de449c34d23853709f57`. QNX build job won't require approval in pushes to main.

  - Updated the `bazel-contrib/setup-bazel` action from version `0.18.0` to `0.19.0`. It comes with Node.js update. See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

  - Removed the `push` trigger for the `main` branch from the `copyright.yml` and `format.yml` workflows, so they now only run on pull requests and merge group events, which is enough for our use case.