### PR TITLE
baselibs: enable contributions to compiler_warnings

### DIFF
--- a/.github/workflows/restricted_paths.yml
+++ b/.github/workflows/restricted_paths.yml
@@ -48,7 +48,6 @@ jobs:
               - 'score/mw/**'
               - 'score/network/**'
               - 'score/os/**'
-              - 'score/quality/compiler_warnings/**'
       - name: Block PR if restricted files are changed
         if: steps.filter.outputs.restricted == 'true' && github.event_name != 'merge_group'
         env:


### PR DESCRIPTION
BMW switched internal development to the score_baselibs provided version.