### PR TITLE
Remove legacy klocwork suppression comments

### DIFF
--- a/score/hash/code/common/algorithms.h
+++ b/score/hash/code/common/algorithms.h
@@ -25,11 +25,7 @@ namespace score
 namespace hash
 {
 
-/* KW_SUPPRESS_START:MISRA.ONEDEFRULE.VAR:constexpr must be initialized */
-/* KW_SUPPRESS_START:UNUSED.STYLE.SINGLE_STMT_PER_LINE:this is a declaration with a literal expression*/
 constexpr std::size_t kMaxDigestSize{64U};
-/* KW_SUPPRESS_END:UNUSED.STYLE.SINGLE_STMT_PER_LINE */
-/* KW_SUPPRESS_END:MISRA.ONEDEFRULE.VAR */
 
 constexpr std::uint8_t kSha1Size{20U};
 constexpr std::uint8_t kSha256Size{32U};
@@ -39,8 +35,6 @@ constexpr std::uint8_t kCrc32Size{4U};
 constexpr std::uint8_t kCrc32AutosarSize{4U};
 
 /// Cryptographic hash algorithm
-/* KW_SUPPRESS_START:UNUSED.STYLE.SINGLE_STMT_PER_LINE:this is a declaration of an enum; putting this on a single */
-/* line harms readability */
 enum class HashAlgorithm : std::uint8_t
 {
     kNone = 0,

--- a/score/hash/code/common/error.h
+++ b/score/hash/code/common/error.h
@@ -25,8 +25,6 @@ namespace score
 namespace hash
 {
 
-/* KW_SUPPRESS_START:UNUSED.STYLE.SINGLE_STMT_PER_LINE: we do want to define an enum on multiple lines */
-/* KW_SUPPRESS_START:MISRA.ONEDEFRULE.VAR: false positive, this is not a variable definition, so ODR doesn't apply */
 enum class ErrorCode : score::result::ErrorCode
 {
     kCouldNotCreateDigest,
@@ -38,16 +36,8 @@ enum class ErrorCode : score::result::ErrorCode
     kStreamError,
     kUnknownError,
 };
-/* KW_SUPPRESS_END:MISRA.ONEDEFRULE.VAR */
-/* KW_SUPPRESS_END:UNUSED.STYLE.SINGLE_STMT_PER_LINE */
 
-/* KW_SUPPRESS_START:MISRA.ONEDEFRULE.VAR: FP: noexcept is a keyword and not an identifier, so ODR doesn't apply */
-/* KW_SUPPRESS_START:UNUSED.STYLE.SINGLE_STMT_PER_LINE: False positive, this is exactly one statement */
-/* KW_SUPPRESS_START:MISRA.VAR.HIDDEN: False positive, noexcept is not an identifier */
 score::result::Error MakeError(const score::hash::ErrorCode code, const std::string_view user_message = "") noexcept;
-/* KW_SUPPRESS_END:MISRA.VAR.HIDDEN */
-/* KW_SUPPRESS_END:UNUSED.STYLE.SINGLE_STMT_PER_LINE */
-/* KW_SUPPRESS_END:MISRA.ONEDEFRULE.VAR */
 
 }  // namespace hash
 }  // namespace score

--- a/score/hash/code/openssl/openssl_wrapper/openssl_lib_impl.cpp
+++ b/score/hash/code/openssl/openssl_wrapper/openssl_lib_impl.cpp
@@ -22,7 +22,6 @@ namespace hash
 namespace openssl
 {
 
-/* KW_SUPPRESS_START:MISRA.VAR.HIDDEN:Shaddowing function name is intended. */
 const StructDigest* OpensslLibImpl::DigestAlgoSha1() const noexcept
 {
     return ::EVP_sha1();
@@ -48,7 +47,6 @@ StructDigestCtx* OpensslLibImpl::CreateDigestCtx() const noexcept
     return ::EVP_MD_CTX_new();
 }
 
-/* KW_SUPPRESS_START:MISRA.VAR.NEEDS.CONST: False positive */
 std::int32_t OpensslLibImpl::InitDigestCtx(StructDigestCtx* ctx, const StructDigest* type, Engine* impl) const noexcept
 {
     return ::EVP_DigestInit_ex(ctx, type, impl);
@@ -59,20 +57,17 @@ std::int32_t OpensslLibImpl::UpdateDigestCtx(StructDigestCtx* ctx, const void* d
     return ::EVP_DigestUpdate(ctx, data, count);
 }
 
-/* KW_SUPPRESS_START:UNUSED.BUILTIN_NUMERIC: The function requires the input param to be basic numeric type*/
 std::int32_t OpensslLibImpl::FinalizeDigestValue(StructDigestCtx* ctx,
                                                  unsigned char* digest_value,
                                                  unsigned int* digest_size) const noexcept
 {
     return ::EVP_DigestFinal_ex(ctx, digest_value, digest_size);
 }
-/* KW_SUPPRESS_END:UNUSED.BUILTIN_NUMERIC */
+
 void OpensslLibImpl::ResetDigestCtx(StructDigestCtx* ctx) const noexcept
 {
     ::EVP_MD_CTX_free(ctx);
 }
-/* KW_SUPPRESS_END:MISRA.VAR.NEEDS.CONST */
-/* KW_SUPPRESS_END:MISRA.VAR.HIDDEN: */
 }  // namespace openssl
 }  // namespace hash
 }  // namespace score

