### PR TITLE
[test only] Change base_library from nlohmann to vajson

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -28,7 +28,7 @@ build --experimental_retain_test_configuration_across_testonly # needed for QNX 
 common --extra_toolchains=@score_gcc_x86_64_toolchain//:x86_64-linux-gcc_12.2.0
 common --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
 
-build:_bl_stub --//score/json:base_library=nlohmann
+build:_bl_stub --//score/json:base_library=vajson
 build:_bl_stub --//score/memory/shared/flags:use_typedshmd=False
 
 build:_bl_stub --features=minimal_warnings --features=-strict_warnings --features=warnings_as_errors


### PR DESCRIPTION
This pull request updates the base JSON library used in the Bazel build configuration for the `_bl_stub` target. The change switches from using `nlohmann` to `vajson` as the base library for `//score/json`.

This is for testing only.