### PR TITLE
Remove deprecated score::StringLiteral from StringComparisonAdaptor

### DIFF
--- a/score/memory/string_comparison_adaptor.cpp
+++ b/score/memory/string_comparison_adaptor.cpp
@@ -46,11 +46,11 @@ StringComparisonAdaptor& StringComparisonAdaptor::operator=(const std::string_vi
     return *this;
 }
 
-StringComparisonAdaptor::StringComparisonAdaptor(const score::StringLiteral& c_str) : str_{c_str} {}
+StringComparisonAdaptor::StringComparisonAdaptor(const char* str) : str_{std::string_view{str}} {}
 
-StringComparisonAdaptor& StringComparisonAdaptor::operator=(const score::StringLiteral& c_str)
+StringComparisonAdaptor& StringComparisonAdaptor::operator=(const char* str)
 {
-    str_ = c_str;
+    str_ = std::string_view{str};
     return *this;
 }
 
@@ -68,9 +68,6 @@ std::string_view StringComparisonAdaptor::GetAsStringView() const noexcept
                               return variant;
                           },
                           [](const std::string& variant) noexcept {
-                              return std::string_view{variant};
-                          },
-                          [](const score::StringLiteral& variant) noexcept {
                               return std::string_view{variant};
                           }),
                       str_);

--- a/score/memory/string_comparison_adaptor.h
+++ b/score/memory/string_comparison_adaptor.h
@@ -13,8 +13,6 @@
 #ifndef SCORE_LIB_MEMORY_STRING_COMPARISON_ADAPTOR_H
 #define SCORE_LIB_MEMORY_STRING_COMPARISON_ADAPTOR_H
 
-#include "score/memory/string_literal.h"
-
 #include <functional>
 #include <string>
 #include <string_view>
@@ -48,16 +46,15 @@ class StringComparisonAdaptor
     StringComparisonAdaptor(std::string&& str);
     StringComparisonAdaptor& operator=(std::string&& str);
 
+    /// @brief Constructor for string literal / null-terminated C string
+    // NOLINTNEXTLINE(google-explicit-constructor): IMPLICIT CONVERSION JUSTIFICATION
+    StringComparisonAdaptor(const char* str);
+    StringComparisonAdaptor& operator=(const char* str);
+
     /// @brief Constructors for std::string view
     // NOLINTNEXTLINE(google-explicit-constructor): IMPLICIT CONVERSION JUSTIFICATION
     StringComparisonAdaptor(const std::string_view& str_view);
     StringComparisonAdaptor& operator=(const std::string_view& str_view);
-
-    /// @brief Constructors for assignment of c-style strings
-    /// This is mainly required for strings specified at compile time
-    // NOLINTNEXTLINE(google-explicit-constructor): IMPLICIT CONVERSION JUSTIFICATION
-    StringComparisonAdaptor(const score::StringLiteral& c_str);
-    StringComparisonAdaptor& operator=(const score::StringLiteral& c_str);
 
     ~StringComparisonAdaptor() = default;
 
@@ -66,7 +63,7 @@ class StringComparisonAdaptor
     std::string_view GetAsStringView() const noexcept;
 
   private:
-    std::variant<std::string_view, std::string, score::StringLiteral> str_;
+    std::variant<std::string_view, std::string> str_;
 };
 
 /// @brief Compares the underlying content of the string/string_view.

--- a/score/memory/string_comparison_adaptor_test.cpp
+++ b/score/memory/string_comparison_adaptor_test.cpp
@@ -12,8 +12,6 @@
  ********************************************************************************/
 #include "score/memory/string_comparison_adaptor.h"
 
-#include "score/memory/string_literal.h"
-
 #include <score/assert.hpp>
 
 #include <gmock/gmock.h>
@@ -33,7 +31,7 @@ using ::testing::Ne;
 using ::testing::StrEq;
 
 /// Set of specialised template functions which allows creating a std::string, std::string_view, or
-/// score::StringLiteral in a generic way, solely based on the template type. We use specialized template functions
+/// the underlying string type in a generic way, solely based on the template type. We use specialized template functions
 /// instead of overloading, since the signatures only differ in the return type.
 template <typename T>
 T CreateUnderlyingString(std::string_view /* string_view */)
@@ -54,12 +52,6 @@ std::string_view CreateUnderlyingString(const std::string_view string_view)
     return string_view;
 }
 
-template <>
-score::StringLiteral CreateUnderlyingString(const std::string_view string_view)
-{
-    return string_view.data();
-}
-
 template <typename T>
 class StringComparisonAdaptorFixture : public ::testing::Test
 {
@@ -68,14 +60,13 @@ class StringComparisonAdaptorFixture : public ::testing::Test
 
 // Gtest will run all tests in the StringComparisonAdaptorFixture once for every type, t, in MyTypes, such that
 // TypeParam == t for each run.
-using MyTypes = ::testing::Types<std::string, std::string_view, score::StringLiteral>;
+using MyTypes = ::testing::Types<std::string, std::string_view>;
 TYPED_TEST_SUITE(StringComparisonAdaptorFixture, MyTypes, );
 
 TEST(StringComparisonAdaptorHelpersFixture, CreateUnderlyingStringReturnCorrectValues)
 {
     EXPECT_THAT(CreateUnderlyingString<std::string>("test_string"), "test_string");
     EXPECT_THAT(CreateUnderlyingString<std::string_view>("test_string").data(), StrEq("test_string"));
-    EXPECT_THAT(CreateUnderlyingString<score::StringLiteral>("test_string"), StrEq("test_string"));
 }
 
 TYPED_TEST(StringComparisonAdaptorFixture, CanBeConvertedImplicitly)


### PR DESCRIPTION
- Remove #include "score/memory/string_literal.h" from header
- Remove StringLiteral-based constructor and assignment operator
- Simplify std::variant to <std::string_view, std::string>
- Remove corresponding implementations from .cpp
- Simplify GetAsStringView() std::visit to two lambdas
- Update tests: remove StringLiteral from MyTypes and helper specialization

std::string_view already handles implicit conversion from const char*, making the dedicated StringLiteral constructor redundant.

Fixes: https://github.com/eclipse-score/baselibs/issues/215