### PR TITLE
analysis/tracing: Refactor visibilities and dependencies of bazel targets

### DIFF
--- a/score/analysis/tracing/common/canary_wrapper/BUILD
+++ b/score/analysis/tracing/common/canary_wrapper/BUILD
@@ -20,6 +20,6 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing:__subpackages__",
+        "//score/analysis/tracing:__subpackages__",
     ],
 )

--- a/score/analysis/tracing/common/canary_wrapper/test/BUILD
+++ b/score/analysis/tracing/common/canary_wrapper/test/BUILD
@@ -23,8 +23,8 @@ cc_test(
     features = COMPILER_WARNING_FEATURES,
     tags = ["unit"],
     deps = [
+        "//score/analysis/tracing/common/canary_wrapper",
         "@googletest//:gtest_main",
-        "@score_baselibs//score/analysis/tracing/common/canary_wrapper",
     ],
 )
 
@@ -33,5 +33,5 @@ cc_unit_test_suites_for_host_and_qnx(
     cc_unit_tests = [
         ":canary_wrapper_test",
     ],
-    visibility = ["@score_baselibs//score/analysis/tracing:__subpackages__"],
+    visibility = ["//score/analysis/tracing:__subpackages__"],
 )

--- a/score/analysis/tracing/common/interface_types/BUILD
+++ b/score/analysis/tracing/common/interface_types/BUILD
@@ -25,11 +25,11 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing:__subpackages__",
+        "//score/analysis/tracing:__subpackages__",
     ],
     deps = [
-        "@score_baselibs//score/language/safecpp/scoped_function:move_only_scoped_function",
-        "@score_baselibs//score/result",
+        "//score/language/safecpp/scoped_function:move_only_scoped_function",
+        "//score/result",
     ],
 )
 
@@ -40,7 +40,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing:__subpackages__",
+        "//score/analysis/tracing:__subpackages__",
     ],
     deps = [
         ":generic_trace_api_types",
@@ -54,11 +54,11 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing:__subpackages__",
+        "//score/analysis/tracing:__subpackages__",
     ],
     deps = [
         ":generic_trace_api_types",
         ":shared_memory_location",
-        "@score_baselibs//score/analysis/tracing/common/canary_wrapper",
+        "//score/analysis/tracing/common/canary_wrapper",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/BUILD
+++ b/score/analysis/tracing/generic_trace_library/BUILD
@@ -18,18 +18,18 @@ load("@score_baselibs//score/quality/clang_tidy:extra_checks.bzl", "clang_tidy_e
 
 alias(
     name = "api",
-    actual = "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api",
+    actual = "//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api",
     visibility = ["//visibility:public"],
 )
 
 label_flag(
     name = "implementation",
-    build_setting_default = "@score_baselibs//score/analysis/tracing/generic_trace_library/stub_implementation:stub_implementation",
+    build_setting_default = "//score/analysis/tracing/generic_trace_library/stub_implementation:stub_implementation",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "mock",
-    actual = "@score_baselibs//score/analysis/tracing/generic_trace_library/mock:trace_library_mock",
+    actual = "//score/analysis/tracing/generic_trace_library/mock:trace_library_mock",
     visibility = ["//visibility:public"],
 )

--- a/score/analysis/tracing/generic_trace_library/interface_types/BUILD
+++ b/score/analysis/tracing/generic_trace_library/interface_types/BUILD
@@ -20,9 +20,9 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing/generic_trace_library:__pkg__",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/mock:__pkg__",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/stub_implementation:__pkg__",
+        "//score/analysis/tracing/generic_trace_library:__pkg__",
+        "//score/analysis/tracing/generic_trace_library/mock:__pkg__",
+        "//score/analysis/tracing/generic_trace_library/stub_implementation:__pkg__",
     ],
     deps = [
         ":trace_library_interface",
@@ -35,14 +35,14 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing/generic_trace_library:__subpackages__",
+        "//score/analysis/tracing/generic_trace_library:__subpackages__",
     ],
     deps = [
         ":meta_info",
-        "@score_baselibs//score/analysis/tracing/common/interface_types:generic_trace_api_types",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/chunk_list",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
-        "@score_baselibs//score/language/futurecpp",
+        "//score/analysis/tracing/common/interface_types:generic_trace_api_types",
+        "//score/analysis/tracing/generic_trace_library/interface_types/chunk_list",
+        "//score/analysis/tracing/generic_trace_library/interface_types/error_code",
+        "//score/language/futurecpp",
     ],
 )
 
