### PR TITLE
Add InitializeRuntime API to logging

### DIFF
--- a/score/mw/log/logging.cpp
+++ b/score/mw/log/logging.cpp
@@ -86,3 +86,9 @@ void score::mw::log::SetLogRecorder(score::mw::log::Recorder* const recorder) no
 {
     score::mw::log::detail::Runtime::SetRecorder(recorder);
 }
+
+void score::mw::log::InitializeRuntime() noexcept
+{
+    score::cpp::ignore = score::mw::log::detail::Runtime::GetRecorder();
+    score::cpp::ignore = score::mw::log::detail::Runtime::GetFallbackRecorder();
+}

--- a/score/mw/log/logging.h
+++ b/score/mw/log/logging.h
@@ -152,6 +152,12 @@ log::Recorder& GetDefaultLogRecorder() noexcept;
 /// \details In a normal case the user does not want to use this API. It is only exposed e.g. for testing purposes
 void SetLogRecorder(score::mw::log::Recorder* const recorder) noexcept;
 
+/// \brief Ensures the logging runtime singleton is initialized.
+/// \details Call before creating any static object that relies on logging, to prevent
+///          static initialization order issues. Safe to call multiple times.
+/// \thread-safe
+void InitializeRuntime() noexcept;
+
 }  // namespace log
 }  // namespace mw
 }  // namespace score


### PR DESCRIPTION
- Added [InitializeRuntime] as a new public API in [logging.h]
- Implemented in [logging.cpp] using [score::cpp::ignore] to trigger [GetRecorder] and [GetFallbackRecorder]
- No public API existed to initialize the logging runtime, forcing consumers to reach into detail::Runtime directly 
- This provides a proper public alternative that is safe to call multiple times