### PR TITLE
impl: mmap arena allocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ user.bazelrc
 .cache
 compile_commands.json
 target/
+rust-project.json
 
 # docs build artifacts
 _build

--- a/.vscode/rustfmt.sh
+++ b/.vscode/rustfmt.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bazel run @score_tooling//format_checker:rustfmt_with_policies

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,30 @@
 {
+    "[rust]": {
+        "editor.defaultFormatter": "rust-lang.rust-analyzer",
+        "editor.rulers": [
+            150
+        ]
+    },
+    "rust-analyzer.cargo.cfgs": [],
+    "rust-analyzer.cargo.features": [],
+    "rust-analyzer.cargo.noDefaultFeatures": false,
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.rustfmt.overrideCommand": [
+        "${workspaceFolder}/.vscode/rustfmt.sh"
+    ],
+    "clangd.arguments": [
+        "--header-insertion=never",
+        "--compile-commands-dir=${workspaceFolder}/",
+        "--query-driver=**",
+        "--clang-tidy",
+        "--fallback-style=None"
+    ],
+    "[cpp]": {
+        "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+    },
+    "[c]": {
+        "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd",
+    },
     "json.schemas": [
         {
             "fileMatch": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Generate compile_commands.json",
+            "type": "shell",
+            "isBackground": true,
+            "command": "bazel run //:generate_compile_commands",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Refresh IntelliSense",
+            "dependsOn": [
+                "Generate compile_commands.json"
+            ],
+            "command": "${command:clangd.restart}",
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Generate rust-project.json",
+            "type": "shell",
+            "isBackground": true,
+            "command": "bazel run //:generate_rust_project",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared"
+            }
+        },
+        {
+            "label": "Refresh rust-analyzer",
+            "dependsOn": [
+                "Generate rust-project.json"
+            ],
+            "command": "${command:rust-analyzer.reloadWorkspace}",
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent",
+                "panel": "shared"
+            }
+        }
+    ]
+}

--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@score_bazel_tools_cc//quality:defs.bzl", "quality_clang_tidy_config")
 load("@score_docs_as_code//:docs.bzl", "docs")
 load("@score_tooling//:defs.bzl", "copyright_checker", "dash_license_checker", "rust_coverage_report", "use_format_targets")
@@ -23,6 +24,25 @@ docs(
         "@score_process//:needs_json",
     ],
     source_dir = "docs",
