### PR TITLE
Fix ParseBom corrupting stream state on inputs shorter than 3 bytes

### DIFF
--- a/score/json/internal/parser/vajson/vajson_impl/reader/json_data.cpp
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/json_data.cpp
@@ -205,6 +205,8 @@ auto JsonData::Restore() noexcept -> Result<void>
  * - If the first three bytes of the document are the UTF-8 BOM:
  *   - Set the encoding type.
  *   - Move the stream buffer past the BOM.
+ * - If the stream is too short for a BOM check:
+ *   - Ensure the stream state is cleared and position is restored.
  * \endinternal
  */
 void JsonData::ParseBom() noexcept
@@ -223,6 +225,14 @@ void JsonData::ParseBom() noexcept
             // It worked, so it was a utf-8 BOM.
             encoding_ = EncodingType::kUtf8;
         }
+    }
+    else
+    {
+        // ReadString failed (e.g., stream shorter than BOM).
+        // Ensure stream is in a usable state for subsequent parsing.
+        auto& stream = this->stream_.get();
+        stream.clear(stream.rdstate() & ~(std::ios::failbit | std::ios::eofbit));
+        stream.seekg(0, std::ios::beg);
     }
 }
 

--- a/score/json/internal/parser/vajson/vajson_parser_test.cpp
+++ b/score/json/internal/parser/vajson/vajson_parser_test.cpp
@@ -70,6 +70,44 @@ TEST(VajsonParser, CanParseObjectHexadecimalNumber)
     EXPECT_EQ(value, 0xdd);
 }
 
+TEST(VajsonParser, CanParseTwoByteBuffer)
+{
+    this->RecordProperty("Verifies", "SCR-5310867");
+    this->RecordProperty("ASIL", "B");
+    this->RecordProperty("Description",
+                         "parse a two-byte JSON object from a buffer shorter than the 3-byte UTF-8 BOM");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-value-analysis");
+
+    // Given a valid JSON buffer of exactly 2 bytes (shorter than BOM)
+    auto root = VajsonParser::FromBuffer("{}");
+
+    // Then parsing succeeds and returns an empty object
+    ASSERT_TRUE(root.has_value());
+    auto obj = root->As<Object>();
+    ASSERT_TRUE(obj.has_value());
+    EXPECT_TRUE(obj->get().empty());
+}
+
+TEST(VajsonParser, CanParseBufferWithUtf8Bom)
+{
+    this->RecordProperty("Verifies", "SCR-5310867");
+    this->RecordProperty("ASIL", "B");
+    this->RecordProperty("Description",
+                         "parse a JSON buffer prefixed with a UTF-8 BOM, ensuring BOM is consumed correctly");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
+    // Given a JSON buffer with a UTF-8 BOM prefix
+    std::string bom_json{"\xEF\xBB\xBF{\"key\": 123}"};
+    auto root = VajsonParser::FromBuffer(bom_json);
+
+    // Then parsing succeeds and the value is correct
+    ASSERT_TRUE(root.has_value());
+    auto value = GetValueOfObject<std::uint64_t>(root.value(), "key");
+    EXPECT_EQ(value, 123U);
+}
+
 INSTANTIATE_TYPED_TEST_SUITE_P(Test, ParserTest, VajsonParser, /*unused*/);
 
 }  // namespace


### PR DESCRIPTION
ParseBom always attempts to read 3 bytes for the UTF-8 BOM check. When the input stream has fewer than 3 bytes, stream.read() sets failbit|eofbit. The subsequent seekg() in RewindIf is a no-op when failbit is set (per C++ standard), leaving the stream in a failed state with consumed bytes not restored. All subsequent parsing fails.

Fix: In ParseBom, when ReadString fails, clear the stream state and seek to position 0 to ensure the stream is usable for parsing.