--- a/score/hash/code/openssl/openssl_wrapper/openssl_lib_impl.h
+++ b/score/hash/code/openssl/openssl_wrapper/openssl_lib_impl.h
@@ -36,7 +36,6 @@ class OpensslLibImpl final : public IOpensslLib
     OpensslLibImpl& operator=(const OpensslLibImpl&) = delete;
     OpensslLibImpl& operator=(OpensslLibImpl&&) noexcept = delete;
 
-    /* KW_SUPPRESS_START:MISRA.VAR.HIDDEN:Shaddowing function name is intended. */
     const StructDigest* DigestAlgoSha1() const noexcept override;
     const StructDigest* DigestAlgoSha256() const noexcept override;
     const StructDigest* DigestAlgoSha384() const noexcept override;
@@ -44,13 +43,10 @@ class OpensslLibImpl final : public IOpensslLib
     StructDigestCtx* CreateDigestCtx() const noexcept override;
     std::int32_t InitDigestCtx(StructDigestCtx* ctx, const StructDigest* type, Engine* impl) const noexcept override;
     std::int32_t UpdateDigestCtx(StructDigestCtx* ctx, const void* data, std::size_t count) const noexcept override;
-    /* KW_SUPPRESS_START:UNUSED.BUILTIN_NUMERIC: The function requires the input param to be basic numeric type*/
     std::int32_t FinalizeDigestValue(StructDigestCtx* ctx,
                                      unsigned char* digest_value,
                                      unsigned int* digest_size) const noexcept override;
-    /* KW_SUPPRESS_END:UNUSED.BUILTIN_NUMERIC*/
     void ResetDigestCtx(StructDigestCtx* ctx) const noexcept override;
-    /* KW_SUPPRESS_END:MISRA.VAR.HIDDEN */
 };
 
 }  // namespace openssl

--- a/score/hash/code/openssl/openssl_wrapper/openssl_lib_mock.h
+++ b/score/hash/code/openssl/openssl_wrapper/openssl_lib_mock.h
@@ -29,7 +29,6 @@ namespace openssl
 class OpensslLibMock : public IOpensslLib
 {
   public:
-    /* KW_SUPPRESS_START:MISRA.MEMB.NOT_PRIVATE: caused by MOCK_METHOD macros */
     MOCK_METHOD((const StructDigest*), DigestAlgoSha1, (), (const, noexcept, override));
     MOCK_METHOD((const StructDigest*), DigestAlgoSha256, (), (const, noexcept, override));
     MOCK_METHOD((const StructDigest*), DigestAlgoSha384, (), (const, noexcept, override));
@@ -48,7 +47,6 @@ class OpensslLibMock : public IOpensslLib
                 (StructDigestCtx * ctx, unsigned char* digest_value, unsigned int* digest_size),
                 (const, noexcept, override));
     MOCK_METHOD(void, ResetDigestCtx, (StructDigestCtx * ctx), (const, noexcept, override));
-    /* KW_SUPPRESS_END:MISRA.MEMB.NOT_PRIVATE: caused by MOCK_METHOD macros */
 };
 
 }  // namespace openssl

--- a/score/static_reflection_with_serialization/serialization/include/serialization/for_logging.h
+++ b/score/static_reflection_with_serialization/serialization/include/serialization/for_logging.h
@@ -24,9 +24,7 @@ namespace common
 namespace visitor
 {
 
-/* KW_SUPPRESS_START:AUTOSAR.BUILTIN_NUMERIC: Char used as a byte representation. */
 using Byte = char;
-/* KW_SUPPRESS_END:AUTOSAR.BUILTIN_NUMERIC: Char used as a byte representation. */
 
 struct log_alloc_t
 {
@@ -63,10 +61,8 @@ class logging_serializer
         {
             return static_cast<offset_t>(0);  // LCOV_EXCL_LINE
         }
-        /* KW_SUPPRESS_START:AUTOSAR.CAST.REINTERPRET: Intended */
         // coverity[autosar_cpp14_a5_2_4_violation]
         return impl::serialize(t, reinterpret_cast<std::uint8_t* const>(data), static_cast<offset_t>(size));
-        /* KW_SUPPRESS_END:AUTOSAR.CAST.REINTERPRET: Intended */
     }
     template <typename T>
     static deserialization_result_t deserialize(const std::uint8_t* const data, const size_t size, T& t)
@@ -91,12 +87,8 @@ class logging_serializer
             return deserialization_result_t{
                 true /* out of bounds */, false /* invalid format */, false /* zero offset */};
         }
-        /* KW_SUPPRESS_START:AUTOSAR.CAST.REINTERPRET: Intended */
-        /* KW_SUPPRESS_START: MISRA.CAST.CONST: False positive: constness is preserved. */
         // coverity[autosar_cpp14_a5_2_4_violation]
         return impl::deserialize(reinterpret_cast<const std::uint8_t* const>(data), static_cast<offset_t>(size), t);
