### PR TITLE
os: Add sem_timedwait_monotonic

### DIFF
--- a/score/os/BUILD
+++ b/score/os/BUILD
@@ -257,7 +257,10 @@ cc_library(
     srcs = [
         "semaphore.cpp",
         "semaphore_impl.cpp",
-    ],
+    ] + select({
+        "@platforms//os:qnx": ["semaphore_impl_qnx.cpp"],
+        "//conditions:default": ["semaphore_impl_linux.cpp"],
+    }),
     hdrs = [
         "semaphore.h",
         "semaphore_impl.h",

--- a/score/os/libod.md
+++ b/score/os/libod.md
@@ -270,14 +270,15 @@ This library provides the following internal function:
 ## semaphore
 This lib exports the following OS functions:
 
-* `sem_init` - This is a wrapper over the os sem_init(). This function is to initialize an unnamed semaphore. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_init.html
-* `sem_open` - This function after converting openflag to nativeflag and the modeflag to nativeflag(depending on the parameters) calls the os sem_open(). Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_open.html
-* `sem_wait` - This is a wrapper over the os sem_wait(). This function wait on a named or unnamed semaphore. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_wait.html
-* `sem_post` - This is a wrapper over the os sem_post(). This function increment a named or unnamed semaphore. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_post.html
-* `sem_close` - This is a wrapper over the os sem_close(). This function is to close a named semaphore. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_close.html
-* `sem_unlink` - This is a wrapper over the os sem_unlink(). This function is to destroy a named semaphore. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_unlink.html
-* `sem_timedwait` - This is a wrapper over the os sem_timedwait(). This function waits on a named or unnamed semaphore, with a timeout. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_timedwait.html
-* `sem_getvalue` - This is a wrapper over the os sem_getvalue(). This function is to get the value of a named or unnamed semaphore. Reference: https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/s/sem_getvalue.html
+* `sem_init` - This is a wrapper over the os sem_init(). This function is to initialize an unnamed semaphore. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_init.html
+* `sem_open` - This function after converting openflag to nativeflag and the modeflag to nativeflag(depending on the parameters) calls the os sem_open(). Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_open.html
+* `sem_wait` - This is a wrapper over the os sem_wait(). This function wait on a named or unnamed semaphore. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_wait.html
+* `sem_post` - This is a wrapper over the os sem_post(). This function increment a named or unnamed semaphore. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_post.html
+* `sem_close` - This is a wrapper over the os sem_close(). This function is to close a named semaphore. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_close.html
+* `sem_unlink` - This is a wrapper over the os sem_unlink(). This function is to destroy a named semaphore. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_unlink.html
+* `sem_timedwait` - This is a wrapper over the os sem_timedwait(). This function waits on a named or unnamed semaphore, with a timeout. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_timedwait.html
+* `sem_timedwait_monotonic` - This is a wrapper over the os sem_timedwait_monotonic() on QNX and sem_clockwait() with CLOCK_MONOTONIC on Linux (glibc). It behaves like sem_timedwait() but measures the absolute timeout against CLOCK_MONOTONIC, so the timeout is unaffected by wall-clock adjustments. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_timedwait.html
+* `sem_getvalue` - This is a wrapper over the os sem_getvalue(). This function is to get the value of a named or unnamed semaphore. Reference: https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/s/sem_getvalue.html
 ### External Dependencies
 * errno
 * object_seam

--- a/score/os/mocklib/semaphoremock.h
+++ b/score/os/mocklib/semaphoremock.h
@@ -42,6 +42,10 @@ class SemaphoreMock : public Semaphore
                 sem_timedwait,
                 (sem_t*, const struct timespec*),
                 (const, noexcept, override));
+    MOCK_METHOD((score::cpp::expected_blank<Error>),
+                sem_timedwait_monotonic,
+                (sem_t*, const struct timespec*),
+                (const, noexcept, override));
     MOCK_METHOD((score::cpp::expected_blank<Error>), sem_getvalue, (sem_t*, std::int32_t*), (const, noexcept, override));
 };
 

--- a/score/os/semaphore.h
+++ b/score/os/semaphore.h
@@ -67,6 +67,9 @@ class Semaphore : public ObjectSeam<Semaphore>
     virtual score::cpp::expected_blank<Error> sem_unlink(const char* const pathname) const noexcept = 0;
     virtual score::cpp::expected_blank<Error> sem_timedwait(sem_t* const sem,
                                                      const struct timespec* const abs_time) const noexcept = 0;
+    virtual score::cpp::expected_blank<Error> sem_timedwait_monotonic(
+        sem_t* const sem,
+        const struct timespec* const abs_time) const noexcept = 0;
     virtual score::cpp::expected_blank<Error> sem_getvalue(sem_t* const sem, std::int32_t* const sval) const noexcept = 0;
 
     virtual ~Semaphore() = default;

