### PR TITLE
feat(hash): add requirements and architecture documentation for LibHash

### DIFF
--- a/docs/baselibs/components/hash/docs/index.rst
+++ b/docs/baselibs/components/hash/docs/index.rst
@@ -1,0 +1,29 @@
+..
+   # ******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # ******************************************************************************
+
+hash
+####
+
+.. document:: Hash Library
+   :id: doc__hash
+   :status: draft
+   :safety: ASIL_B
+   :tags: baselibs_hash
+   :realizes: wp__cmpt_request
+   :security: NO
+
+.. toctree::
+   :hidden:
+
+   requirements/index.rst

--- a/docs/baselibs/components/hash/docs/requirements/index.rst
+++ b/docs/baselibs/components/hash/docs/requirements/index.rst
@@ -1,0 +1,121 @@
+..
+   # ******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # ******************************************************************************
+
+Requirements
+############
+
+.. document:: Hash Requirements
+   :id: doc__hash_requirements
+   :status: draft
+   :safety: ASIL_B
+   :security: NO
+   :realizes: wp__requirements_comp
+   :tags: requirements, hash
+
+.. comp:: Hash Library
+   :id: comp__baselibs_hash
+   :security: NO
+   :safety: ASIL_B
+   :status: valid
+   :tags: baselibs_hash
+   :belongs_to: feat__baselibs
+
+Functional Requirements
+=======================
+
+.. comp_req:: Hash Computation from Byte Data
+   :id: comp_req__hash__calculation_interface
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__hash_library
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall compute a hash value over a contiguous byte sequence
+   supplied by the caller, accumulating state across one or more data inputs
+   and producing the final digest upon finalization.
+
+.. comp_req:: Hash Value Retrieval as Raw Bytes
+   :id: comp_req__hash__value_retrieval_bytes
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__hash_library
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall expose the computed hash value as a raw byte sequence.
+
+.. comp_req:: Hash Value Retrieval as Hexadecimal String
+   :id: comp_req__hash__value_retrieval_hex
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__hash_library
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall expose the computed hash value as a hexadecimal string
+   representation.
+
+.. comp_req:: Algorithm Selection via Factory
+   :id: comp_req__hash__factory_interface
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__hash_library
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall allow the hash algorithm to be selected and a
+   calculator instance to be created independently of the code that performs
+   the computation, so that the calling code is not coupled to any specific
+   algorithm implementation.
+
+.. comp_req:: Cryptographic Hash Algorithms
+   :id: comp_req__hash__sha_algorithms
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__hash_library
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall support SHA-1, SHA-256, SHA-384, and SHA-512 as
+   cryptographic hash algorithms.
+
+.. comp_req:: CRC-32 Checksum Algorithm
+   :id: comp_req__hash__crc32_algorithm
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__hash_library
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall support IEEE CRC-32 as a checksum algorithm.
+
+.. comp_req:: Exception-Free Error Propagation
+   :id: comp_req__hash__safe_computation
+   :reqtype: Functional
+   :security: NO
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__safety
+   :status: valid
+   :satisfied_by: comp__baselibs_hash
+
+   The hash library shall propagate errors from hash calculator instantiation
+   via return-value types, enabling use in safety-critical contexts where
+   exception handling is not available.

--- a/docs/baselibs/components/index.rst
+++ b/docs/baselibs/components/index.rst
@@ -38,6 +38,8 @@ Overview
 - :need:`doc__flatbuffers`: FlatBuffers-Library with serialization, read access, and structural
   verification of FlatBuffers data, plus code generation via ``flatc`` for C++, Rust, and Python.
 - :need:`doc__filesystem`: Filesystem manipulation library similar to ``std::filesystem``.
+- :need:`doc__hash`: Hash calculation library supporting cryptographic (SHA-256, SHA-512) and
+  checksum (CRC-32) algorithms via a pluggable interface.
 - :need:`doc__futurecpp`: Extends the C++17 Standard Library with features from newer C++ standards up to C++26,
   as well as selected proposals for the C++ Standard Library.
 - :need:`doc__safecpp`: A collection of utilities that helps developers write safer C++ code, including


### PR DESCRIPTION
Add sphinx-needs component requirements documentation for the hash library (`score::hash`).

## What's added

- `docs/baselibs/components/hash/docs/index.rst` — Hash component document (`doc__hash`)
- `docs/baselibs/components/hash/docs/requirements/index.rst` — 5 component requirements:
  - `comp_req__hash__calculation_interface` — derived from `feat_req__baselibs__hash_library`
  - `comp_req__hash__value_retrieval` — derived from `feat_req__baselibs__hash_library`
  - `comp_req__hash__factory_interface` — derived from `feat_req__baselibs__hash_library`
  - `comp_req__hash__openssl_algorithms` — derived from `feat_req__baselibs__hash_library`
  - `comp_req__hash__safe_computation` — derived from `feat_req__baselibs__safety`

## Temporary `git_override` in `MODULE.bazel`

`feat_req__baselibs__hash_library` is defined in `score_platform` and has been merged to
`eclipse-score/score` (commit `8d92b2cc43`), but a new `score_platform` release has not
been published yet. A temporary `git_override` points Bazel at that commit so the
`:derived_from:` links resolve correctly in CI.

The override will be removed once a `score_platform` release including
`feat_req__baselibs__hash_library` is available.