-        /* KW_SUPPRESS_END: MISRA.CAST.CONST: False positive: constness is preserved. */
-        /* KW_SUPPRESS_END:AUTOSAR.CAST.REINTERPRET: Intended */
     }
     template <typename T>
     static offset_t serialize_size(const T& t)
@@ -117,10 +109,8 @@ using logging_serialized_descriptor = serialized_descriptor_t<log_alloc_t, T>;
 template <typename T>
 inline std::string logger_memcpy(const T& t)
 {
-    /* KW_SUPPRESS_START:AUTOSAR.CAST.REINTERPRET: Intended */
     // coverity[autosar_cpp14_a5_2_4_violation]
     return std::string(reinterpret_cast<const Byte*>(&t), sizeof(T));
-    /* KW_SUPPRESS_END:AUTOSAR.CAST.REINTERPRET: Intended */
 }
 
 inline std::string logger_pack_string(const std::string& str)
@@ -152,11 +142,8 @@ inline auto logger_type_info()
             const auto strsize = static_cast<std::size_t>(std::distance(payload_.first, payload_.second));
             return sizeof(uint32_t) + strsize;
         }
-        /* KW_SUPPRESS_START: MISRA.VAR.HIDDEN: False positive: local variable 'size' does not hide method name
-         * 'size()'. */
         void copy(Byte* const data, const std::size_t size) const
         {
-            /* KW_SUPPRESS_END: MISRA.VAR.HIDDEN: False positive: local variable does not hide method name. */
             if (size >= sizeof(uint32_t))
             {
                 const auto strsize = static_cast<std::size_t>(std::distance(payload_.first, payload_.second));
@@ -166,13 +153,11 @@ inline auto logger_type_info()
                     auto intsize = static_cast<uint32_t>(strsize);
                     // needed to copy data to the target location
                     std::ignore = memcpy(data, &intsize, sizeof(uint32_t));
-                    /* KW_SUPPRESS_START:MISRA.PTR.ARITH:Needed to get offset from this location */
                     // needed to copy data to the target location and arithmetic used to get offset from this location
                     // tolerated per design
                     score::cpp::span<Byte> dataSpan{static_cast<Byte*>(data),
                                              static_cast<typename score::cpp::span<Byte*>::size_type>(size)};
                     std::ignore = memcpy(dataSpan.subspan(sizeof(uint32_t)).data(), payload_.first, strsize);
-                    /* KW_SUPPRESS_END:MISRA.PTR.ARITH:Needed to get offset from this location */
                 }
                 else
                 {
@@ -182,12 +167,8 @@ inline auto logger_type_info()
             }
         }
 
-        /* KW_SUPPRESS_START: MISRA.USE.EXPANSION: False positive: it is not macro. */
       private:
-        /* KW_SUPPRESS_END: MISRA.USE.EXPANSION: False positive: it is not macro. */
-        /* KW_SUPPRESS_START: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
         const std::pair<const Byte*, const Byte*> payload_;
-        /* KW_SUPPRESS_END: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
     };
 
     return Typeinfo();

--- a/score/static_reflection_with_serialization/serialization/include/serialization/skip_deserialize.h
+++ b/score/static_reflection_with_serialization/serialization/include/serialization/skip_deserialize.h
@@ -39,7 +39,6 @@ struct skip_deserialize
 {
 };
 
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 template <typename A, typename S, typename T>
 inline void serialize(const T& /*unused*/, serializer_helper<A>& /*unused*/, skip_deserialize_serialized<S>& /*unused*/)
 {
@@ -67,7 +66,6 @@ inline auto visit_as(serialized_visitor<A>& /*unused*/, const skip_deserialize<T
 {
     return skip_deserialize_serialized_descriptor<A, T>();
 }
-/* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 
 // This is supposed to be a guard protecting against incompatibilities between the payload layout
 // of the original serialized type and the payload layout of the corresponding types containing

--- a/score/static_reflection_with_serialization/serialization/include/serialization/visit_serialize.h
+++ b/score/static_reflection_with_serialization/serialization/include/serialization/visit_serialize.h
@@ -42,9 +42,7 @@ namespace common
 namespace visitor
 {
 
-/* KW_SUPPRESS_START:AUTOSAR.BUILTIN_NUMERIC: Char used as a byte representation. */
 using OneByte = char;
-/* KW_SUPPRESS_END:AUTOSAR.BUILTIN_NUMERIC: Char used as a byte representation. */
 
 namespace payload_tags
 {
@@ -124,12 +122,6 @@ struct is_serialized_type : public std::false_type
 {
 };
 
-/* KW_SUPPRESS_START:MISRA.LOGIC.OPERATOR.NOT_BOOL: False positive: all boolean expressions are correct. */
-/* KW_SUPPRESS_START:AUTOSAR.CAST.REINTERPRET:Reinterpret needs to be used to cast to ptr. */
-/* KW_SUPPRESS_START:MISRA.FUNC.UNUSEDPAR: False positive: all templates arguments are used. */
-/* KW_SUPPRESS_START:MISRA.VAR.NEEDS.CONST: False positive for some cases: Variables in templates are modified. */
-/* KW_SUPPRESS_START:AUTOSAR.FUNC.TMPL.EXPLICIT_SPEC: False positive: no specialization is used. */
-
 template <typename A>
 class serializer_helper
 {
@@ -142,11 +134,9 @@ class serializer_helper
     serializer_helper(std::uint8_t* base, offset_t maxSize, offset_t startSize)
         : base_(base), maxSize_(maxSize), curSize_(startSize)
     {
-        /* KW_SUPPRESS_START: MISRA.USE.EXPANSION: Macro for assertion is tolerated by decision. */
         SCORE_LANGUAGE_FUTURECPP_ASSERT(base != nullptr);
         SCORE_LANGUAGE_FUTURECPP_ASSERT(startSize > static_cast<offset_t>(0));
         SCORE_LANGUAGE_FUTURECPP_ASSERT(startSize <= maxSize);
-        /* KW_SUPPRESS_END: MISRA.USE.EXPANSION */
     }
 
     offset_t advance(std::size_t size)
@@ -176,9 +166,8 @@ class serializer_helper
     {
         static_assert(std::is_standard_layout<T>::value, "attempt to serialize to a non-StandardLayout type");
         static_assert(alignof(T) == 1, "attempt to serialize to a not byte aligned type");
-        /* KW_SUPPRESS_START:MISRA.PTR.ARITH:Needed to get offset from this location */
-        // reinterpret cast need to cast to different pointer type
-        // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic) same as KW
+        // cast need to obtain offset from this location
+        // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         score::cpp::span<std::uint8_t> dataSpan{base_,
                                          static_cast<typename score::cpp::span<std::uint8_t* const>::size_type>(maxSize_)};
         /*
@@ -189,22 +178,15 @@ class serializer_helper
             inside base_ into type specified (T).
         */
         // coverity[autosar_cpp14_a5_2_4_violation]
-        return reinterpret_cast<T*>(  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast) jusified
+        return reinterpret_cast<T*>(  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast) justified
             dataSpan.subspan(static_cast<typename score::cpp::span<std::uint8_t* const>::size_type>(size)).data());
-        // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic) same as KW
-        /* KW_SUPPRESS_END:MISRA.PTR.ARITH:Needed to get offset from this location */
+        // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     }
 
-    /* KW_SUPPRESS_START: MISRA.USE.EXPANSION: False positive: it is not macro. */
   private:
-    /* KW_SUPPRESS_END: MISRA.USE.EXPANSION: False positive: it is not macro. */
-    /* KW_SUPPRESS_START: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
-    /* KW_SUPPRESS_START: MISRA.VAR.HIDDEN: False positive: it is struct member. */
     std::uint8_t* const base_;
     const offset_t maxSize_;
-    /* KW_SUPPRESS_END: MISRA.VAR.HIDDEN: False positive: it is struct member. */
     offset_t curSize_;
-    /* KW_SUPPRESS_END: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
 };
 
 template <typename A>
@@ -226,7 +208,6 @@ class deserializer_helper
     {
         static_assert(std::is_standard_layout<T>::value, "attempt to deserialize from a non-StandardLayout type");
         static_assert(alignof(T) == 1, "attempt to deserialize from a not byte aligned type");
-        /* KW_SUPPRESS_START: AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: False positive. */
         /*
                 Deviation from Rule A4-7-1:
                 - An integer expression shall not lead to data loss.
@@ -237,14 +218,9 @@ class deserializer_helper
         // coverity[autosar_cpp14_a4_7_1_violation]
         if (size + sizeof(T) * n > maxSize_)
         {
-            /* KW_SUPPRESS_END: AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: False positive. */
-            /* KW_SUPPRESS_START: MISRA.ONEDEFRULE.VAR: False positive. */
             out_of_bounds_ = true;
-            /* KW_SUPPRESS_END: MISRA.ONEDEFRULE.VAR: False positive. */
             return nullptr;
         }
-        /* KW_SUPPRESS_START:MISRA.PTR.ARITH:Needed to get offset from this location */
-        /* KW_SUPPRESS_START: AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: False positive. */
         // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic) justified
         score::cpp::span<const std::uint8_t> dataSpan{
             base_, static_cast<typename score::cpp::span<const std::uint8_t* const>::size_type>(maxSize_)};
@@ -259,8 +235,6 @@ class deserializer_helper
         return reinterpret_cast<T*>(  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast) justified
             dataSpan.subspan(static_cast<typename score::cpp::span<std::uint8_t* const>::size_type>(size)).data());
         // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic) justified
-        /* KW_SUPPRESS_END: AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: False positive. */
-        /* KW_SUPPRESS_END:MISRA.PTR.ARITH:Needed to get offset from this location */
     }
 
     bool getInvalidFormat() const
@@ -286,30 +260,12 @@ class deserializer_helper
         invalid_format_ = true;
     }
 
-    /* KW_SUPPRESS_START: MISRA.USE.EXPANSION: False positive: it is not macro. */
   private:
-    /* KW_SUPPRESS_END: MISRA.USE.EXPANSION: False positive: it is not macro. */
-    /* KW_SUPPRESS_START: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
-    /* KW_SUPPRESS_START: MISRA.VAR.HIDDEN: False positive: it is struct member. */
     const std::uint8_t* const base_;
     const offset_t maxSize_;
-    /* KW_SUPPRESS_END: MISRA.VAR.HIDDEN: False positive: it is struct member. */
-    /* KW_SUPPRESS_START: MISRA.ONEDEFRULE.VAR: False positive. */
     bool invalid_format_;
     bool zero_offset_;
-    /* KW_SUPPRESS_START: MISRA.OBJ.TYPE.COMPAT: This is struct field and constness of another struct's field has no
-     * meaning. */
-    /* KW_SUPPRESS_START: MISRA.OBJ.TYPE.IDENT: This is struct field and constness of another struct's field has no
-     * meaning. */
-    /* KW_SUPPRESS_START: MISRA.LINKAGE.EXTERN: False positive. */
     bool out_of_bounds_;
-    /* KW_SUPPRESS_END: MISRA.LINKAGE.EXTERN: False positive. */
-    /* KW_SUPPRESS_END: MISRA.OBJ.TYPE.IDENT: This is struct field and constness of another struct's field has no
-     * meaning. */
-    /* KW_SUPPRESS_END: MISRA.OBJ.TYPE.COMPAT: This is struct field and constness of another struct's field has no
-     * meaning. */
-    /* KW_SUPPRESS_END: MISRA.ONEDEFRULE.VAR: False positive. */
-    /* KW_SUPPRESS_END: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
 };
 
 // memcpy_serialized
@@ -325,7 +281,6 @@ struct is_serialized_type<memcpy_serialized<N>> : public std::true_type
 {
 };
 
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 template <typename A, typename T>
 // This is false positive, Overload signatures are different.
 // coverity[autosar_cpp14_a2_10_4_violation : FALSE]
@@ -355,7 +310,6 @@ inline void deserialize(const memcpy_serialized<sizeof(T)>& serial, deserializer
     std::ignore = std::memcpy(&t, serial.arr.data(), sizeof(T));
     // NOLINTEND(score-banned-function) tolerated per design
 }
-/* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 
 // array_serialized
 
@@ -512,8 +466,6 @@ struct is_serialized_type<vector_serialized<A, S>> : public std::true_type
 namespace detail
 {
 
-/* KW_SUPPRESS_START:MISRA.LOGIC.NOT_BOOL: false positive */
-/* KW_SUPPRESS_START:AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
 template <typename T, std::enable_if_t<has_clear<T>::value, std::int32_t> = 0>
 inline void clear(T& t)
 {
@@ -550,8 +502,6 @@ inline void resize(T& t, size_t n)
         t.push_back(typename T::value_type{});
     }
 }
-/* KW_SUPPRESS_END:AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
-/* KW_SUPPRESS_END:MISRA.LOGIC.NOT_BOOL: false positive */
 
 }  // namespace detail
 
@@ -589,13 +539,11 @@ inline void serialize(const T& t, serializer_helper<A>& a, vector_serialized<A, 
             a.template address<S>(static_cast<typename A::offset_t>(offset + sizeof(subsize_s_t)));
         for (std::size_t i = 0UL; i != n; ++i)
         {
-            /* KW_SUPPRESS_START:MISRA.PTR.ARITH:Needed to get offset from this location */
             // Suppress AUTOSAR C++14 M5-0-15 rule findings. This rule stated: "indexing shall be the only
             // form of pointer arithmetic"
             // False positive, no pointer arithmetic applied to pointer string_size_location
             // coverity[autosar_cpp14_m5_0_15_violation]
             serialize(*(t.cbegin() + static_cast<std::ptrdiff_t>(i)), a, string_size_location[i]);
-            /* KW_SUPPRESS_END:MISRA.PTR.ARITH:Needed to get offset from this location */
         }
     }
 }
@@ -690,9 +638,7 @@ inline void deserialize(const vector_serialized<A, S>& serial, deserializer_help
     detail::resize(t, n);
     for (std::size_t i = 0; i != n; ++i)
     {
-        /* KW_SUPPRESS_START:MISRA.PTR.ARITH:Needed to get offset from this location */
         deserialize(vector_contents_address[i], a, *(t.begin() + static_cast<std::ptrdiff_t>(i)));
-        /* KW_SUPPRESS_END:MISRA.PTR.ARITH:Needed to get offset from this location */
     }
 }
 
