### PR TITLE
impl: fix QNX test issues, restore CI tests

### DIFF
--- a/.github/workflows/build_qnx.yml
+++ b/.github/workflows/build_qnx.yml
@@ -38,7 +38,6 @@ jobs:
               -//score/memory/shared:shared_memory_resource_open_test
               -//score/os/test:asil_qm_test
               -//score/os/test:grp_test
-              -//src/containers:tests
           - bazel-config: bl-aarch64-qnx
             bazel-test-target: >-
               //score/...
@@ -48,9 +47,6 @@ jobs:
               -//score/memory/shared:shared_memory_factory_test
               -//score/memory/shared:shared_memory_resource_open_test
               -//score/os/utils/inotify:unit_test
-              -//src/containers:tests
-              -//src/pal:tests
-              -//src/thread:tests
             extra-bazel-test-flags: "--test_timeout=120,600,1800,7200" # Increase test timeout due to QEMU emulation
     uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@af347722c7ae3ed85518895c11268d96ac728f62
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ examples/integration/bazel-*
 user.bazelrc
 .cache
 compile_commands.json
+target/
 
 # docs build artifacts
 _build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,6 @@ name = "elementary"
 version = "0.0.1"
 
 [[package]]
-name = "libc"
-version = "0.2.186"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
 name = "log_builtin"
 version = "0.0.1"
 dependencies = [
@@ -40,7 +34,6 @@ name = "pal"
 version = "0.0.1"
 dependencies = [
  "containers",
- "libc",
  "score_log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,6 @@ license-file = "LICENSE.md"
 authors = ["S-CORE Contributors"]
 
 [workspace.dependencies]
-libc = "0.2.177"
-
 containers = { path = "src/containers" }
 score_log = { path = "src/log/score_log" }
 score_log_fmt = { path = "src/log/score_log_fmt" }

--- a/src/containers/storage/heap.rs
+++ b/src/containers/storage/heap.rs
@@ -142,10 +142,15 @@ mod tests {
     use super::*;
     use elementary::{HeapAllocator, GLOBAL_ALLOCATOR};
 
+    // Type used by all tests.
+    type T = u64;
+    // Equals to 1GB. Tests might fail for runners with <1GB.
+    const LARGE_CAP: u32 = (i32::MAX as u32 / size_of::<T>() as u32) / 2;
+    // Capacity test cases.
+    const CAP_CASES: [u32; 7] = [0, 1, 2, 3, 4, 5, LARGE_CAP];
+
     #[test]
     fn subslice() {
-        type T = u64;
-
         fn run_test(capacity: u32) {
             let instance = Heap::<T, _>::new(capacity, &GLOBAL_ALLOCATOR);
 
@@ -171,15 +176,13 @@ mod tests {
             }
         }
 
-        for cap in [0, 1, 2, 3, 4, 5, i32::MAX as u32 / size_of::<T>() as u32] {
+        for cap in CAP_CASES {
             run_test(cap);
         }
     }
 
     #[test]
     fn subslice_mut() {
-        type T = u64;
-
         fn run_test(capacity: u32) {
             let mut instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
 
@@ -205,15 +208,13 @@ mod tests {
             }
         }
 
-        for cap in [0, 1, 2, 3, 4, 5, i32::MAX as u32 / size_of::<T>() as u32] {
+        for cap in CAP_CASES {
             run_test(cap);
         }
     }
 
     #[test]
     fn element() {
-        type T = u64;
-
         fn run_test(capacity: u32) {
             let instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
 
@@ -240,15 +241,13 @@ mod tests {
             }
         }
 
-        for cap in [0, 1, 2, 3, 4, 5, i32::MAX as u32 / size_of::<T>() as u32] {
+        for cap in CAP_CASES {
             run_test(cap);
         }
     }
 
     #[test]
     fn element_mut() {
-        type T = u64;
-
         fn run_test(capacity: u32) {
             let mut instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
 
@@ -275,7 +274,7 @@ mod tests {
             }
         }
 
-        for cap in [0, 1, 2, 3, 4, 5, i32::MAX as u32 / size_of::<T>() as u32] {
+        for cap in CAP_CASES {
             run_test(cap);
         }
     }

--- a/src/pal/BUILD
+++ b/src/pal/BUILD
@@ -21,7 +21,6 @@ rust_library(
     deps = [
         "//src/containers",
         "//src/log/score_log",
-        "@score_crates//:libc",
     ],
 )
 

--- a/src/pal/Cargo.toml
+++ b/src/pal/Cargo.toml
@@ -23,6 +23,5 @@ edition.workspace = true
 path = "lib.rs"
 
 [dependencies]
-libc.workspace = true
 containers.workspace = true
 score_log.workspace = true

--- a/src/pal/affinity.rs
+++ b/src/pal/affinity.rs
@@ -40,6 +40,9 @@ extern "C" {
     pub fn ThreadCtl(__cmd: c_int, __data: *mut crate::c_void) -> c_int;
 }
 
+#[cfg(target_os = "nto")]
+pub const _SC_NPROCESSORS_ONLN: c_int = 91;
+
 const MAX_CPU_NUM: usize = 1024;
 const CPU_MASK_SIZE: usize = MAX_CPU_NUM / (u8::BITS as usize);
 
@@ -142,29 +145,50 @@ impl From<CpuSet> for cpu_set_t {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct NtoCpuSet {
-    // Expected to always be set to `32` - see comment above.
-    size: i32,
-    run_mask: [u32; 32],
-    // Expected to always be zeroed - left unaltered.
-    inherit_mask: [u32; 32],
+    // `ThreadCtl` data internal representation.
+    // `size` must be determined based on number of CPU, with max allowed value equal to 32.
+    // [ size: i32 | run_mask: size * u32 | inherit_mask: size * u32 ]
+    data: [u32; 1 + 32 + 32],
 }
 
 #[cfg(target_os = "nto")]
 impl NtoCpuSet {
-    fn new(mask: [u32; 32]) -> Self {
-        Self {
-            size: 32,
-            run_mask: mask,
-            inherit_mask: [0; 32],
-        }
+    fn new() -> Self {
+        // Get number of CPUs.
+        let num_cpus = unsafe { crate::sysconf(_SC_NPROCESSORS_ONLN) } as u32;
+        assert!(
+            num_cpus >= 1 && num_cpus <= MAX_CPU_NUM as u32,
+            "number of CPUs in the system out of expected range: {num_cpus}"
+        );
+
+        // Get number of elements and set it at 0.
+        let size = (num_cpus - 1) / u32::BITS + 1;
+        let mut data = [0; _];
+        data[0] = size;
+
+        Self { data }
+    }
+
+    fn run_mask(&self) -> &[u32] {
+        let size = self.data[0] as usize;
+        &self.data[1..1 + size]
+    }
+
+    fn run_mask_mut(&mut self) -> &mut [u32] {
+        let size = self.data[0] as usize;
+        &mut self.data[1..1 + size]
     }
 }
 
 #[cfg(target_os = "nto")]
 impl From<NtoCpuSet> for CpuSet {
     fn from(value: NtoCpuSet) -> Self {
-        // SAFETY: CPU mask layout and size is ensured.
-        let mask = unsafe { core::mem::transmute(value.run_mask) };
+        // Reorient data from array of u32 to array of u8.
+        let mut mask = [0u8; CPU_MASK_SIZE];
+        for (i, &word) in value.run_mask().iter().enumerate() {
+            const CHUNK_SIZE: usize = i32::BITS as usize / 8;
+            mask[i * CHUNK_SIZE..i * CHUNK_SIZE + CHUNK_SIZE].copy_from_slice(&word.to_le_bytes());
+        }
         Self { mask }
     }
 }
@@ -172,9 +196,19 @@ impl From<NtoCpuSet> for CpuSet {
 #[cfg(target_os = "nto")]
 impl From<CpuSet> for NtoCpuSet {
     fn from(value: CpuSet) -> Self {
-        // SAFETY: CPU mask layout and size is ensured.
-        let run_mask = unsafe { core::mem::transmute(value.mask) };
-        Self::new(run_mask)
+        // Reorient data from array of u8 to array of u32.
+        let mut nto_cpu_set = Self::new();
+        let size = nto_cpu_set.data[0] as usize;
+        let used_bytes = size * (u32::BITS as usize / 8);
+        assert!(
+            value.mask[used_bytes..].iter().all(|&b| b == 0),
+            "provided CpuSet contains CPU IDs out of range for NtoCpuSet in this configuration"
+        );
+
+        for (i, chunk) in value.mask[..used_bytes].chunks_exact(4).enumerate() {
+            nto_cpu_set.run_mask_mut()[i] = u32::from_le_bytes(chunk.try_into().expect("chunk is 4 bytes"));
+        }
+        nto_cpu_set
     }
 }
 
@@ -236,7 +270,7 @@ pub fn get_affinity() -> FixedCapacityVec<usize> {
 
     #[cfg(target_os = "nto")]
     {
-        let mut native_cpu_set = NtoCpuSet::new([0; _]);
+        let mut native_cpu_set = NtoCpuSet::new();
         // SAFETY:
         // Native CPU set is properly initialized.
         // `NtoCpuSet` layout must be as expected by `ThreadCtl`.

--- a/src/pal/affinity.rs
+++ b/src/pal/affinity.rs
@@ -14,15 +14,31 @@
 //! Affinity handling differs between Linux and QNX.
 //! Module ensures similar behavior between both OSes.
 
-use crate::errno;
+use crate::{c_int, errno};
 use containers::fixed_capacity::FixedCapacityVec;
 use score_log::ScoreDebug;
 
 #[cfg(target_os = "linux")]
-use libc::{cpu_set_t, sched_getaffinity, sched_setaffinity};
+#[repr(C)]
+pub struct cpu_set_t {
+    #[cfg(all(target_pointer_width = "32", not(target_arch = "x86_64")))]
+    bits: [u32; 32],
+    #[cfg(not(all(target_pointer_width = "32", not(target_arch = "x86_64"))))]
+    bits: [u64; 16],
+}
+
+#[cfg(target_os = "linux")]
+extern "C" {
+    pub fn sched_getaffinity(pid: crate::pid_t, cpusetsize: crate::size_t, cpuset: *mut cpu_set_t) -> c_int;
+    pub fn sched_setaffinity(pid: crate::pid_t, cpusetsize: crate::size_t, cpuset: *const cpu_set_t) -> c_int;
+}
 
 #[cfg(target_os = "nto")]
-use libc::{ThreadCtl, _NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT};
+const _NTO_TCTL_RUNMASK_GET_AND_SET_INHERIT: u32 = 10;
+#[cfg(target_os = "nto")]
+extern "C" {
+    pub fn ThreadCtl(__cmd: c_int, __data: *mut crate::c_void) -> c_int;
+}
 
 const MAX_CPU_NUM: usize = 1024;
 const CPU_MASK_SIZE: usize = MAX_CPU_NUM / (u8::BITS as usize);

--- a/src/pal/errno.rs
+++ b/src/pal/errno.rs
@@ -13,11 +13,23 @@
 
 //! Unified `errno` access.
 
+use crate::c_int;
+
 #[cfg(target_os = "linux")]
-use libc::__errno_location as errno_ptr;
+extern "C" {
+    pub fn __errno_location() -> *mut c_int;
+}
 
 #[cfg(target_os = "nto")]
-use libc::__get_errno_ptr as errno_ptr;
+extern "C" {
+    pub fn __get_errno_ptr() -> *mut c_int;
+}
+
+#[cfg(target_os = "linux")]
+use __errno_location as errno_ptr;
+
+#[cfg(target_os = "nto")]
+use __get_errno_ptr as errno_ptr;
 
 /// Current errno value.
 pub fn errno() -> crate::c_int {

--- a/src/pal/lib.rs
+++ b/src/pal/lib.rs
@@ -21,9 +21,9 @@ mod errno;
 pub use affinity::{get_affinity, set_affinity, CpuSet};
 pub use errno::errno;
 
-pub type c_int = i32;
-pub type c_long = i64;
-pub type c_ulong = u64;
+pub type c_int = core::ffi::c_int;
+pub type c_long = core::ffi::c_long;
+pub type c_ulong = core::ffi::c_ulong;
 pub type size_t = usize;
 pub type c_void = core::ffi::c_void;
 pub type pid_t = i32;

--- a/src/pal/lib.rs
+++ b/src/pal/lib.rs
@@ -13,33 +13,69 @@
 
 //! Minimal POSIX adaptation layer.
 
+#![allow(non_camel_case_types)]
+
 mod affinity;
 mod errno;
 
 pub use affinity::{get_affinity, set_affinity, CpuSet};
 pub use errno::errno;
 
-pub use libc::{
-    c_int, c_ulong, c_void, pid_t, pthread_attr_destroy, pthread_attr_getstacksize, pthread_attr_init,
-    pthread_attr_setstacksize, pthread_attr_t, pthread_create, pthread_getschedparam, pthread_join, pthread_self,
-    pthread_setschedparam, pthread_t, sched_get_priority_max, sched_get_priority_min, sched_param, SCHED_FIFO,
-    SCHED_OTHER, SCHED_RR,
-};
+pub type c_int = i32;
+pub type c_long = i64;
+pub type c_ulong = u64;
+pub type size_t = usize;
+pub type c_void = core::ffi::c_void;
+pub type pid_t = i32;
+pub type pthread_t = c_ulong;
 
 #[cfg(target_os = "linux")]
-pub use libc::{
-    pthread_attr_getinheritsched, pthread_attr_getschedparam, pthread_attr_getschedpolicy,
-    pthread_attr_setinheritsched, pthread_attr_setschedparam, pthread_attr_setschedpolicy, PTHREAD_EXPLICIT_SCHED,
-    PTHREAD_INHERIT_SCHED,
-};
+#[repr(C)]
+pub struct pthread_attr_t {
+    #[cfg(target_pointer_width = "32")]
+    __size: [u32; 8],
+    #[cfg(target_pointer_width = "64")]
+    __size: [u64; 7],
+}
+#[cfg(target_os = "nto")]
+#[repr(C)]
+pub struct pthread_attr_t {
+    __data1: c_long,
+    __data2: [u8; 96],
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+pub struct sched_param {
+    pub sched_priority: c_int,
+}
 
 #[cfg(target_os = "nto")]
-pub const PTHREAD_INHERIT_SCHED: c_int = 0;
-#[cfg(target_os = "nto")]
-pub const PTHREAD_EXPLICIT_SCHED: c_int = 1;
+#[repr(C)]
+#[repr(align(8))]
+pub struct sched_param {
+    pub sched_priority: c_int,
+    pub sched_curpriority: c_int,
+    pub reserved: [c_int; 10],
+}
 
-#[cfg(target_os = "nto")]
 extern "C" {
+    pub fn pthread_self() -> pthread_t;
+    pub fn pthread_join(native: pthread_t, value: *mut *mut c_void) -> c_int;
+    pub fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int;
+    pub fn pthread_attr_destroy(attr: *mut pthread_attr_t) -> c_int;
+    pub fn pthread_attr_getstacksize(attr: *const pthread_attr_t, stacksize: *mut size_t) -> c_int;
+    pub fn pthread_attr_setstacksize(attr: *mut pthread_attr_t, stack_size: size_t) -> c_int;
+    pub fn pthread_create(
+        native: *mut pthread_t,
+        attr: *const pthread_attr_t,
+        f: extern "C" fn(*mut c_void) -> *mut c_void,
+        value: *mut c_void,
+    ) -> c_int;
+    pub fn pthread_getschedparam(native: pthread_t, policy: *mut c_int, param: *mut sched_param) -> c_int;
+    pub fn pthread_setschedparam(native: pthread_t, policy: c_int, param: *const sched_param) -> c_int;
+    pub fn sched_get_priority_max(policy: c_int) -> c_int;
+    pub fn sched_get_priority_min(policy: c_int) -> c_int;
     pub fn pthread_attr_getinheritsched(attr: *const pthread_attr_t, inheritsched: *mut c_int) -> c_int;
     pub fn pthread_attr_setinheritsched(attr: *mut pthread_attr_t, inheritsched: c_int) -> c_int;
     pub fn pthread_attr_getschedparam(attr: *const pthread_attr_t, param: *mut sched_param) -> c_int;
@@ -47,3 +83,13 @@ extern "C" {
     pub fn pthread_attr_getschedpolicy(attr: *const pthread_attr_t, policy: *mut c_int) -> c_int;
     pub fn pthread_attr_setschedpolicy(attr: *mut pthread_attr_t, policy: c_int) -> c_int;
 }
+
+#[cfg(target_os = "linux")]
+pub const SCHED_OTHER: c_int = 0;
+#[cfg(target_os = "nto")]
+pub const SCHED_OTHER: c_int = 3;
+pub const SCHED_FIFO: c_int = 1;
+pub const SCHED_RR: c_int = 2;
+
+pub const PTHREAD_INHERIT_SCHED: c_int = 0;
+pub const PTHREAD_EXPLICIT_SCHED: c_int = 1;

--- a/src/pal/lib.rs
+++ b/src/pal/lib.rs
@@ -60,6 +60,7 @@ pub struct sched_param {
 }
 
 extern "C" {
+    pub fn sysconf(__name: c_int) -> c_long;
     pub fn pthread_self() -> pthread_t;
     pub fn pthread_join(native: pthread_t, value: *mut *mut c_void) -> c_int;
     pub fn pthread_attr_init(attr: *mut pthread_attr_t) -> c_int;
@@ -92,4 +93,7 @@ pub const SCHED_FIFO: c_int = 1;
 pub const SCHED_RR: c_int = 2;
 
 pub const PTHREAD_INHERIT_SCHED: c_int = 0;
+#[cfg(target_os = "linux")]
 pub const PTHREAD_EXPLICIT_SCHED: c_int = 1;
+#[cfg(target_os = "nto")]
+pub const PTHREAD_EXPLICIT_SCHED: c_int = 2;

--- a/src/thread/parameters.rs
+++ b/src/thread/parameters.rs
@@ -148,9 +148,14 @@ mod tests {
 
     #[test]
     fn scheduler_policy_min_max_priority() {
+        #[cfg(target_os = "linux")]
+        const FIFO_MAX_PRIORITY: i32 = 99;
+        #[cfg(target_os = "nto")]
+        const FIFO_MAX_PRIORITY: i32 = 253;
+
         let policy = SchedulerPolicy::Fifo;
         assert_eq!(policy.priority_min(), 1);
-        assert_eq!(policy.priority_max(), 99);
+        assert_eq!(policy.priority_max(), FIFO_MAX_PRIORITY);
     }
 
     #[test]
@@ -179,7 +184,7 @@ mod tests {
     #[should_panic(expected = "priority is not in allowed range for the scheduler policy")]
     fn scheduler_parameters_new_priority_out_of_range() {
         let policy = SchedulerPolicy::Other;
-        let priority = 1;
+        let priority = 255;
         let _ = SchedulerParameters::new(policy, priority);
     }
 

--- a/src/thread/thread.rs
+++ b/src/thread/thread.rs
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "pthread_attr_setschedparam failed, rc:")]
     fn attributes_priority_wrong_scheduler_policy() {
-        // Test is disabled for Neutrino - priority range seem to be unchecked on set.
+        // Test is disabled for Neutrino - priority range seems to be unchecked on set.
         let mut attrs = Attributes::new();
         attrs.priority(255);
     }

--- a/src/thread/thread.rs
+++ b/src/thread/thread.rs
@@ -355,11 +355,16 @@ mod tests {
     fn attributes_inherit_scheduling_attributes_succeeds() {
         let mut attrs = Attributes::new();
 
-        attrs.inherit_scheduling_attributes(true);
+        // Check default - inherit sched.
         assert!(attr_inherit_scheduling_attributes(&attrs));
 
+        // Check explicit sched.
         attrs.inherit_scheduling_attributes(false);
         assert!(!attr_inherit_scheduling_attributes(&attrs));
+
+        // Check inherit sched.
+        attrs.inherit_scheduling_attributes(true);
+        assert!(attr_inherit_scheduling_attributes(&attrs));
     }
 
     #[test]
@@ -371,11 +376,13 @@ mod tests {
         assert_eq!(attr_priority(&attrs), 50);
     }
 
+    #[cfg(not(target_os = "nto"))]
     #[test]
     #[should_panic(expected = "pthread_attr_setschedparam failed, rc:")]
     fn attributes_priority_wrong_scheduler_policy() {
+        // Test is disabled for Neutrino - priority range seem to be unchecked on set.
         let mut attrs = Attributes::new();
-        attrs.priority(50);
+        attrs.priority(255);
     }
 
     #[test]
@@ -399,7 +406,7 @@ mod tests {
     #[should_panic(expected = "pthread_attr_setstacksize failed, rc:")]
     fn attributes_stack_size_too_small() {
         let mut attrs = Attributes::new();
-        attrs.stack_size(4 * 1024);
+        attrs.stack_size(1024);
     }
 
     #[test]


### PR DESCRIPTION
- Remove libc dependency - not available for QNX x86_64.
- Fix implementation and tests.
- Restore tests in CI.

Resolves #251