### PR TITLE
adopt cicd-actions/setup-bazel-cache for all workflows

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -13,6 +13,7 @@
 name: Bazel Build (Linux)
 permissions:
   contents: read
+  actions: write
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -53,13 +54,10 @@ jobs:
           level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+      - name: Setup Bazel Cache
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.job }}_${{ matrix.bazel-config }}
-          repository-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}-${{ matrix.bazel-config }}
       - name: Install QEMU
         if: matrix.bazel-config == 'bl-aarch64-linux'
         run: |

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -13,6 +13,7 @@
 name: Code Coverage
 permissions:
   contents: read
+  actions: write
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -35,13 +36,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y lcov
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+      - name: Setup Bazel Cache
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.job }}
-          repository-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
       - name: Run Bazel Coverage
         run: |
           bazel coverage --config=bl-x86_64-linux -- //score/... \

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,6 +13,7 @@
 name: Formatting checks
 permissions:
   contents: read
+  actions: write
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -26,13 +27,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+      - name: Setup Bazel Cache
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.job }}
-          repository-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
       - name: Bazel Build with clang-format
         run: |
           bazel build --config clang_format -- //... || true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,7 @@
 name: Linter checks
 permissions:
   contents: read
+  actions: write
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -31,13 +32,10 @@ jobs:
           level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+      - name: Setup Bazel Cache
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.job }}
-          repository-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
       - name: Bazel Build with clang-tidy
         run: |
           bazel build --config clang_tidy -- //...

--- a/.github/workflows/sanitizers_linux.yml
+++ b/.github/workflows/sanitizers_linux.yml
@@ -13,6 +13,7 @@
 name: Bazel Sanitizers (Linux)
 permissions:
   contents: read
+  actions: write
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -31,13 +32,10 @@ jobs:
           level: 4
       - name: Checkout Repository
         uses: actions/checkout@v6
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
+      - name: Setup Bazel Cache
+        uses: eclipse-score/cicd-actions/setup-bazel-cache@659dcbed63f6b7fbde88c7850125ea0a0a92f939
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.job }}
-          repository-cache: true
-          cache-save: ${{ github.event_name == 'push' }}
+          unique-cache-name: ${{ github.workflow }}-${{ github.job }}
       - name: Bazel Test with Sanitizers
         run: |
           bazel test --config bl-x86_64-linux --config=asan_ubsan_lsan --build_tests_only -- //score/... \


### PR DESCRIPTION
Fixes: https://github.com/eclipse-score/baselibs/issues/259