@@ -889,7 +835,6 @@ inline void deserialize_parameter_pack(const pair_serialized<S1, S2>& serial,
 
 // serializing tuples
 
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 template <typename A, typename S, typename... Args, std::size_t... I>
 inline void serialize_tuple_start(const std::tuple<Args...>& t,
                                   serializer_helper<A>& a,
@@ -928,7 +873,6 @@ template <typename A, typename S>
 struct struct_serializer_visitor
 {
   public:
-    /* KW_SUPPRESS_START: MISRA.MEMB.NOT_PRIVATE: template struct field used in another template function. */
     /*
        Maintaining compatibility and avoiding performance overhead outweighs POD Type (class) based design for this
        particular struct. The Type is Simple Template type and does not require invariance (interface OR custom
@@ -938,7 +882,6 @@ struct struct_serializer_visitor
     serializer_helper<A>& a;
     // coverity[autosar_cpp14_m11_0_1_violation]
     S& serializer;
-    /* KW_SUPPRESS_END: MISRA.MEMB.NOT_PRIVATE: template struct field used in another template function. */
 };
 
 template <typename A, typename S, typename T, typename... Args>
@@ -962,7 +905,6 @@ inline void serialize(const T& t, serializer_helper<A>& a, S& serial)
 template <typename A, typename S>
 struct struct_deserializer_visitor
 {
-    /* KW_SUPPRESS_START: MISRA.MEMB.NOT_PRIVATE: Intended by the design of this templated code. */
     /*
        Maintaining compatibility and avoiding performance overhead outweighs POD Type (class) based design for this
        particular struct. The Type is Simple Template type and does not require invariance (interface OR custom
@@ -972,7 +914,6 @@ struct struct_deserializer_visitor
     deserializer_helper<A>& a;
     // coverity[autosar_cpp14_m11_0_1_violation]
     const S& s;
-    /* KW_SUPPRESS_END: MISRA.MEMB.NOT_PRIVATE: Intended by the design of this templated code. */
 };
 
 template <typename A, typename S, typename T, typename... Args>
@@ -1029,8 +970,6 @@ struct memcpy_serialized_descriptor
     using payload_type = memcpy_serialized<sizeof(T)>;
 };
 
-/* KW_SUPPRESS_START:MISRA.LOGIC.NOT_BOOL: false positive */
-/* KW_SUPPRESS_START:AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
 template <typename A,
           typename T,
           std::enable_if_t<(std::is_integral<T>::value) && (std::is_signed<T>::value), std::int32_t> = 0>
@@ -1083,8 +1022,6 @@ inline auto visit_as(serialized_visitor<A>& /*unused*/, T& /*unused*/)
 {
     return memcpy_serialized_descriptor<payload_tags::unsigned_le, T>();
 }
-/* KW_SUPPRESS_END:AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
-/* KW_SUPPRESS_END:MISRA.LOGIC.NOT_BOOL: false positive */
 
 template <typename A, size_t N>
 // This is false positive, Overload signatures are different.
@@ -1128,7 +1065,6 @@ struct array_serialized_descriptor
     static constexpr size_t element_number = N;
 };
 
-/* KW_SUPPRESS_START:AUTOSAR.ARRAY.CSTYLE: intentionally */
 template <typename A, typename T, size_t N>
 // This is false positive, Overload signatures are different.
 // coverity[autosar_cpp14_m3_2_3_violation : FALSE]
@@ -1137,7 +1073,6 @@ inline auto visit_as(serialized_visitor<A>& /*unused*/, const T (& /*unused*/)[N
 {  // NOLINT(modernize-avoid-c-arrays) intentionally
     return array_serialized_descriptor<A, T, N>();
 }
-/* KW_SUPPRESS_END:AUTOSAR.ARRAY.CSTYLE: intentionally */
 
 template <typename A, typename T, size_t N>
 // This is false positive, Overload signatures are different.
@@ -1195,7 +1130,6 @@ struct vector_serialized_descriptor
     using payload_type = vector_serialized<A, typename element_type::payload_type>;
 };
 
-/* KW_SUPPRESS_START:AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
 template <typename A,
           typename T,
           std::enable_if_t<::score::common::visitor::is_vector_serializable<T>::value, std::int32_t> = 0>
@@ -1217,7 +1151,6 @@ inline auto visit_as(serialized_visitor<A>& /*unused*/, T& /*unused*/)
 {
     return vector_serialized_descriptor<A, typename T::value_type>();
 }
-/* KW_SUPPRESS_END:AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
 
 template <typename A, typename T>
 inline auto visit_parameter_pack(serialized_visitor<A>& /*unused*/, T& /*unused*/)
@@ -1402,7 +1335,6 @@ inline auto visit_as(serialized_visitor<A>& /*unused*/, const score::cpp::option
 {
     return pack_serialized_descriptor<A, optional_pack_desc, char, T>();
 }
-/* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 
 // This is false positive, because it's declared in this file in namespace score::common::visitor.
 // so different namespaces are used to organize and encapsulate code,
@@ -1434,10 +1366,7 @@ class deserialization_result_t
         return zero_offset_;
     }
 
-    /* KW_SUPPRESS_START: MISRA.USE.EXPANSION: False positive: it is not macro. */
   private:
-    /* KW_SUPPRESS_END: MISRA.USE.EXPANSION: False positive: it is not macro. */
-    /* KW_SUPPRESS_START: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
     // This flag is set if tried to deserialize behind the boundary of the data array
     const bool out_of_bounds_;
 
@@ -1446,7 +1375,6 @@ class deserialization_result_t
 
     // This flag is set if the offset of a dynamic element (in static payload) is 0 (as a result of too little buffer)
     const bool zero_offset_;
-    /* KW_SUPPRESS_END: MISRA.MEMB.NOT_PRIVATE: False positive: it is private member. */
 };
 
 // serializer_t (encapsulating the visitors and the helpers)