+)
+
+# Generate `compile_commands.json`.
+# Required for `clangd` support.
+refresh_compile_commands(
+    name = "generate_compile_commands",
+    exclude_external_sources = True,
+    target_compatible_with = ["@platforms//os:linux"],
+    targets = {
+        "//...": "",
+    },
+)
+
+# Generate `rust_project.json`.
+# Required for `rust-analyzer` support.
+alias(
+    name = "generate_rust_project",
+    actual = "@rules_rust//tools/rust_analyzer:gen_rust_project",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 copyright_checker(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,10 @@ version = 4
 [[package]]
 name = "allocator"
 version = "0.0.1"
+dependencies = [
+ "pal",
+ "score_log",
+]
 
 [[package]]
 name = "containers"
@@ -33,7 +37,6 @@ dependencies = [
 name = "pal"
 version = "0.0.1"
 dependencies = [
- "containers",
  "score_log",
 ]
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -224,6 +224,18 @@ bazel_dep(name = "flatbuffers", version = "25.12.19")
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    commit = "abb61a688167623088f8768cc9264798df6a9d10",
+    patch_args = ["-p1"],
+    # Patch for support for Bazel 8.6.0.
+    patches = ["//patches:hedron_compile_commands_env_vars.patch"],
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+)
+
 #############################################################
 #
 # Constraint values for specifying platforms and toolchains

--- a/patches/BUILD
+++ b/patches/BUILD
@@ -1,0 +1,1 @@
+exports_files(["hedron_compile_commands_env_vars.patch"])

--- a/patches/hedron_compile_commands_env_vars.patch
+++ b/patches/hedron_compile_commands_env_vars.patch
@@ -1,0 +1,11 @@
+--- a/refresh.template.py
++++ b/refresh.template.py
+@@ -1103,6 +1103,6 @@ def _get_cpp_command_for_files(compile_action):
+     Undo Bazel-isms and figures out which files clangd should apply the command to.
+     """
+     # Condense aquery's environment variables into a dictionary, the format you might expect.
+-    compile_action.environmentVariables = {pair.key: pair.value for pair in getattr(compile_action, 'environmentVariables', [])}
++    compile_action.environmentVariables = {pair.key: getattr(pair, 'value', '') for pair in getattr(compile_action, 'environmentVariables', [])}
+     if 'PATH' not in compile_action.environmentVariables: # Bazel only adds if --incompatible_strict_action_env is passed--and otherwise inherits.
+         compile_action.environmentVariables['PATH'] = os.environ['PATH']
+

--- a/score/allocator/BUILD
+++ b/score/allocator/BUILD
@@ -18,6 +18,10 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     edition = "2021",
     visibility = ["//visibility:public"],
+    deps = [
+        "//score/log_rust/score_log",
+        "//score/pal",
+    ],
 )
 
 rust_test(

--- a/score/allocator/Cargo.toml
+++ b/score/allocator/Cargo.toml
@@ -22,5 +22,9 @@ license-file.workspace = true
 [lib]
 path = "lib.rs"
 
+[dependencies]
+pal.workspace = true
+score_log.workspace = true
+
 [lints]
 workspace = true

--- a/score/allocator/allocator_traits.rs
+++ b/score/allocator/allocator_traits.rs
@@ -13,9 +13,10 @@
 
 use core::alloc::Layout;
 use core::ptr::NonNull;
+use score_log::ScoreDebug;
 
 /// Allocation errors.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, ScoreDebug, Clone, Copy, PartialEq, Eq)]
 pub enum AllocationError {
     /// Memory allocation failed due to insufficient memory.
     OutOfMemory,

--- a/score/allocator/heap_allocator.rs
+++ b/score/allocator/heap_allocator.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 use alloc::alloc::{alloc, dealloc};
 use core::alloc::Layout;
 use core::ptr::NonNull;
+use score_log::ScoreDebug;
 
 use crate::allocator_traits::{AllocationError, BasicAllocator};
 
@@ -23,7 +24,7 @@ use crate::allocator_traits::{AllocationError, BasicAllocator};
 pub static GLOBAL_ALLOCATOR: HeapAllocator = HeapAllocator;
 
 /// Proxy to global heap allocation in Rust.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, ScoreDebug, Default, Clone, Copy)]
 pub struct HeapAllocator;
 
 impl BasicAllocator for HeapAllocator {

--- a/score/allocator/lib.rs
+++ b/score/allocator/lib.rs
@@ -15,6 +15,8 @@
 
 mod allocator_traits;
 mod heap_allocator;
+mod mmap_arena_allocator;
 
 pub use allocator_traits::{AllocationError, BasicAllocator};
 pub use heap_allocator::{HeapAllocator, GLOBAL_ALLOCATOR};
+pub use mmap_arena_allocator::{page_size, MmapArenaAllocator};

--- a/score/allocator/mmap_arena_allocator.rs
+++ b/score/allocator/mmap_arena_allocator.rs
@@ -13,6 +13,8 @@
 
 //! mmap-backed arena allocator.
 
+// TODO: safety clauses.
+
 use crate::{AllocationError, BasicAllocator};
 use core::alloc::Layout;
 use core::cell::Cell;
@@ -37,6 +39,13 @@ fn align_to(value: usize, align: usize) -> usize {
     v_div * align
 }
 
+/// Arena header, placed at the start of memory region.
+/// Keeps track of living object references and current pointer position.
+struct ArenaHeader {
+    ref_count: Cell<usize>,
+    offset: Cell<usize>,
+}
+
 /// mmap-backed memory region.
 struct MemoryRegion {
     ptr: *mut u8,
@@ -59,25 +68,56 @@ impl MemoryRegion {
         let prot = PROT_READ | PROT_WRITE;
         let flags = MAP_PRIVATE | MAP_ANONYMOUS;
         let fd = -1;
-        let ptr = unsafe { mmap(null_mut(), capacity, prot, flags, fd, 0) };
+        let ptr: *mut u8 = unsafe { mmap(null_mut(), capacity, prot, flags, fd, 0) }.cast();
         if ptr as isize == -1 || ptr.is_null() {
             // TODO: information about errno is missing.
             return Err(AllocationError::Internal);
         }
 
-        Ok(Self {
-            ptr: ptr.cast(),
-            capacity,
-        })
+        // Initialize the header at the start of memory region.
+        // Offset is set with regard to header size.
+        unsafe {
+            ptr.cast::<ArenaHeader>().write(ArenaHeader {
+                ref_count: Cell::new(1),
+                offset: Cell::new(size_of::<ArenaHeader>()),
+            });
+        }
+
+        Ok(Self { ptr, capacity })
+    }
+
+    /// Access the header.
+    fn header(&self) -> &ArenaHeader {
+        unsafe { &*self.ptr.cast::<ArenaHeader>() }
+    }
+}
+
+impl Clone for MemoryRegion {
+    fn clone(&self) -> Self {
+        let ref_count_cell = &self.header().ref_count;
+        ref_count_cell.set(ref_count_cell.get() + 1);
+        Self {
+            ptr: self.ptr,
+            capacity: self.capacity,
+        }
     }
 }
 
 impl Drop for MemoryRegion {
     fn drop(&mut self) {
-        let rc = unsafe { munmap(self.ptr.cast(), self.capacity) };
-        if rc != 0 {
-            let errno = errno();
-            panic!("munmap failed, rc: {rc}, errno: {errno}");
+        let ref_count_cell = &self.header().ref_count;
+        let ref_count = ref_count_cell.get();
+        ref_count_cell.set(ref_count - 1);
+
+        // Release the memory on last reference dropping.
+        if ref_count == 1 {
+            unsafe { core::ptr::drop_in_place(self.ptr.cast::<ArenaHeader>()) };
+
+            let rc = unsafe { munmap(self.ptr.cast(), self.capacity) };
+            if rc != 0 {
+                let errno = errno();
+                panic!("munmap failed, rc: {rc}, errno: {errno}");
+            }
         }
     }
 }
@@ -86,9 +126,9 @@ impl Drop for MemoryRegion {
 ///
 /// Allocated chunks are from a continuous chunk of memory obtained using mmap.
 /// Deallocation is a no-op.
+#[derive(Clone)]
 pub struct MmapArenaAllocator {
     memory_region: MemoryRegion,
-    offset: Cell<usize>,
 }
 
 impl MmapArenaAllocator {
@@ -96,8 +136,7 @@ impl MmapArenaAllocator {
     /// Capacity is rounded up to the nearest multiplication of a page size.
     pub fn new(capacity: usize) -> Result<Self, AllocationError> {
         let memory_region = MemoryRegion::new(capacity)?;
-        let offset = Cell::new(0);
-        Ok(Self { memory_region, offset })
+        Ok(Self { memory_region })
     }
 
     /// Capacity of the allocator.
@@ -117,7 +156,8 @@ impl BasicAllocator for MmapArenaAllocator {
         let aligned_size = align_to(layout.size(), layout.align());
 
         // Get current pointer position and align.
-        let current_offset = align_to(self.offset.get(), layout.align());
+        let offset_cell = &self.memory_region.header().offset;
+        let current_offset = align_to(offset_cell.get(), layout.align());
 
         // Check if allocation will not exceed capacity.
         let new_offset = current_offset + aligned_size;
@@ -132,7 +172,7 @@ impl BasicAllocator for MmapArenaAllocator {
         };
 
         // Set new offset.
-        self.offset.set(new_offset);
+        offset_cell.set(new_offset);
 
         Ok(ptr_as_non_null)
     }
@@ -158,8 +198,11 @@ impl score_fmt::ScoreDebug for MmapArenaAllocator {
 
 #[cfg(test)]
 mod tests {
+    use crate::mmap_arena_allocator::ArenaHeader;
     use crate::{page_size, AllocationError, BasicAllocator, MmapArenaAllocator};
     use core::alloc::Layout;
+
+    const HEADER_SIZE: usize = size_of::<ArenaHeader>();
 
     #[test]
     fn test_page_size_ok() {
@@ -203,11 +246,11 @@ mod tests {
 
         // Allocate.
         let layout = Layout::from_size_align(253, 4).unwrap();
-        let result = allocator.allocate(layout.clone());
+        let result = allocator.allocate(layout);
         assert!(result.is_ok());
 
         // Check offset.
-        assert_eq!(allocator.offset.get(), 256);
+        assert_eq!(allocator.memory_region.header().offset.get(), HEADER_SIZE + 256);
     }
 
     #[test]
@@ -220,9 +263,17 @@ mod tests {
         // - allocation pointer offset from memory region start
         // - internal allocator offset
         let cases = vec![
-            (Layout::from_size_align(253, 1).unwrap(), 0, 253),
-            (Layout::from_size_align(557, 2).unwrap(), 254, 812),
-            (Layout::from_size_align(39, 8).unwrap(), 816, 856),
+            (Layout::from_size_align(253, 1).unwrap(), HEADER_SIZE, HEADER_SIZE + 253),
+            (
+                Layout::from_size_align(557, 2).unwrap(),
+                HEADER_SIZE + 254,
+                HEADER_SIZE + 812,
+            ),
+            (
+                Layout::from_size_align(39, 8).unwrap(),
+                HEADER_SIZE + 816,
+                HEADER_SIZE + 856,
+            ),
         ];
 
         let memory_region_ptr = allocator.memory_region.ptr;
@@ -232,8 +283,8 @@ mod tests {
 
             // Check position relative to memory region and allocator offset.
             let allocation_ptr_offset = unsafe { alloc_ptr.offset_from(memory_region_ptr) };
-            assert_eq!(allocation_ptr_offset, exp_ptr_offset);
-            assert_eq!(allocator.offset.get(), exp_allocator_offset);
+            assert_eq!(allocation_ptr_offset, exp_ptr_offset as isize);
+            assert_eq!(allocator.memory_region.header().offset.get(), exp_allocator_offset);
         }
     }
 
@@ -244,11 +295,11 @@ mod tests {
 
         // Allocate.
         let layout = Layout::from_size_align(2 * page_size(), 4).unwrap();
-        let result = allocator.allocate(layout.clone());
+        let result = allocator.allocate(layout);
         assert!(result.is_err_and(|e| e == AllocationError::OutOfMemory));
 
         // Check offset.
-        assert_eq!(allocator.offset.get(), 0);
+        assert_eq!(allocator.memory_region.header().offset.get(), HEADER_SIZE);
     }
 
     #[test]
@@ -258,11 +309,11 @@ mod tests {
 
         // Allocate.
         let layout = Layout::from_size_align(0, 4).unwrap();
-        let result = allocator.allocate(layout.clone());
+        let result = allocator.allocate(layout);
         assert!(result.is_err_and(|e| e == AllocationError::ZeroSizeAllocation));
 
         // Check offset.
-        assert_eq!(allocator.offset.get(), 0);
+        assert_eq!(allocator.memory_region.header().offset.get(), HEADER_SIZE);
     }
 
     #[test]
@@ -272,9 +323,47 @@ mod tests {
 
         // Allocate.
         let layout = Layout::from_size_align(253, 4).unwrap();
-        let ptr = allocator.allocate(layout.clone()).unwrap();
+        let ptr = allocator.allocate(layout).unwrap();
 
         // Deallocate - no-op.
         unsafe { allocator.deallocate(ptr, layout) };
+    }
+
+    #[test]
+    fn test_clone_shared_offset() {
+        // Create allocator and its clone.
+        let capacity = page_size();
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+        let clone = allocator.clone();
+
+        // Allocate using cloned object.
+        let layout = Layout::from_size_align(253, 4).unwrap();
+        clone.allocate(layout).unwrap();
+
+        // Check offset is bumped for both objects.
+        let expected = HEADER_SIZE + 256;
+        assert_eq!(clone.memory_region.header().offset.get(), expected);
+        assert_eq!(allocator.memory_region.header().offset.get(), expected);
+    }
+
+    #[test]
+    fn test_clone_ref_count() {
+        let allocator = MmapArenaAllocator::new(page_size()).unwrap();
+        assert_eq!(allocator.memory_region.header().ref_count.get(), 1);
+
+        let clone = allocator.clone();
+        assert_eq!(allocator.memory_region.header().ref_count.get(), 2);
+
+        drop(clone);
+        assert_eq!(allocator.memory_region.header().ref_count.get(), 1);
+    }
+
+    #[test]
+    fn test_clone_single_unmap() {
+        // Check no panic happens when both instances are dropped.
+        let allocator = MmapArenaAllocator::new(page_size()).unwrap();
+        let clone = allocator.clone();
+        drop(allocator);
+        drop(clone);
     }
 }

--- a/score/allocator/mmap_arena_allocator.rs
+++ b/score/allocator/mmap_arena_allocator.rs
@@ -1,0 +1,280 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+//! mmap-backed arena allocator.
+
+use crate::{AllocationError, BasicAllocator};
+use core::alloc::Layout;
+use core::cell::Cell;
+use core::fmt as core_fmt;
+use core::ptr::{null_mut, NonNull};
+use pal::{errno, mmap, munmap, sysconf, MAP_ANONYMOUS, MAP_PRIVATE, PROT_READ, PROT_WRITE, _SC_PAGESIZE};
+use score_log::fmt as score_fmt;
+
+/// Get current page size.
+pub fn page_size() -> usize {
+    let result = unsafe { sysconf(_SC_PAGESIZE) };
+    assert!(result >= 1, "page size must not be less than 1");
+    result as usize
+}
+
+/// Get aligned value - rounded up to a multiplication of the second value.
+fn align_to(value: usize, align: usize) -> usize {
+    let mut v_div = value / align;
+    if !value.is_multiple_of(align) {
+        v_div += 1;
+    }
+    v_div * align
+}
+
+/// mmap-backed memory region.
+struct MemoryRegion {
+    ptr: *mut u8,
+    capacity: usize,
+}
+
+impl MemoryRegion {
+    /// Create new memory region using mmap.
+    /// Capacity of the region is rounded up to the nearest multiplication of a page size.
+    pub fn new(capacity: usize) -> Result<Self, AllocationError> {
+        // Disallow zero size allocation.
+        if capacity == 0 {
+            return Err(AllocationError::ZeroSizeAllocation);
+        }
+
+        // Determine final capacity with regard to page size.
+        let capacity = align_to(capacity, page_size());
+
+        // Create a memory mapping.
+        let prot = PROT_READ | PROT_WRITE;
+        let flags = MAP_PRIVATE | MAP_ANONYMOUS;
+        let fd = -1;
+        let ptr = unsafe { mmap(null_mut(), capacity, prot, flags, fd, 0) };
+        if ptr as isize == -1 || ptr.is_null() {
+            // TODO: information about errno is missing.
+            return Err(AllocationError::Internal);
+        }
+
+        Ok(Self {
+            ptr: ptr.cast(),
+            capacity,
+        })
+    }
+}
+
+impl Drop for MemoryRegion {
+    fn drop(&mut self) {
+        let rc = unsafe { munmap(self.ptr.cast(), self.capacity) };
+        if rc != 0 {
+            let errno = errno();
+            panic!("munmap failed, rc: {rc}, errno: {errno}");
+        }
+    }
+}
+
+/// mmap-backed arena allocator.
+///
+/// Allocated chunks are from a continuous chunk of memory obtained using mmap.
+/// Deallocation is a no-op.
+pub struct MmapArenaAllocator {
+    memory_region: MemoryRegion,
+    offset: Cell<usize>,
+}
+
+impl MmapArenaAllocator {
+    /// Create new allocator.
+    /// Capacity is rounded up to the nearest multiplication of a page size.
+    pub fn new(capacity: usize) -> Result<Self, AllocationError> {
+        let memory_region = MemoryRegion::new(capacity)?;
+        let offset = Cell::new(0);
+        Ok(Self { memory_region, offset })
+    }
+
+    /// Capacity of the allocator.
+    pub fn capacity(&self) -> usize {
+        self.memory_region.capacity
+    }
+}
+
+impl BasicAllocator for MmapArenaAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocationError> {
+        // Disallow zero size allocation.
+        if layout.size() == 0 {
+            return Err(AllocationError::ZeroSizeAllocation);
+        }
+
+        // Get aligned size.
+        let aligned_size = align_to(layout.size(), layout.align());
+
+        // Get current pointer position and align.
+        let current_offset = align_to(self.offset.get(), layout.align());
+
+        // Check if allocation will not exceed capacity.
+        let new_offset = current_offset + aligned_size;
+        if new_offset >= self.capacity() {
+            return Err(AllocationError::OutOfMemory);
+        }
+
+        // Get pointer at given offset from memory region.
+        let ptr_as_non_null = unsafe {
+            let ptr_with_offset = self.memory_region.ptr.byte_offset(current_offset as isize);
+            NonNull::new_unchecked(ptr_with_offset)
+        };
+
+        // Set new offset.
+        self.offset.set(new_offset);
+
+        Ok(ptr_as_non_null)
+    }
+
+    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+}
+
+impl core_fmt::Debug for MmapArenaAllocator {
+    fn fmt(&self, f: &mut core_fmt::Formatter<'_>) -> core_fmt::Result {
+        f.debug_struct("MmapArenaAllocator")
+            .field("capacity", &self.capacity())
+            .finish()
+    }
+}
+
+impl score_fmt::ScoreDebug for MmapArenaAllocator {
+    fn fmt(&self, f: score_fmt::Writer, spec: &score_fmt::FormatSpec) -> score_fmt::Result {
+        score_fmt::DebugStruct::new(f, spec, "MmapArenaAllocator")
+            .field("capacity", &self.capacity())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{page_size, AllocationError, BasicAllocator, MmapArenaAllocator};
+    use core::alloc::Layout;
+
+    #[test]
+    fn test_page_size_ok() {
+        // Check no panic, exact size is platform-specific.
+        let _ = page_size();
+    }
+
+    #[test]
+    fn test_new_ok() {
+        let capacity = page_size();
+        let result = MmapArenaAllocator::new(capacity);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_new_zero() {
+        let capacity = 0;
+        let result = MmapArenaAllocator::new(capacity);
+        assert!(result.is_err_and(|e| e == AllocationError::ZeroSizeAllocation));
+    }
+
+    #[test]
+    fn test_capacity_aligned_to_page_size() {
+        let capacity = 4 * page_size();
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+        assert_eq!(allocator.capacity(), capacity);
+    }
+
+    #[test]
+    fn test_capacity_not_aligned_to_page_size() {
+        let expected_capacity = 4 * page_size();
+        let capacity = expected_capacity - 123;
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+        assert_eq!(allocator.capacity(), expected_capacity);
+    }
+
+    #[test]
+    fn test_allocate_single() {
+        let capacity = 0x1000;
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+
+        // Allocate.
+        let layout = Layout::from_size_align(253, 4).unwrap();
+        let result = allocator.allocate(layout.clone());
+        assert!(result.is_ok());
+
+        // Check offset.
+        assert_eq!(allocator.offset.get(), 256);
+    }
+
+    #[test]
+    fn test_allocate_multiple() {
+        let capacity = 0x1000;
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+
+        // Cases to check, contains:
+        // - layout
+        // - allocation pointer offset from memory region start
+        // - internal allocator offset
+        let cases = vec![
+            (Layout::from_size_align(253, 1).unwrap(), 0, 253),
+            (Layout::from_size_align(557, 2).unwrap(), 254, 812),
+            (Layout::from_size_align(39, 8).unwrap(), 816, 856),
+        ];
+
+        let memory_region_ptr = allocator.memory_region.ptr;
+        for (layout, exp_ptr_offset, exp_allocator_offset) in cases {
+            // Allocate.
+            let alloc_ptr = allocator.allocate(layout).unwrap().as_ptr();
+
+            // Check position relative to memory region and allocator offset.
+            let allocation_ptr_offset = unsafe { alloc_ptr.offset_from(memory_region_ptr) };
+            assert_eq!(allocation_ptr_offset, exp_ptr_offset);
+            assert_eq!(allocator.offset.get(), exp_allocator_offset);
+        }
+    }
+
+    #[test]
+    fn test_allocate_oom() {
+        let capacity = page_size();
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+
+        // Allocate.
+        let layout = Layout::from_size_align(2 * page_size(), 4).unwrap();
+        let result = allocator.allocate(layout.clone());
+        assert!(result.is_err_and(|e| e == AllocationError::OutOfMemory));
+
+        // Check offset.
+        assert_eq!(allocator.offset.get(), 0);
+    }
+
+    #[test]
+    fn test_allocate_zero() {
+        let capacity = page_size();
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+
+        // Allocate.
+        let layout = Layout::from_size_align(0, 4).unwrap();
+        let result = allocator.allocate(layout.clone());
+        assert!(result.is_err_and(|e| e == AllocationError::ZeroSizeAllocation));
+
+        // Check offset.
+        assert_eq!(allocator.offset.get(), 0);
+    }
+
+    #[test]
+    fn test_deallocate_panic() {
+        let capacity = page_size();
+        let allocator = MmapArenaAllocator::new(capacity).unwrap();
+
+        // Allocate.
+        let layout = Layout::from_size_align(253, 4).unwrap();
+        let ptr = allocator.allocate(layout.clone()).unwrap();
+
+        // Deallocate - no-op.
+        unsafe { allocator.deallocate(ptr, layout) };
+    }
+}

--- a/score/pal/BUILD
+++ b/score/pal/BUILD
@@ -19,7 +19,6 @@ rust_library(
     edition = "2021",
     visibility = ["//score:__subpackages__"],
     deps = [
-        "//score/containers_rust:containers",
         "//score/log_rust/score_log",
     ],
 )

--- a/score/pal/Cargo.toml
+++ b/score/pal/Cargo.toml
@@ -24,7 +24,6 @@ license-file.workspace = true
 path = "lib.rs"
 
 [dependencies]
-containers.workspace = true
 score_log.workspace = true
 
 [lints]

--- a/score/pal/affinity.rs
+++ b/score/pal/affinity.rs
@@ -347,7 +347,7 @@ mod tests {
         let exp = vec![0, 123, 1023];
         let cpu_set = CpuSet::new(&exp);
         let got = cpu_set.get();
-        assert_eq!(exp, got.iter().copied().collect::<Vec<_>>());
+        assert_eq!(exp, got.to_vec());
     }
 
     #[test]
@@ -361,7 +361,7 @@ mod tests {
         });
         join_handle.join().unwrap();
 
-        assert_eq!(rx.recv().unwrap().iter().copied().collect::<Vec<_>>(), exp_affinity);
+        assert_eq!(rx.recv().unwrap().to_vec(), exp_affinity);
     }
 
     #[test]

--- a/score/pal/affinity.rs
+++ b/score/pal/affinity.rs
@@ -14,8 +14,9 @@
 //! Affinity handling differs between Linux and QNX.
 //! Module ensures similar behavior between both OSes.
 
+extern crate alloc;
+
 use crate::{c_int, errno};
-use containers::fixed_capacity::FixedCapacityVec;
 use score_log::ScoreDebug;
 
 #[cfg(target_os = "linux")]
@@ -78,28 +79,24 @@ impl CpuSet {
         mask
     }
 
-    /// Create list based on provided mask.
-    fn create_list(mask: &[u8; CPU_MASK_SIZE]) -> FixedCapacityVec<usize> {
-        let mut list = FixedCapacityVec::new(MAX_CPU_NUM);
-        for cpu_id in 0..MAX_CPU_NUM {
-            let index = cpu_id / 8;
-            let offset = cpu_id % 8;
-
-            if (mask[index] & (1 << offset)) != 0 {
-                // Error should not occur, since capacity is matching the mask size.
-                list.push(cpu_id).expect("failed to push CPU ID to the list");
-            }
-        }
-
-        list
-    }
-
     pub fn set(&mut self, affinity: &[usize]) {
         self.mask = Self::create_mask(affinity);
     }
 
-    pub fn get(&self) -> FixedCapacityVec<usize> {
-        Self::create_list(&self.mask)
+    pub fn get(&self) -> Box<[usize]> {
+        let mut cpu_id_array = [0usize; MAX_CPU_NUM];
+        let mut counter = 0;
+        for cpu_id in 0..MAX_CPU_NUM {
+            let index = cpu_id / 8;
+            let offset = cpu_id % 8;
+
+            if (self.mask[index] & (1 << offset)) != 0 {
+                cpu_id_array[counter] = cpu_id;
+                counter += 1;
+            }
+        }
+
+        Box::from(&cpu_id_array[..counter])
     }
 }
 
@@ -249,7 +246,7 @@ pub fn set_affinity(cpu_set: CpuSet) {
 }
 
 /// Get affinity of a current thread.
-pub fn get_affinity() -> FixedCapacityVec<usize> {
+pub fn get_affinity() -> Box<[usize]> {
     #[cfg(target_os = "linux")]
     {
         let mut native_cpu_set = core::mem::MaybeUninit::zeroed();

--- a/score/pal/lib.rs
+++ b/score/pal/lib.rs
@@ -27,6 +27,7 @@ pub type c_long = core::ffi::c_long;
 pub type c_ulong = core::ffi::c_ulong;
 pub type size_t = usize;
 pub type c_void = core::ffi::c_void;
+pub type off_t = i64;
 pub type pid_t = i32;
 pub type pthread_t = c_ulong;
 
@@ -61,6 +62,8 @@ pub struct sched_param {
 }
 
 extern "C" {
+    pub fn mmap(addr: *mut c_void, len: size_t, prot: c_int, flags: c_int, fd: c_int, offset: off_t) -> *mut c_void;
+    pub fn munmap(addr: *mut c_void, len: size_t) -> c_int;
     pub fn sysconf(__name: c_int) -> c_long;
     pub fn pthread_self() -> pthread_t;
     pub fn pthread_join(native: pthread_t, value: *mut *mut c_void) -> c_int;
@@ -98,3 +101,32 @@ pub const PTHREAD_INHERIT_SCHED: c_int = 0;
 pub const PTHREAD_EXPLICIT_SCHED: c_int = 1;
 #[cfg(target_os = "nto")]
 pub const PTHREAD_EXPLICIT_SCHED: c_int = 2;
+
+#[cfg(target_os = "linux")]
+pub const _SC_PAGESIZE: c_int = 30;
+#[cfg(target_os = "nto")]
+pub const _SC_PAGESIZE: c_int = 11;
+
+#[cfg(target_os = "linux")]
+pub const PROT_NONE: c_int = 0;
+#[cfg(target_os = "linux")]
+pub const PROT_READ: c_int = 1;
+#[cfg(target_os = "linux")]
+pub const PROT_WRITE: c_int = 2;
+#[cfg(target_os = "linux")]
+pub const PROT_EXEC: c_int = 4;
+
+#[cfg(target_os = "nto")]
+pub const PROT_NONE: c_int = 0x00000000;
+#[cfg(target_os = "nto")]
+pub const PROT_READ: c_int = 0x00000100;
+#[cfg(target_os = "nto")]
+pub const PROT_WRITE: c_int = 0x00000200;
+#[cfg(target_os = "nto")]
+pub const PROT_EXEC: c_int = 0x00000400;
+
+pub const MAP_PRIVATE: c_int = 0x0002;
+#[cfg(target_os = "linux")]
+pub const MAP_ANONYMOUS: c_int = 0x0020;
+#[cfg(target_os = "nto")]
+pub const MAP_ANONYMOUS: c_int = 0x00080000;

--- a/score/thread/thread.rs
+++ b/score/thread/thread.rs
@@ -522,7 +522,7 @@ mod tests {
         let result = join_handle.join();
         assert!(result.is_ok());
 
-        assert_eq!(rx.recv().unwrap().iter().copied().collect::<Vec<_>>(), exp_affinity);
+        assert_eq!(rx.recv().unwrap().to_vec(), exp_affinity);
     }
 
     #[test]


### PR DESCRIPTION
- Basic `mmap`-backed arena allocator.
- Extended `pal` with `mmap`-related features.
- Made `AllocationError` comparable.