### PR TITLE
OS: Add QNX I/O and OCB wrappers

### DIFF
--- a/score/os/mocklib/qnx/mock_iofunc.h
+++ b/score/os/mocklib/qnx/mock_iofunc.h
@@ -138,6 +138,21 @@ class MockIoFunc : public IoFunc
                 iofunc_notify_remove,
                 (resmgr_context_t * ctp, iofunc_notify_t* nop),
                 (const, noexcept, override));
+
+    MOCK_METHOD((std::int32_t),
+                iofunc_close_dup_default,
+                (resmgr_context_t * ctp, io_close_t* msg, iofunc_ocb_t* ocb),
+                (const, noexcept, override));
+
+    MOCK_METHOD((std::int32_t),
+                iofunc_lock_ocb_default,
+                (resmgr_context_t * ctp, void* reserved, iofunc_ocb_t* ocb),
+                (const, noexcept, override));
+
+    MOCK_METHOD((std::int32_t),
+                iofunc_unlock_ocb_default,
+                (resmgr_context_t * ctp, void* reserved, iofunc_ocb_t* ocb),
+                (const, noexcept, override));
 };
 
 /* KW_SUPPRESS_END:MISRA.VAR.HIDDEN:Shadowing function name is intended. */

--- a/score/os/qnx/iofunc.cpp
+++ b/score/os/qnx/iofunc.cpp
@@ -277,6 +277,27 @@ void score::os::IoFuncQnx::iofunc_notify_remove(resmgr_context_t* const ctp, iof
     ::iofunc_notify_remove(ctp, nop);
 }
 
+std::int32_t score::os::IoFuncQnx::iofunc_close_dup_default(resmgr_context_t* ctp,
+                                                          io_close_t* msg,
+                                                          iofunc_ocb_t* ocb) const noexcept
+{
+    return ::iofunc_close_dup_default(ctp, msg, ocb);
+}
+
+std::int32_t score::os::IoFuncQnx::iofunc_lock_ocb_default(resmgr_context_t* ctp,
+                                                         void* reserved,
+                                                         iofunc_ocb_t* ocb) const noexcept
+{
+    return ::iofunc_lock_ocb_default(ctp, reserved, ocb);
+}
+
+std::int32_t score::os::IoFuncQnx::iofunc_unlock_ocb_default(resmgr_context_t* ctp,
+                                                           void* reserved,
+                                                           iofunc_ocb_t* ocb) const noexcept
+{
+    return ::iofunc_unlock_ocb_default(ctp, reserved, ocb);
+}
+
 score::os::IoFunc& score::os::IoFunc::instance() noexcept
 {
     // The rule states: Static and thread-local objects shall be constant-initialized.

--- a/score/os/qnx/iofunc.h
+++ b/score/os/qnx/iofunc.h
@@ -130,6 +130,19 @@ class IoFunc : public ObjectSeam<IoFunc>
 
     virtual void iofunc_notify_remove(resmgr_context_t* const ctp, iofunc_notify_t* const nop) const noexcept = 0;
 
+
+    virtual std::int32_t iofunc_close_dup_default(resmgr_context_t* ctp,
+                                                  io_close_t* msg,
+                                                  iofunc_ocb_t* ocb) const noexcept = 0;
+    
+    virtual std::int32_t iofunc_lock_ocb_default(resmgr_context_t* ctp,
+                                                 void* reserved,
+                                                 iofunc_ocb_t* ocb) const noexcept = 0;
+                                                 
+    virtual std::int32_t iofunc_unlock_ocb_default(resmgr_context_t* ctp,
+                                                   void* reserved,
+                                                   iofunc_ocb_t* ocb) const noexcept = 0;
+
     IoFunc() = default;
     virtual ~IoFunc() = default;
 
@@ -226,6 +239,18 @@ class IoFuncQnx final : public IoFunc
                                       const std::int32_t index) const noexcept override;
 
     void iofunc_notify_remove(resmgr_context_t* const ctp, iofunc_notify_t* const nop) const noexcept override;
+
+    std::int32_t iofunc_close_dup_default(resmgr_context_t* ctp,
+                                                  io_close_t* msg,
+                                                  iofunc_ocb_t* ocb) const noexcept override;
+
+    std::int32_t iofunc_lock_ocb_default(resmgr_context_t* ctp,
+                                        void* reserved,
+                                        iofunc_ocb_t* ocb) const noexcept override;
+                                                 
+    std::int32_t iofunc_unlock_ocb_default(resmgr_context_t* ctp,
+                                            void* reserved,
+                                            iofunc_ocb_t* ocb) const noexcept override;
 };
 
 }  // namespace os