@@ -1528,7 +1456,6 @@ class serializer_t
         {
             return deserialization_result_t{true, false, false};
         }
-        /* KW_SUPPRESS_START: MISRA.CAST.CONST: False positive: constness is preserved. */
         // cast to different pointer type
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) [score-qualified-nolint]
         /*
@@ -1546,17 +1473,10 @@ class serializer_t
         */
         // coverity[autosar_cpp14_a5_2_4_violation]
         ::score::common::visitor::deserialize(*reinterpret_cast<const serialized_type* const>(data), a, t);
-        /* KW_SUPPRESS_END: MISRA.CAST.CONST: False positive: constness is preserved. */
 
         return deserialization_result_t{a.getOutOfBounds(), a.getInvalidFormat(), a.getZeroOffset()};
     }
 };
-
-/* KW_SUPPRESS_END:AUTOSAR.FUNC.TMPL.EXPLICIT_SPEC: False positive: no specialization is used. */
-/* KW_SUPPRESS_END:MISRA.VAR.NEEDS.CONST: False positive for some cases: Variables in templates are modified. */
-/* KW_SUPPRESS_END:MISRA.FUNC.UNUSEDPAR: False positive: all templates arguments are used. */
-/* KW_SUPPRESS_END:AUTOSAR.CAST.REINTERPRET:Reinterpret needs to be used to cast to ptr */
-/* KW_SUPPRESS_END:MISRA.LOGIC.OPERATOR.NOT_BOOL: False positive: all boolean expressions are correct. */
 
 }  // namespace visitor
 
@@ -1564,8 +1484,6 @@ class serializer_t
 
 }  // namespace score
 
-/* KW_SUPPRESS_START:MISRA.USE.DEFINE: intentionally. */
-/* KW_SUPPRESS_START:MISRA.DEFINE.NOPARS: Correct usage of macro. */
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage) same as KW
 /// \public
 /*
@@ -1613,7 +1531,5 @@ class serializer_t
     {                                                                                                               \
         v.out += static_cast<SizeType>(sizeof(::score::common::visitor::memcpy_serialized<sizeof(std::decay_t<T>)>)); \
     }
-/* KW_SUPPRESS_END:MISRA.DEFINE.NOPARS: Correct usage of macro. */
-/* KW_SUPPRESS_END:MISRA.USE.DEFINE: intentionally. */
 
 #endif  // SCORE_COMMON_SERIALIZATION_INCLUDE_SERIALIZATION_VISIT_SERIALIZE_H

