### PR TITLE
Baselibs AutoSD Fixes

### DIFF
--- a/score/concurrency/future/base_interruptible_future_test.cpp
+++ b/score/concurrency/future/base_interruptible_future_test.cpp
@@ -316,7 +316,7 @@ TYPED_TEST(BaseInterruptibleFutureTest, WaitReturnsOnlyAfterValueWasSet)
 
     BaseInterruptibleFutureTest<TypeParam>::SetPromise(this->promise_);
 
-    auto expected = std::move(async_future.get());
+    auto expected = async_future.get();
     EXPECT_TRUE(expected.has_value());
 }
 
@@ -351,7 +351,7 @@ TYPED_TEST(BaseInterruptibleFutureTest, WaitForReturnsTimeoutErrorWhenValueWasNo
         return this->future_->WaitFor(stop_token, TIMEOUT);
     });
 
-    auto expected = std::move(async_future.get());
+    auto expected = async_future.get();
     ASSERT_FALSE(expected.has_value());
     EXPECT_EQ(expected.error(), Error::kTimeout);
 }
@@ -388,7 +388,7 @@ TYPED_TEST(BaseInterruptibleFutureTest, WaitForReturnsWhenValueIsSet)
     });
     BaseInterruptibleFutureTest<TypeParam>::SetPromise(this->promise_);
 
-    auto expected = std::move(async_future.get());
+    auto expected = async_future.get();
     EXPECT_TRUE(expected.has_value());
 }
 
@@ -400,7 +400,7 @@ TYPED_TEST(BaseInterruptibleFutureTest, WaitUntilReturnsTimeoutErrorWhenValueWas
         return this->future_->WaitUntil(stop_token, std::chrono::steady_clock::now() + TIMEOUT);
     });
 
-    auto expected = std::move(async_future.get());
+    auto expected = async_future.get();
     ASSERT_FALSE(expected.has_value());
     EXPECT_EQ(expected.error(), Error::kTimeout);
 }

--- a/score/concurrency/future/base_interruptible_promise_test.cpp
+++ b/score/concurrency/future/base_interruptible_promise_test.cpp
@@ -179,7 +179,8 @@ TYPED_TEST(BaseInterruptiblePromiseTest, MoveAssignmentAlsoMovesFutureRetrievalS
 TYPED_TEST(BaseInterruptiblePromiseTest, MoveAssignmentToSelf)
 {
     BaseInterruptiblePromise<TypeParam> moved_to_promise{};
-    moved_to_promise = std::move(moved_to_promise);
+    auto* promise_ptr = &moved_to_promise;
+    moved_to_promise = std::move(*promise_ptr);
     ASSERT_TRUE(moved_to_promise.GetInterruptibleFuture().has_value());
 }
 

--- a/score/concurrency/future/interruptible_shared_future_test.cpp
+++ b/score/concurrency/future/interruptible_shared_future_test.cpp
@@ -349,7 +349,7 @@ TYPED_TEST(InterruptibleSharedFutureTest, GetReturnsOnlyAfterValueWasSet)
 
     InterruptibleSharedFutureTest<TypeParam>::SetPromise(this->promise_);
 
-    auto expected = std::move(async_future.get());
+    auto expected = async_future.get();
     InterruptibleSharedFutureTest<TypeParam>::ExpectCorrectValue(expected);
 }
 
@@ -358,7 +358,7 @@ TYPED_TEST(InterruptibleSharedFutureTest, GetReturnsErrorWhenSet)
     this->promise_.SetError(Error::kFutureAlreadyRetrieved);
 
     score::cpp::stop_token stop_token{};
-    auto expected = std::move(this->future_.Get(stop_token));
+    auto expected = this->future_.Get(stop_token);
     ASSERT_FALSE(expected.has_value());
     EXPECT_EQ(expected.error(), Error::kFutureAlreadyRetrieved);
 }

--- a/score/concurrency/task_result_test.cpp
+++ b/score/concurrency/task_result_test.cpp
@@ -157,7 +157,7 @@ class TaskResultContinuationTest : public ::testing::Test
   public:
     typename T::TaskType Make()
     {
-        return std::move(T::Make(promise_));
+        return T::Make(promise_);
     }
 
     void ExpectCallNTimes(std::uint16_t n)

