### PR TITLE
json: add explicit override specifiers for GCC 8 compatibility

### DIFF
--- a/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/array_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/array_parser.h
@@ -65,7 +65,7 @@ class ArrayParser final : public v2::SingleArrayParser
     /// - Otherwise:
     ///   - Return the error of the callback.
     /// \endinternal
-    auto OnElement() noexcept -> ParserResult final
+    auto OnElement() noexcept -> ParserResult override final
     {
 
         return std::forward<Fn>(this->fn_)(this->GetIndex()).transform([](void) noexcept {

--- a/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/bool_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/bool_parser.h
@@ -68,7 +68,7 @@ class BoolParser final : public VirtualParser
     /// - Otherwise:
     ///   - Return the error of the callback.
     /// \endinternal
-    auto OnBool(bool v) noexcept -> ParserResult final
+    auto OnBool(bool v) noexcept -> ParserResult override final
     {
 
         return score::Result<void>{std::forward<Fn>(this->fn_)(v)}.transform([](void) noexcept {
@@ -83,7 +83,7 @@ class BoolParser final : public VirtualParser
     /// \pre             -
     /// \threadsafe      FALSE
     /// \reentrant       FALSE
-    auto OnUnexpectedEvent() noexcept -> ParserResult final
+    auto OnUnexpectedEvent() noexcept -> ParserResult override final
     {
         return MakeErrorResult<ParserState>(JsonErrc::kUserValidationFailed, "Expected to parse a boolean.");
     }

--- a/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/key_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/key_parser.h
@@ -67,7 +67,7 @@ class KeyParser final : public VirtualParser
     /// - Otherwise:
     ///   - Return the error of the callback.
     /// \endinternal
-    auto OnKey(StringView key) noexcept -> ParserResult final
+    auto OnKey(StringView key) noexcept -> ParserResult override final
     {
 
         return this->fn_(key).transform([](void) noexcept {
@@ -82,7 +82,7 @@ class KeyParser final : public VirtualParser
     /// \pre             -
     /// \threadsafe      FALSE
     /// \reentrant       FALSE
-    auto OnUnexpectedEvent() noexcept -> ParserResult final
+    auto OnUnexpectedEvent() noexcept -> ParserResult override final
     {
         return MakeErrorResult<ParserState>(JsonErrc::kUserValidationFailed, "Expected to parse a key.");
     }

--- a/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/object_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/object_parser.h
@@ -72,7 +72,7 @@ class ObjectParser final : public v2::SingleObjectParser
     /// - Otherwise:
     ///   - Return the error of the callback.
     /// \endinternal
-    auto OnKey(std::string_view key) noexcept -> ParserResult final
+    auto OnKey(std::string_view key) noexcept -> ParserResult override final
     {
 
         return std::forward<Fn>(this->fn_)(key).transform([](void) noexcept {

--- a/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/string_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/internal/parsers/string_parser.h
@@ -67,7 +67,7 @@ class StringParser : public VirtualParser
     /// - Otherwise:
     ///   - Return the error of the callback.
     /// \endinternal
-    auto OnString(StringView str) noexcept -> ParserResult final
+    auto OnString(StringView str) noexcept -> ParserResult override final
     {
 
         return this->fn_(str).transform([](void) noexcept {
@@ -82,7 +82,7 @@ class StringParser : public VirtualParser
     /// \pre             -
     /// \threadsafe      FALSE
     /// \reentrant       FALSE
-    auto OnUnexpectedEvent() noexcept -> ParserResult final
+    auto OnUnexpectedEvent() noexcept -> ParserResult override final
     {
         return MakeErrorResult<ParserState>(JsonErrc::kUserValidationFailed, "Expected to parse a string.");
     }

--- a/score/json/internal/parser/vajson/vajson_impl/reader/v2/single_array_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/v2/single_array_parser.h
@@ -76,7 +76,7 @@ class SingleArrayParser : public v2::Parser
     /// - Otherwise:
     ///   - Return an error.
     /// \endinternal
-    auto OnStartArray() noexcept -> ParserResult final
+    auto OnStartArray() noexcept -> ParserResult override final
     {
         return this->validator_
             .Enter()
@@ -103,7 +103,7 @@ class SingleArrayParser : public v2::Parser
     /// - Otherwise:
     ///   - Return an error.
     /// \endinternal
-    auto OnEndArray(std::size_t) noexcept -> ParserResult final
+    auto OnEndArray(std::size_t) noexcept -> ParserResult override final
     {
         return this->validator_.Leave().and_then([this](ParserState state) noexcept {
             return Finalize().transform([&state](void) noexcept {
@@ -129,7 +129,7 @@ class SingleArrayParser : public v2::Parser
     ///   - On success, take a new snapshot, because the value could be followed by another value, and increase the
     ///   index.
     /// \endinternal
-    auto OnUnexpectedEvent() noexcept -> ParserResult final
+    auto OnUnexpectedEvent() noexcept -> ParserResult override final
     {
         return MakeResult(this->validator_.IsInside(),
                           {JsonErrc::kUserValidationFailed, "Expected to parse an array of elements."})

--- a/score/json/internal/parser/vajson/vajson_impl/reader/v2/single_object_parser.h
+++ b/score/json/internal/parser/vajson/vajson_impl/reader/v2/single_object_parser.h
@@ -77,7 +77,7 @@ class SingleObjectParser : public v2::Parser
     /// - Otherwise:
     ///   - Return an error.
     /// \endinternal
-    auto OnStartObject() noexcept -> ParserResult final
+    auto OnStartObject() noexcept -> ParserResult override final
     {
         return this->validator_.Enter();
     }
@@ -94,7 +94,7 @@ class SingleObjectParser : public v2::Parser
     /// - Check if inside an object:
     ///   - Call the Finalize callback and return its Result.
     /// \endinternal
-    auto OnEndObject(std::size_t) noexcept -> ParserResult final
+    auto OnEndObject(std::size_t) noexcept -> ParserResult override final
     {
         return this->validator_.Leave().and_then([this](ParserState state) noexcept {
             return this->Finalize().transform([&state](void) noexcept {

--- a/score/json/internal/parser/vajson/vajson_impl/util/json_error_domain.h
+++ b/score/json/internal/parser/vajson/vajson_impl/util/json_error_domain.h
@@ -84,7 +84,7 @@ class JsonErrorDomain final : public ErrorDomain
     /// - Otherwise:
     ///   - Return "unknown error".
     /// \endinternal
-    auto MessageFor(const Errc& error_code) const noexcept -> std::string_view final
+    auto MessageFor(const Errc& error_code) const noexcept -> std::string_view override final
     {
         Errc errc{error_code};
         constexpr static std::array<std::string_view, 6> kMessages{{


### PR DESCRIPTION
Add 'override' before 'final' on virtual function declarations. GCC 8 emits -Wsuggest-override warnings on functions marked only with 'final'. This was fixed in GCC 9, which treats 'final' as implying 'override'.