### PR TITLE
Alow actions write in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ name: Release
 run-name: Release ${{ inputs.tag }}
 permissions:
   contents: read
+  actions: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The `actions: write` is needed in the release workflow because the nested workflows require it to operate on the bazel cache.

Without it we end up with the following error:
```
The workflow is not valid. .github/workflows/release.yml (Line: 32, Col: 3): Error calling workflow 'eclipse-score/baselibs/.github/workflows/build_linux.yml@599150acb07acc9b05c47973e2aa2453837d4e93'. The workflow is requesting 'actions: write', but is only allowed 'actions: none'.
```