### PR TITLE
Use system libs for acl and libcap2 on ebclfsa and autosd10 platforms

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,20 +11,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 
-cc_library(
-    name = "acl_system",
-    linkopts = ["-lacl"],
-    visibility = ["//:__subpackages__"],
+config_setting(
+    name = "ebclfsa",
+    constraint_values = [
+        "@score_bazel_platforms//runtime_es:ebclfsa",
+    ],
 )
 
-alias(
-    name = "acl",
-    actual = select({
-        "//third_party:use_system_libs": ":acl_system",
-        "@platforms//cpu:aarch64": "@acl-deb-aarch64//:acl",
-        "//conditions:default": "@acl-deb//:acl",
-    }),
+config_setting(
+    name = "autosd10",
+    constraint_values = [
+        "@score_bazel_platforms//runtime_es:autosd10",
+    ],
+)
+
+selects.config_setting_group(
+    name = "use_system_libs",
+    match_any = [
+        ":ebclfsa",
+        ":autosd10",
+    ],
     visibility = ["//:__subpackages__"],
 )

--- a/third_party/libcap2/BUILD
+++ b/third_party/libcap2/BUILD
@@ -11,9 +11,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "libcap2_system",
+    linkopts = ["-lcap"],
+    visibility = ["//:__subpackages__"],
+)
+
 alias(
     name = "libcap2",
     actual = select({
+        "//third_party:use_system_libs": ":libcap2_system",
         "@platforms//cpu:aarch64": "@libcap2-dev-deb-aarch64//:libcap2",
         "//conditions:default": "@libcap2-dev-deb//:libcap2",
     }),


### PR DESCRIPTION
This pull request adds support for building against system-installed versions of the `acl` and `libcap2` libraries when specific Bazel platform constraints are set. It introduces new configuration settings and updates the build rules to allow for selection between system and bundled versions of these libraries.

**Build system enhancements:**

* Added new configuration settings (`ebclfsa` and `autosd10`) and a `use_system_libs` config setting group in `third_party/BUILD` to enable conditional use of system libraries based on Bazel platform constraints.

**Library selection improvements:**

* In `third_party/acl/BUILD`, added a `cc_library` target (`acl_system`) that links against the system `acl` library (`-lacl`), and updated the `acl` alias to select this target when `use_system_libs` is enabled.
* In `third_party/libcap2/BUILD`, added a `cc_library` target (`libcap2_system`) that links against the system `libcap2` library (`-lcap`), and updated the `libcap2` alias to select this target when `use_system_libs` is enabled.