@@ -63,11 +63,11 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing:__subpackages__",
+        "//score/analysis/tracing:__subpackages__",
     ],
     deps = [
         ":type_definitions",
-        "@score_baselibs//score/language/futurecpp",
+        "//score/language/futurecpp",
     ],
 )
 
@@ -83,9 +83,9 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing:__subpackages__",
+        "//score/analysis/tracing:__subpackages__",
     ],
     deps = [
-        "@score_baselibs//score/language/futurecpp",
+        "//score/language/futurecpp",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/interface_types/chunk_list/BUILD
+++ b/score/analysis/tracing/generic_trace_library/interface_types/chunk_list/BUILD
@@ -27,11 +27,11 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis:__subpackages__",
+        "//score/analysis:__subpackages__",
     ],
     deps = [
-        "@score_baselibs//score/analysis/tracing/common/interface_types:shared_memory_chunk",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types/error_code",
-        "@score_baselibs//score/language/futurecpp",
+        "//score/analysis/tracing/common/interface_types:shared_memory_chunk",
+        "//score/analysis/tracing/generic_trace_library/interface_types/error_code",
+        "//score/language/futurecpp",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/interface_types/error_code/BUILD
+++ b/score/analysis/tracing/generic_trace_library/interface_types/error_code/BUILD
@@ -25,10 +25,10 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis:__subpackages__",
+        "//score/analysis:__subpackages__",
     ],
     deps = [
-        "@score_baselibs//score/language/futurecpp",
-        "@score_baselibs//score/result",
+        "//score/language/futurecpp",
+        "//score/result",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/mock/BUILD
+++ b/score/analysis/tracing/generic_trace_library/mock/BUILD
@@ -20,14 +20,12 @@ cc_library(
     hdrs = ["trace_library_mock.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [
-        "//platform/aas/ara:__subpackages__",  # TODO Ticket-259481
-        "//platform/aas/mw/com:__subpackages__",  # To be removed once me/com is pulled via bzlmod
-        "@score_baselibs//score/analysis/tracing/generic_trace_library:__pkg__",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/test:__subpackages__",
+        "//score/analysis/tracing/generic_trace_library:__pkg__",
+        "//score/analysis/tracing/generic_trace_library/test:__subpackages__",
     ],
     deps = [
+        "//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api",
+        "//score/analysis/tracing/generic_trace_library/interface_types:trace_library_interface",
         "@googletest//:gtest_main",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:trace_library_interface",
     ],
 )

--- a/score/analysis/tracing/generic_trace_library/stub_implementation/BUILD
+++ b/score/analysis/tracing/generic_trace_library/stub_implementation/BUILD
@@ -22,12 +22,12 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
-        "@score_baselibs//score/analysis/tracing/generic_trace_library:__pkg__",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/test:__subpackages__",
+        "//score/analysis/tracing/generic_trace_library:__pkg__",
+        "//score/analysis/tracing/generic_trace_library/test:__subpackages__",
     ],
     deps = [
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api",
-        "@score_baselibs//score/analysis/tracing/generic_trace_library/interface_types:trace_library_interface",
-        "@score_baselibs//score/language/futurecpp",
+        "//score/analysis/tracing/generic_trace_library/interface_types:generic_trace_api",
+        "//score/analysis/tracing/generic_trace_library/interface_types:trace_library_interface",
+        "//score/language/futurecpp",
     ],
 )

--- a/third_party/qnx/BUILD
+++ b/third_party/qnx/BUILD
@@ -18,8 +18,8 @@ cc_library(
     linkopts = [
         "-lfsnotify",
     ],
-    target_compatible_with = ["@platforms//os:qnx"],
     tags = ["third_party_FUSA"],
+    target_compatible_with = ["@platforms//os:qnx"],
     visibility = ["//:__subpackages__"],
 )
 


### PR DESCRIPTION
Removing targets that are not inside S-CORE
Removing superfluous self-reference with @score_baselibs