--- a/score/os/semaphore_impl.cpp
+++ b/score/os/semaphore_impl.cpp
@@ -146,6 +146,8 @@ score::cpp::expected_blank<Error> SemaphoreImpl::sem_timedwait(sem_t* const sem,
     }
     return {};
 }
+// SemaphoreImpl::sem_timedwait_monotonic() is platform-specific and lives in
+// semaphore_impl_linux.cpp / semaphore_impl_qnx.cpp (selected in BUILD).
 /* KW_SUPPRESS_START:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override */
 score::cpp::expected_blank<Error> SemaphoreImpl::sem_getvalue(sem_t* const sem, std::int32_t* const sval) const noexcept
 /* KW_SUPPRESS_END:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override  */

--- a/score/os/semaphore_impl.h
+++ b/score/os/semaphore_impl.h
@@ -67,6 +67,12 @@ class SemaphoreImpl final : public Semaphore
     /* KW_SUPPRESS_END:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override  */
 
     /* KW_SUPPRESS_START:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override */
+    score::cpp::expected_blank<Error> sem_timedwait_monotonic(
+        sem_t* const sem,
+        const struct timespec* const abs_time) const noexcept override;
+    /* KW_SUPPRESS_END:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override  */
+
+    /* KW_SUPPRESS_START:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override */
     score::cpp::expected_blank<Error> sem_getvalue(sem_t* const sem, std::int32_t* const sval) const noexcept override;
     /* KW_SUPPRESS_END:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override  */
 

--- a/score/os/semaphore_impl_linux.cpp
+++ b/score/os/semaphore_impl_linux.cpp
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/os/semaphore_impl.h"
+
+#include <cerrno>
+#include <time.h>
+
+/* KW_SUPPRESS_START:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
+
+namespace score
+{
+namespace os
+{
+
+// Linux variant of SemaphoreImpl::sem_timedwait_monotonic(); selected via BUILD select(). glibc >= 2.30
+// provides sem_clockwait(), which lets us pin the timeout to CLOCK_MONOTONIC (immune to wall-clock changes
+// such as NTP steps). g++/clang++ predefine _GNU_SOURCE for C++, so the __USE_GNU-guarded declaration is
+// visible.
+/* KW_SUPPRESS_START:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override */
+score::cpp::expected_blank<Error> SemaphoreImpl::sem_timedwait_monotonic(
+    sem_t* const sem,
+    const struct timespec* const abs_time) const noexcept
+/* KW_SUPPRESS_END:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override  */
+{
+    // A16-0-1: version guard avoids a compile error on glibc < 2.30 (no sem_clockwait()).
+    // coverity[autosar_cpp14_a16_0_1_violation]
+#if defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 30)))
+    if (::sem_clockwait(sem, CLOCK_MONOTONIC, abs_time) != 0)
+    {
+        return score::cpp::make_unexpected(score::os::Error::createFromErrno());
+    }
+    return {};
+// coverity[autosar_cpp14_a16_0_1_violation], see above rationale
+#else
+    // glibc < 2.30: no monotonic wait primitive. Warn at build time, return ENOSYS at runtime.
+    // coverity[autosar_cpp14_a16_0_1_violation], see above rationale
+#warning "sem_timedwait_monotonic(): requires glibc >= 2.30; returning ENOSYS"
+    static_cast<void>(sem);
+    static_cast<void>(abs_time);
+    return score::cpp::make_unexpected(score::os::Error::createFromErrno(ENOSYS));
+// coverity[autosar_cpp14_a16_0_1_violation], see above rationale
+#endif
+}
+
+/* KW_SUPPRESS_END:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
+
+}  // namespace os
+}  // namespace score

--- a/score/os/semaphore_impl_qnx.cpp
+++ b/score/os/semaphore_impl_qnx.cpp
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/os/semaphore_impl.h"
+
+/* KW_SUPPRESS_START:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
+
+namespace score
+{
+namespace os
+{
+
+// QNX variant of SemaphoreImpl::sem_timedwait_monotonic(); selected via BUILD select(). QNX provides a
+// dedicated monotonic variant of sem_timedwait(): the timeout is measured against CLOCK_MONOTONIC and is
+// therefore immune to wall-clock changes such as NTP steps.
+/* KW_SUPPRESS_START:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override */
+score::cpp::expected_blank<Error> SemaphoreImpl::sem_timedwait_monotonic(
+    sem_t* const sem,
+    const struct timespec* const abs_time) const noexcept
+/* KW_SUPPRESS_END:AUTOSAR.MEMB.VIRTUAL.FINAL: Compiler warn suggests override  */
+{
+    if (::sem_timedwait_monotonic(sem, abs_time) != 0)
+    {
+        return score::cpp::make_unexpected(score::os::Error::createFromErrno());
+    }
+    return {};
+}
+
+/* KW_SUPPRESS_END:MISRA.VAR.HIDDEN:Wrapper function is identifiable through namespace usage */
+
+}  // namespace os
+}  // namespace score