--- a/score/containers/dynamic_array_test.cpp
+++ b/score/containers/dynamic_array_test.cpp
@@ -263,8 +263,9 @@ TYPED_TEST(DynamicArrayTestFixture, SelfMoveAssign)
     DynamicArray<TrivialType, TypeParam> unit{kNonEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
 
-    // when doing a self-move-assign
-    unit = std::move(unit);
+    // when doing a self-move-assign (use pointer indirection to avoid compiler warning)
+    auto* unit_ptr = &unit;
+    unit = std::move(*unit_ptr);
 
     // expect, that the unit afterward still has the same size
     EXPECT_EQ(unit.size(), kNonEmptyArraySize);

--- a/score/containers/intrusive_list_test.cpp
+++ b/score/containers/intrusive_list_test.cpp
@@ -552,7 +552,8 @@ TEST(IntrusiveList, MoveAssignmentTest)
     // NOLINTBEGIN(bugprone-use-after-move): testing correctness of implementation
 
     List list;
-    list = std::move(list);
+    auto* list_ptr = &list;
+    list = std::move(*list_ptr);
     CheckEmpty(list);
 
     List list_from;
@@ -562,7 +563,8 @@ TEST(IntrusiveList, MoveAssignmentTest)
     list = std::move(list_from);
     CheckEmpty(list_from);
     CheckNonEmpty(list, 1, front_back, front_back);
-    list = std::move(list);
+    list_ptr = &list;
+    list = std::move(*list_ptr);
     CheckNonEmpty(list, 1, front_back, front_back);
 
     ListElement front;
@@ -572,7 +574,8 @@ TEST(IntrusiveList, MoveAssignmentTest)
     list = std::move(list_from);
     CheckEmpty(list_from);
     CheckNonEmpty(list, 2, front, back);
-    list = std::move(list);
+    list_ptr = &list;
+    list = std::move(*list_ptr);
     CheckNonEmpty(list, 2, front, back);
 
     constexpr std::size_t num_elements = 6;
@@ -581,7 +584,8 @@ TEST(IntrusiveList, MoveAssignmentTest)
     list = std::move(list_from);
     CheckEmpty(list_from);
     CheckNonEmpty(list, num_elements, elements[0], elements[num_elements - 1]);
-    list = std::move(list);
+    list_ptr = &list;
+    list = std::move(*list_ptr);
     CheckNonEmpty(list, num_elements, elements[0], elements[num_elements - 1]);
     list.clear();
 

--- a/score/json/internal/parser/parsers_test_suite.h
+++ b/score/json/internal/parser/parsers_test_suite.h
@@ -29,7 +29,7 @@ namespace
 {
 
 template <typename T, std::enable_if_t<!std::is_arithmetic<T>::value, bool> = true>
-const T& GetValueOfObject(const score::json::Any& any, const std::string& key)
+const T GetValueOfObject(const score::json::Any& any, const std::string& key)
 {
     return any.As<score::json::Object>().value().get().at(key).As<T>().value().get();
 }
@@ -114,7 +114,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectString)
     auto root = TypeParam::FromBuffer(buffer_simple_json);
 
     // When reading a key of an object that is interpreted as std::string
-    auto& value = GetValueOfObject<std::string>(root.value(), "color");
+    auto value = GetValueOfObject<std::string>(root.value(), "color");
 
     // Then the correct value is returned
     EXPECT_EQ(value, "gold");
@@ -133,7 +133,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectNull)
     auto root = TypeParam::FromBuffer(buffer_simple_json);
 
     // When reading a key of an object that is interpreted as Null
-    auto& value = GetValueOfObject<Null>(root.value(), "null");
+    auto value = GetValueOfObject<Null>(root.value(), "null");
 
     // Then the correct value is returned
     EXPECT_EQ(value, Null{});
@@ -172,7 +172,7 @@ TYPED_TEST_P(ParserTest, CanParseObjectFloatingPointNumber)
 
     // When reading a key of an object that is interpreted as floating point number
     auto float_value = GetValueOfObject<float>(root.value(), "float");
-    double double_value = GetValueOfObject<double>(root.value(), "double");
+    auto double_value = GetValueOfObject<double>(root.value(), "double");
     auto double_as_float_value =
         root->template As<score::json::Object>().value().get().at("double").template As<float>().has_value();
 
@@ -193,13 +193,16 @@ TYPED_TEST_P(ParserTest, CanParseObjectInObject)
 
     // Given a simple JSON buffer
     auto root = TypeParam::FromBuffer(buffer_simple_json);
-
+    
     // When reading a key of an object that is interpreted as number
-    auto& value = GetValueOfObject<Object>(root.value(), "object");
-
+    auto value = root.value().template As<Object>().value().get()
+      .at("object").template As<Object>().value().get()
+      .at("a").template As<std::string>().value().get();
+    
     // Then the correct value is returned
-    EXPECT_EQ(value.at("a").template As<std::string>().value().get(), "b");
+    EXPECT_EQ(value, "b");
 }
