### PR TITLE
tooling: improve IDE support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ user.bazelrc
 .cache
 compile_commands.json
 target/
+rust-project.json
 
 # docs build artifacts
 _build

--- a/.vscode/rustfmt.sh
+++ b/.vscode/rustfmt.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bazel run @score_tooling//format_checker:rustfmt_with_policies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,24 @@
 {
+    "[rust]": {
+        "editor.defaultFormatter": "rust-lang.rust-analyzer",
+        "editor.rulers": [
+            150
+        ]
+    },
+    "rust-analyzer.cargo.cfgs": [],
+    "rust-analyzer.cargo.features": [],
+    "rust-analyzer.cargo.noDefaultFeatures": false,
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.rustfmt.overrideCommand": [
+        "${workspaceFolder}/.vscode/rustfmt.sh"
+    ],
+    "clangd.arguments": [
+        "--header-insertion=never",
+        "--compile-commands-dir=${workspaceFolder}/",
+        "--query-driver=**",
+        "--clang-tidy",
+        "--fallback-style=None"
+    ],
     "json.schemas": [
         {
             "fileMatch": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Generate compile_commands.json",
+            "type": "shell",
+            "isBackground": true,
+            "command": "bazel run //:generate_compile_commands",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Refresh IntelliSense",
+            "dependsOn": [
+                "Generate compile_commands.json"
+            ],
+            "command": "${command:clangd.restart}",
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Generate rust-project.json",
+            "type": "shell",
+            "isBackground": true,
+            "command": "bazel run //:generate_rust_project",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Refresh rust-analyzer",
+            "dependsOn": [
+                "Generate rust-project.json"
+            ],
+            "command": "${command:rust-analyzer.reloadWorkspace}",
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared"
+            }
+        }
+    ]
+}

--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@score_bazel_tools_cc//quality:defs.bzl", "quality_clang_tidy_config")
 load("@score_docs_as_code//:docs.bzl", "docs")
 load("@score_tooling//:defs.bzl", "copyright_checker", "dash_license_checker", "rust_coverage_report", "use_format_targets")
@@ -23,6 +24,25 @@ docs(
         "@score_process//:needs_json",
     ],
     source_dir = "docs",
+)
+
+# Generate `compile_commands.json`.
+# Required for `clangd` support.
+refresh_compile_commands(
+    name = "generate_compile_commands",
+    exclude_external_sources = True,
+    target_compatible_with = ["@platforms//os:linux"],
+    targets = {
+        "//...": "",
+    },
+)
+
+# Generate `rust_project.json`.
+# Required for `rust-analyzer` support.
+alias(
+    name = "generate_rust_project",
+    actual = "@rules_rust//tools/rust_analyzer:gen_rust_project",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 copyright_checker(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -224,6 +224,18 @@ bazel_dep(name = "flatbuffers", version = "25.12.19")
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "abb61a688167623088f8768cc9264798df6a9d10",
+    patch_args = ["-p1"],
+    # Patch for support for Bazel 8.6.0.
+    patches = ["//patches:hedron_compile_commands_env_vars.patch"],
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)
+
 #############################################################
 #
 # Constraint values for specifying platforms and toolchains

--- a/patches/BUILD
+++ b/patches/BUILD
@@ -1,0 +1,1 @@
+exports_files(["hedron_compile_commands_env_vars.patch"])

--- a/patches/hedron_compile_commands_env_vars.patch
+++ b/patches/hedron_compile_commands_env_vars.patch
@@ -1,0 +1,11 @@
+--- a/refresh.template.py
++++ b/refresh.template.py
+@@ -1103,6 +1103,6 @@ def _get_cpp_command_for_files(compile_action):
+     Undo Bazel-isms and figures out which files clangd should apply the command to.
+     """
+     # Condense aquery's environment variables into a dictionary, the format you might expect.
+-    compile_action.environmentVariables = {pair.key: pair.value for pair in getattr(compile_action, 'environmentVariables', [])}
++    compile_action.environmentVariables = {pair.key: getattr(pair, 'value', '') for pair in getattr(compile_action, 'environmentVariables', [])}
+     if 'PATH' not in compile_action.environmentVariables: # Bazel only adds if --incompatible_strict_action_env is passed--and otherwise inherits.
+         compile_action.environmentVariables['PATH'] = os.environ['PATH']
+


### PR DESCRIPTION
- Add VS Code configuration.
  - Rust formatting, IDE support, basic tasks.
- Add `compile_commands.json` and `rust-project.json` generation.
- Patch to `hedron_compile_commands` for Bazel 8.6.0 support.