--- a/score/os/test/semaphore_test.cpp
+++ b/score/os/test/semaphore_test.cpp
@@ -16,6 +16,7 @@
 #include <fcntl.h>
 #include <gtest/gtest.h>
 #include <limits.h>
+#include <time.h>
 
 namespace score
 {
@@ -245,6 +246,73 @@ TEST_F(SemaphoreTestFixture, SuccessTimedWaitFailure)
     ASSERT_TRUE(sem != nullptr);
     ASSERT_FALSE(unit_.sem_timedwait(sem, &abs_time).has_value());
     unit_.sem_close(sem);
+}
+
+// Positive test for sem_timedwait_monotonic()
+TEST_F(SemaphoreTestFixture, SuccessTimedWaitMonotonic)
+{
+    RecordProperty("Verifies", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "SemaphoreTestFixture Success Timed Wait Monotonic");
+    RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "equivalence-classes"); // equivalence classes
+
+    // The timeout is expressed against CLOCK_MONOTONIC. Since the semaphore is created with value 1 it can be
+    // decremented immediately, so the call returns success without ever blocking until the (future) deadline.
+    timespec abs_time{};
+    ASSERT_EQ(::clock_gettime(CLOCK_MONOTONIC, &abs_time), 0);
+    abs_time.tv_sec += 5;
+    const auto ret =
+        unit_.sem_open(m_name_.c_str(), Semaphore::OpenFlag::kCreate, Semaphore::ModeFlag::kReadUser, value_);
+    ASSERT_TRUE(ret.has_value());
+    ASSERT_TRUE(ret.value() != nullptr);
+    ASSERT_TRUE(unit_.sem_timedwait_monotonic(ret.value(), &abs_time).has_value());
+    unit_.sem_close(ret.value());
+}
+
+// Negative test for sem_timedwait_monotonic()
+TEST_F(SemaphoreTestFixture, FailureTimedWaitMonotonic)
+{
+    RecordProperty("Verifies", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "SemaphoreTestFixture Failure Timed Wait Monotonic");
+    RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "equivalence-classes"); // equivalence classes
+
+    // An invalid nanoseconds field is rejected with EINVAL before the semaphore can be decremented.
+    timespec abs_time{0, -1};
+    const auto sem = ::sem_open(m_name_.c_str(), O_CREAT, S_IRUSR, value_);
+    ASSERT_NE(sem, SEM_FAILED);
+    ASSERT_TRUE(sem != nullptr);
+    ASSERT_FALSE(unit_.sem_timedwait_monotonic(sem, &abs_time).has_value());
+    unit_.sem_close(sem);
+}
+
+// Timeout test for sem_timedwait_monotonic()
+TEST_F(SemaphoreTestFixture, TimeoutTimedWaitMonotonic)
+{
+    RecordProperty("Verifies", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "SemaphoreTestFixture Timeout Timed Wait Monotonic");
+    RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
+    // Semaphore starts at 0 and nobody posts to it, so sem_timedwait_monotonic() must block and
+    // return ETIMEDOUT once the deadline passes. Deadline is 10 ms from now on CLOCK_MONOTONIC.
+    timespec abs_time{};
+    ASSERT_EQ(::clock_gettime(CLOCK_MONOTONIC, &abs_time), 0);
+    abs_time.tv_nsec += 10'000'000L;  // +10 ms
+    if (abs_time.tv_nsec >= 1'000'000'000L)
+    {
+        abs_time.tv_nsec -= 1'000'000'000L;
+        abs_time.tv_sec += 1;
+    }
+    const auto ret =
+        unit_.sem_open(m_name_.c_str(), Semaphore::OpenFlag::kCreate, Semaphore::ModeFlag::kReadUser, 0U);
+    ASSERT_TRUE(ret.has_value());
+    ASSERT_TRUE(ret.value() != nullptr);
+    ASSERT_FALSE(unit_.sem_timedwait_monotonic(ret.value(), &abs_time).has_value());
+    unit_.sem_close(ret.value());
 }
 
 TEST(Semaphore, get_instance)


### PR DESCRIPTION
- Add support for sem_timedwait_monotonic()
- For Linux impl uses sem_clockwait() (glibc>=2.30)
- Add related unit tests