+
 
 TYPED_TEST_P(ParserTest, CanParseListInObject)
 {
@@ -212,14 +215,15 @@ TYPED_TEST_P(ParserTest, CanParseListInObject)
 
     // Given a simple JSON buffer
     auto root = TypeParam::FromBuffer(buffer_simple_json);
-
+    
     // When reading a key of an object that is interpreted as number
-    auto& value = GetValueOfObject<List>(*root, "list");
+    auto* root_map = &root.value().template As<Object>().value().get();
+    auto* value = &root_map->at("list").template As<List>().value().get();
 
     // Then the correct value is returned
-    EXPECT_EQ(value[0].template As<std::string>().value().get(), "first");
-    EXPECT_EQ(value[1].template As<std::uint64_t>().value(), 2UL);
-    EXPECT_EQ(value[2].template As<std::string>().value().get(), "third");
+    EXPECT_EQ((*value)[0].template As<std::string>().value().get(), "first");
+    EXPECT_EQ((*value)[1].template As<std::uint64_t>().value(), 2UL);
+    EXPECT_EQ((*value)[2].template As<std::string>().value().get(), "third");
 }
 
 TYPED_TEST_P(ParserTest, CanParseObjectInObjectAndIterateOverKeys)
@@ -257,14 +261,18 @@ TYPED_TEST_P(ParserTest, CanParseObjectInObjectAndIterateOverKeys)
 }
 )"};
     auto root = TypeParam::FromBuffer(buffer);
+    auto* root_map = &root.value().template As<Object>().value().get();
+    auto* storage_list = &root_map->at("storage_list").template As<Object>().value().get();
 
     // When iterating over the unknown keys
-    const auto& storage_list = root.value().template As<Object>().value().get()["storage_list"];
     std::vector<std::string> collected_paths{};
-    for (const auto& element : storage_list.template As<Object>().value().get())
+    for (const auto& element : *storage_list)
     {
+        auto* inner_obj = &element.second.template As<Object>().value().get();
+
         collected_paths.push_back(
-            element.second.template As<Object>().value().get().at("path").template As<std::string>().value().get());
+            inner_obj->at("path").template As<std::string>().value().get()
+        );
     }
 
     // Then we can store them and thus also access them
@@ -378,7 +386,7 @@ TYPED_TEST_P(ParserTest, ParsingFromFileWorks)
     EXPECT_TRUE(root.has_value());
 
     // When reading a key of an object that is interpreted as bool
-    auto value = GetValueOfObject<bool>(root.value(), "boolean");
+    bool value = GetValueOfObject<bool>(root.value(), "boolean");
 
     // Then the correct value is returned
     EXPECT_EQ(value, true);

--- a/score/language/safecpp/scoped_function/details/allocator_aware_type_erasure_pointer_test.cpp
+++ b/score/language/safecpp/scoped_function/details/allocator_aware_type_erasure_pointer_test.cpp
@@ -272,7 +272,8 @@ TEST_F(AllocatorAwareTypeErasurePointerTest, CanMoveAssignSelfWithoutAdverseEffe
     DISABLE_WARNING_PUSH
     DISABLE_WARNING_SELF_MOVE
 
-    target = std::move(target);
+    auto* target_ptr = &target;
+    target = std::move(*target_ptr);
 
     DISABLE_WARNING_POP
 

--- a/score/language/safecpp/scoped_function/details/allocator_wrapper_test.cpp
+++ b/score/language/safecpp/scoped_function/details/allocator_wrapper_test.cpp
@@ -109,7 +109,8 @@ TEST_F(AllocatorWrapperTest, CorrectlyHandlesSelfMoveAssignment)
     DISABLE_WARNING_PUSH
     DISABLE_WARNING_SELF_MOVE
 
-    allocator_wrapper = std::move(allocator_wrapper);
+    auto* wrapper_ptr = &allocator_wrapper;
+    allocator_wrapper = std::move(*wrapper_ptr);
 
     DISABLE_WARNING_POP
 

--- a/score/language/safecpp/scoped_function/scope_test.cpp
+++ b/score/language/safecpp/scoped_function/scope_test.cpp
@@ -126,7 +126,8 @@ TYPED_TEST(ScopeTest, CanMoveAssignToItselfWithNoAdverseEffects)
     DISABLE_WARNING_PUSH
     DISABLE_WARNING_SELF_MOVE
 
-    scope = std::move(scope);
+    auto* scope_ptr = &scope;
+    scope = std::move(*scope_ptr);
 
     DISABLE_WARNING_POP
 

--- a/score/memory/shared/lock_file_test.cpp
+++ b/score/memory/shared/lock_file_test.cpp
@@ -554,7 +554,8 @@ TEST_F(LockFileMoveFixture, LockFileShouldNotRemoveFileWhenMoveAssigningToItself
         ASSERT_TRUE(lock_file_result.has_value());
 
         // When we move assign the lock file to itself
-        lock_file_result.value() = std::move(lock_file_result.value());
+        auto* lock_file_ptr = &lock_file_result.value();
+        lock_file_result.value() = std::move(*lock_file_ptr);
 
         // Then the lock file won't be destroyed
         EXPECT_FALSE(close_called);


### PR DESCRIPTION
## Changes

* Fixes warnings for GCC 14 (used in AutoSD)
* ~Explicit usage of `-D_GNU_SOURCE`  for GCC 14 (does not break GCC 12)~