--- a/score/os/test/qnx/iofunc_test.cpp
+++ b/score/os/test/qnx/iofunc_test.cpp
@@ -176,6 +176,43 @@ TEST_F(IoFuncMockTest, iofunc_lseek_default)
     EXPECT_CALL(iofuncmock, iofunc_lseek_default);
     unit_->iofunc_lseek_default(nullptr, nullptr, nullptr);
 }
+
+TEST_F(IoFuncMockTest, iofunc_close_dup_default)
+{
+    RecordProperty("ParentRequirement", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "Iofunc Close Dup Default");
+    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("DerivationTechnique", "equivalence classes");
+
+    EXPECT_CALL(iofuncmock, iofunc_close_dup_default);
+    unit_->iofunc_close_dup_default(nullptr, nullptr, nullptr);
+}
+
+TEST_F(IoFuncMockTest, iofunc_lock_ocb_default)
+{
+    RecordProperty("ParentRequirement", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "Iofunc Lock Ocb Default");
+    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("DerivationTechnique", "equivalence classes");
+
+    EXPECT_CALL(iofuncmock, iofunc_lock_ocb_default);
+    unit_->iofunc_lock_ocb_default(nullptr, nullptr, nullptr);
+}
+
+TEST_F(IoFuncMockTest, iofunc_unlock_ocb_default)
+{
+    RecordProperty("ParentRequirement", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "Iofunc Unlock Ocb Default");
+    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("DerivationTechnique", "equivalence classes");
+
+    EXPECT_CALL(iofuncmock, iofunc_unlock_ocb_default);
+    unit_->iofunc_unlock_ocb_default(nullptr, nullptr, nullptr);
+}
+
 // ------------ IoFuncQnx -------------
 class IoFuncFixture : public ::testing::Test
 {
@@ -583,6 +620,67 @@ TEST(IoFuncTest, iofunc_ocb_attach_failure_invalid_ctp)
 
     EXPECT_FALSE(ocb_attach_result.has_value());
     EXPECT_EQ(ocb_attach_result.error(), ENOENT);
+}
+
+TEST_F(IoFuncFixture, iofunc_close_dup_default_success)
+{
+    RecordProperty("ParentRequirement", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "Iofunc Close Dup Default Success");
+    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("DerivationTechnique", "equivalence classes");
+
+    resmgr_context_t ctp{};
+    io_close_t msg{};
+    iofunc_ocb_t ocb{};
+
+    auto& iofunc = score::os::IoFunc::instance();
+    const auto close_dup_result = iofunc.iofunc_close_dup_default(&ctp, &msg, &ocb);
+
+    EXPECT_EQ(close_dup_result, EOK);
+}
+
+TEST_F(IoFuncFixture, iofunc_lock_ocb_default_success)
+{
+    RecordProperty("ParentRequirement", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "Iofunc Lock Ocb Default Success");
+    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("DerivationTechnique", "equivalence classes");
+
+    resmgr_context_t ctp{};
+    extended_dev_attr_t attr{};
+    iofunc_ocb_t ocb{};
+
+    auto& iofunc = score::os::IoFunc::instance();
+    iofunc.iofunc_attr_init(&attr.attr, 0U, nullptr, nullptr);
+    ocb.attr = &attr;
+    const auto lock_ocb_result = iofunc.iofunc_lock_ocb_default(&ctp, nullptr, &ocb);
+
+    EXPECT_EQ(lock_ocb_result, EOK);
+}
+
+TEST_F(IoFuncFixture, iofunc_unlock_ocb_default_success)
+{
+    RecordProperty("ParentRequirement", "SCR-46010294");
+    RecordProperty("ASIL", "B");
+    RecordProperty("Description", "Iofunc Unlock Ocb Default Success");
+    RecordProperty("TestingTechnique", "Interface test");
+    RecordProperty("DerivationTechnique", "equivalence classes");
+
+    resmgr_context_t ctp{};
+    extended_dev_attr_t attr{};
+    iofunc_ocb_t ocb{};
+
+    auto& iofunc = score::os::IoFunc::instance();
+    iofunc.iofunc_attr_init(&attr.attr, 0U, nullptr, nullptr);
+    ocb.attr = &attr;
+
+    const auto lock_ocb_result = iofunc.iofunc_lock_ocb_default(&ctp, nullptr, &ocb);
+    EXPECT_EQ(lock_ocb_result, EOK);
+
+    const auto unlock_ocb_result = iofunc.iofunc_unlock_ocb_default(&ctp, nullptr, &ocb);
+    EXPECT_EQ(unlock_ocb_result, EOK);
 }
 
 }  // namespace


### PR DESCRIPTION
- Add wrappers for io_close_dup_default, io_lock_ocb_default and io_unlock_ocb_default. 
- Added corresponding mocks
- Unit tests to improve coverage.