### PR TITLE
Workflows: Un-restrict score/analysis directory.

### DIFF
--- a/.github/workflows/restricted_paths.yml
+++ b/.github/workflows/restricted_paths.yml
@@ -35,7 +35,6 @@ jobs:
           list-files: json
           filters: |
             restricted:
-              - 'score/analysis/**'
               - 'score/concurrency/**'
               - 'score/containers/**'
               - 'score/filesystem/**'


### PR DESCRIPTION
Analysis is now a first-class score citizen.

Prerequisite for: https://github.com/eclipse-score/baselibs/issues/198