### PR TITLE
json: add conditional compilation for vajson in json_parser.cpp

### DIFF
--- a/score/json/json_parser.cpp
+++ b/score/json/json_parser.cpp
@@ -13,7 +13,11 @@
 
 #include "score/json/json_parser.h"
 
+#ifdef VAJSON
+#include "score/json/internal/parser/vajson/vajson_parser.h"
+#else
 #include "score/json/internal/parser/nlohmann/nlohmann_parser.h"
+#endif
 
 #include <iostream>
 
@@ -26,12 +30,20 @@ namespace json
 // coverity[autosar_cpp14_a15_5_3_violation]
 auto JsonParser::FromFile(const std::string_view file_path) const noexcept -> score::Result<Any>
 {
+#ifdef VAJSON
+    return VajsonParser::FromFile(file_path);
+#else
     return NlohmannParser::FromFile(file_path);
+#endif
 }
 
 auto JsonParser::FromBuffer(const std::string_view buffer) const noexcept -> score::Result<Any>
 {
+#ifdef VAJSON
+    return VajsonParser::FromBuffer(buffer);
+#else
     return NlohmannParser::FromBuffer(buffer);
+#endif
 }
 
 // False positive, user defined literal operator is used to perform conversion.


### PR DESCRIPTION
The `json_parser_impl` target already selects the correct parser dependency and defines `VAJSON` or `NLOHMANN` via `local_defines`, but `json_parser.cpp` unconditionally uses `NlohmannParser`. This means setting `base_library=vajson` results in a compilation failure.

Add `#ifdef VAJSON` guards to `json_parser.cpp` so that the include and function bodies switch between `VajsonParser` and `NlohmannParser` based on the build flag.