### PR TITLE
ci: replace free_disk_space with more-disk-space and update cicd-workflows hash

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -46,10 +46,11 @@ jobs:
               -//score/os/test:socket_test
             bazel-test-extra-flags: "--test_timeout=180,900,2700,10800" # Increase test timeout due to QEMU emulation
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Free Disk Space (Ubuntu)
-        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:

--- a/.github/workflows/build_qnx.yml
+++ b/.github/workflows/build_qnx.yml
@@ -46,7 +46,7 @@ jobs:
               -//score/memory/shared:shared_memory_resource_open_test
               -//score/os/utils/inotify:unit_test
             extra-bazel-test-flags: "--test_timeout=120,600,1800,7200" # Increase test timeout due to QEMU emulation
-    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@7b265b4accb24997dcb0de449c34d23853709f57
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@af347722c7ae3ed85518895c11268d96ac728f62
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -20,4 +20,4 @@ on:
     types: [checks_requested]
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@7b265b4accb24997dcb0de449c34d23853709f57
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@af347722c7ae3ed85518895c11268d96ac728f62

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -26,10 +26,11 @@ jobs:
   coverage-report:
     runs-on: ubuntu-24.04
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Free Disk Space (Ubuntu)
-        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Install lcov
         run: |
           sudo apt-get update

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,7 +20,7 @@ on:
     types: [checks_requested]
 jobs:
   formatting-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@7b265b4accb24997dcb0de449c34d23853709f57
+    uses: eclipse-score/cicd-workflows/.github/workflows/format.yml@af347722c7ae3ed85518895c11268d96ac728f62
   clang-format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,9 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup Bazel

--- a/.github/workflows/sanitizers_linux.yml
+++ b/.github/workflows/sanitizers_linux.yml
@@ -26,10 +26,11 @@ jobs:
   linux-sanitizers:
     runs-on: ubuntu-latest
     steps:
+      - uses: eclipse-score/more-disk-space@6a3b48901846bf7f8cc985925157d71a8973e61f # v1
+        with:
+          level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Free Disk Space (Ubuntu)
-        uses: eclipse-score/cicd-workflows/.github/actions/free_disk_space@7b265b4accb24997dcb0de449c34d23853709f57
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:

--- a/.github/workflows/test_and_docs.yml
+++ b/.github/workflows/test_and_docs.yml
@@ -26,7 +26,7 @@ on:
     types: [checks_requested]
 jobs:
   docs-verify:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@7b265b4accb24997dcb0de449c34d23853709f57
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@af347722c7ae3ed85518895c11268d96ac728f62
     permissions:
       pull-requests: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
   # TODO skipping tests as we don't integrate test results in docs anyways
   docs-build:
     needs: [docs-verify]
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@7b265b4accb24997dcb0de449c34d23853709f57
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@af347722c7ae3ed85518895c11268d96ac728f62
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
Replace the `eclipse-score/cicd-workflows` `free_disk_space` composite action with `eclipse-score/more-disk-space` (level 4) in the `build_linux`, `coverage_report`, and `sanitizers_linux` workflows. The action is now placed before the repository checkout step to maximize available disk space early. The `lint` workflow also gets this action added.

All `cicd-workflows` references are updated to latest hash that includes `more-disk-space` in QNX and docs workflows that we use. There were failures related to lack of disk space recently