### PR TITLE
chore(CI): verify bazel lockfile is correct

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Bazel Lockfile
+#
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+  workflow_call:
+  workflow_dispatch:
+#
+permissions:
+  contents: read
+#
+jobs:
+  bazel-lockfile:
+    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@93aac16ada7d247bbb6ae926509ddea74cf5213a # main on 2026-06-09


### PR DESCRIPTION
Verify correctness of Bazel lockfile on Pull Request

Note: this will fail until lockfile is manually fixed