--- a/score/static_reflection_with_serialization/serialization/include/serialization/visit_size.h
+++ b/score/static_reflection_with_serialization/serialization/include/serialization/visit_size.h
@@ -35,10 +35,8 @@ namespace visitor
 template <typename SizeType = uint64_t>
 struct size_helper
 {
-    /* KW_SUPPRESS_START:MISRA.LOGIC.NOT_BOOL: false positive */
     static_assert(std::is_arithmetic<SizeType>::value, "Size type should be arithmetic");
     static_assert(!std::is_const<SizeType>::value, "Size type should not be const");
-    /* KW_SUPPRESS_END:MISRA.LOGIC.NOT_BOOL: false positive */
     /*
       1 - It's not a POD type because of initialization of member variables.
       2 - Maintaining compatibility and avoiding performance overhead outweighs POD Type (class) based design for
@@ -57,19 +55,15 @@ struct size_helper
     SizeType string_offset{0UL};
 };
 
-/* KW_SUPPRESS_START:MISRA.LOGIC.NOT_BOOL: false positive */
 template <typename SizeType,
           typename T,
           std::enable_if_t<(!std::is_pointer<std::decay_t<T>>::value) && (!std::is_class<std::decay_t<T>>::value),
                            std::int32_t> = 0>
-/* KW_SUPPRESS_END:MISRA.LOGIC.NOT_BOOL: false positive */
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 // This is false positive, Overload signatures are different.
 // coverity[autosar_cpp14_a2_10_4_violation : FALSE]
 inline void visit_as(size_helper<SizeType>& v, T&&)
 {
     static_assert(sizeof(std::decay_t<T>) <= std::numeric_limits<SizeType>::max(), "size of T too large");
-    /* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
     const auto new_size = v.out + static_cast<SizeType>(sizeof(std::decay_t<T>));
     // There is no benefit of writing unit test to cover the TRUE case of this condition, it will not have any
     // expectation or assertion because the function will return gracefully without any return values or even
@@ -92,18 +86,12 @@ inline void visit_as(size_helper<SizeType>& v, T&& t)
     V::visit(v, t);
 }
 
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 template <typename SizeType, typename S, typename... Args>
 inline void visit_as_struct(size_helper<SizeType>& v, S&&, Args&&... args)
 {
-    /* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
     // pre-C++17 parameter pack folding idiom
-    /* KW_SUPPRESS_START:AUTOSAR.ARRAY.CSTYLE: intentionally */
     using expander = std::int32_t[];
-    /* KW_SUPPRESS_END:AUTOSAR.ARRAY.CSTYLE: intentionally */
-    /* KW_SUPPRESS_START:MISRA.COMMA: False positive: correct usage of comma. */
     std::ignore = expander{(score::common::visitor::visit(v, std::forward<Args>(args)), 0)...};
-    /* KW_SUPPRESS_END:MISRA.COMMA: False positive: correct usage of comma. */
 }
 
 template <typename SizeType, typename T1, typename T2>
@@ -133,11 +121,9 @@ inline void visit_tuple_continue(size_helper<SizeType>& v, const T& t, Args&&...
     visit_tuple_continue(v, std::forward<Args>(args)...);
 }
 
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 template <typename SizeType, typename... T, std::size_t... I>
 inline void visit_tuple_start(size_helper<SizeType>& v, const std::tuple<T...>& t, std::index_sequence<I...>)
 {
-    /* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
     visit_tuple_continue(v, std::get<I>(t)...);
 }
 
@@ -252,12 +238,10 @@ inline void visit_as(size_helper<SizeType>& v, const std::array<T, N>& t)
 }
 
 template <typename SizeType, typename T, size_t N>
-/* KW_SUPPRESS_START:AUTOSAR.ARRAY.CSTYLE: intentionally */
 // This is false positive, Overload signatures are different.
 // coverity[autosar_cpp14_a2_10_4_violation : FALSE]
 inline void visit_as(size_helper<SizeType>& v, const T (&t)[N])
 {
-    /* KW_SUPPRESS_END:AUTOSAR.ARRAY.CSTYLE: intentionally */
     for (size_t i = 0; i < N; ++i)
     {
         score::common::visitor::visit(v, t[i]);

--- a/score/static_reflection_with_serialization/serialization/include/serialization/visit_type_traits.h
+++ b/score/static_reflection_with_serialization/serialization/include/serialization/visit_type_traits.h
@@ -53,12 +53,10 @@ struct has_clear<T, detail::void_t<decltype(std::declval<T>().clear())>> : std::
 template <typename T>
 struct is_resizeable
 {
-    /* KW_SUPPRESS_START: MISRA.LOGIC.NOT_BOOL: false positive */
     // It is used by is_vector_serializable to enable it or not.
     // coverity[autosar_cpp14_a0_1_1_violation : FALSE]
     static constexpr bool value = ((has_resize<T>::value || has_clear<T>::value) ||
                                    (std::is_default_constructible<T>::value && std::is_copy_assignable<T>::value));
-    /* KW_SUPPRESS_END: MISRA.LOGIC.NOT_BOOL: false positive */
 };
 
 template <typename T, typename = void, typename = void>
@@ -74,11 +72,9 @@ struct is_vector_serializable<
                    decltype(std::declval<T>().cbegin()),
                    decltype(std::declval<T>().size()),
                    decltype(std::declval<T>().push_back(std::declval<typename T::value_type>())),
-                   /* KW_SUPPRESS_START: AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
                    typename std::enable_if<is_resizeable<T>::value>::type>> : std::true_type
 {
 };
-/* KW_SUPPRESS_END: AUTOSAR.STYLE.SINGLE_STMT_PER_LINE: false positive */
 
 }  // namespace visitor
 }  // namespace common

--- a/score/static_reflection_with_serialization/visitor/include/visitor/visit.h
+++ b/score/static_reflection_with_serialization/visitor/include/visitor/visit.h
@@ -28,29 +28,23 @@ struct visitable_type
 {
 };
 
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 inline void forgot_to_define_as_visitable(visitable_type /*unused*/) {}
-/* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 
 // fallback code to produce a nicer compiler error if visit_as() not defined;
 // the error can be avoided in coverage tests by providing a conversion operator
 // from T to visitable_type
 template <typename V, typename T, typename Unused>
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 inline void visit_internal(V&& /*unused*/, T&& t, Unused&& /*unused*/)
-/* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 {
     forgot_to_define_as_visitable(std::forward<T>(t));
 }
 // explicit nullptr_t parameter has a priority over template parameter in overload resolution
 // explicit return type is used to participate in SFINAE
 template <typename V, typename T>
-/* KW_SUPPRESS_START: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 // Unused variables needed for correct template deduction
 // coverity[autosar_cpp14_a13_3_1_violation : FALSE]
 inline auto visit_internal(V&& v, T&& t, std::nullptr_t /*unused*/)
     -> decltype(visit_as(std::forward<V>(v), std::forward<T>(t)))
-/* KW_SUPPRESS_END: MISRA.FUNC.UNUSEDPAR.UNNAMED: Unused variables needed for correct template deduction. */
 {
     return visit_as(std::forward<V>(v), std::forward<T>(t));
 }


### PR DESCRIPTION
This is a pure comment cleanup PR. No code was touched. This PR declutters the code base by removing klocwork specific comments.

Klocwork static code analysis suppression comments were removed from the codebase. Klocwork was never used inside S-CORE. The suppression are a legacy artifact from initial open-sourcing of formerly proprietary code.