### PR TITLE
mem: Mark get mem resource proxy const

### DIFF
--- a/score/memory/shared/fake/my_bounded_memory_resource.h
+++ b/score/memory/shared/fake/my_bounded_memory_resource.h
@@ -45,7 +45,15 @@ class MyBoundedMemoryResource final : public ManagedMemoryResource
     MyBoundedMemoryResource& operator=(const MyBoundedMemoryResource&) noexcept = default;
     MyBoundedMemoryResource& operator=(MyBoundedMemoryResource&&) noexcept = default;
 
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    {
+        return manager_;
+    }
+
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return manager_;
     }

--- a/score/memory/shared/fake/my_bounded_shared_memory_resource.h
+++ b/score/memory/shared/fake/my_bounded_shared_memory_resource.h
@@ -54,7 +54,15 @@ class MyBoundedSharedMemoryResource final : public ISharedMemoryResource
         return false;
     }
 
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    {
+        return resource_.getMemoryResourceProxy();
+    }
+
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return resource_.getMemoryResourceProxy();
     }

--- a/score/memory/shared/fake/my_memory_resource.h
+++ b/score/memory/shared/fake/my_memory_resource.h
@@ -42,12 +42,20 @@ class MyMemoryResource : public ManagedMemoryResource
           memoryResourceId_{instanceId++},
           manager_{memoryResourceId_}
     {
-    }
-
-    MemoryResourceProxy* getMemoryResourceProxy() noexcept override
-    {
         MemoryResourceRegistry::getInstance().clear();
         score::cpp::ignore = MemoryResourceRegistry::getInstance().insert_resource({memoryResourceId_, this});
+    }
+
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
+    const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    {
+        return &this->manager_;
+    }
+
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    {
         return &this->manager_;
     }
 

--- a/score/memory/shared/managed_memory_resource.h
+++ b/score/memory/shared/managed_memory_resource.h
@@ -162,10 +162,25 @@ class ManagedMemoryResource : public ::score::cpp::pmr::memory_resource
      * pointer into an OffsetPtr if it shall be stored in shared memory.
      * @return MemoryResourceProxy* that identifies _this_ memory_resource.
      */
-
-    /// \todo: getMemoryResourceProxy should not return a non const pointer and the method should also be marked const.
-    /// This issue will be investigated and fixed in Ticket-146625"
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
     virtual const MemoryResourceProxy* getMemoryResourceProxy() noexcept = 0;
+
+    /**
+     * We need to return a raw pointer, since we need to convert this
+     * pointer into an OffsetPtr if it shall be stored in shared memory.
+     * @return MemoryResourceProxy* that identifies _this_ memory_resource.
+     *
+     * @note Not pure virtual yet: mw::com has a subclass that does not override this yet and cannot be
+     *       updated until this change is consumed downstream. Returning nullptr is safe here since this
+     *       is a private method only reachable by the friend classes above, which always operate on
+     *       subclasses that provide their own override. Will be made pure virtual once downstream is updated.
+     */
+    virtual const MemoryResourceProxy* getMemoryResourceProxy() const noexcept
+    {
+        return nullptr;
+    }
 };
 
 }  // namespace score::memory::shared

--- a/score/memory/shared/memory_resource_registry_test.cpp
+++ b/score/memory/shared/memory_resource_registry_test.cpp
@@ -52,6 +52,10 @@ class BasicMemoryResource : public ManagedMemoryResource
     {
         return nullptr;
     }
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    {
+        return nullptr;
+    }
     void* getBaseAddress() const noexcept override
     {
         return base_address_;
@@ -98,6 +102,10 @@ class BoundsCheckBypassingMemoryResource : public ManagedMemoryResource
     {
     }
     MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    {
+        return nullptr;
+    }
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return nullptr;
     }

--- a/score/memory/shared/new_delete_delegate_resource.cpp
+++ b/score/memory/shared/new_delete_delegate_resource.cpp
@@ -38,8 +38,9 @@ static_assert((PAGE_SIZE % alignof(std::max_align_t) == 0), "allocation_buffer_s
 }  // namespace
 
 // coverity[autosar_cpp14_a3_3_1_violation] false-positive: declared in header, implemented here
-NewDeleteDelegateMemoryResource::NewDeleteDelegateMemoryResource(const std::uint64_t mem_res_id,
-                                                                 score::cpp::pmr::memory_resource* upstream_resource) noexcept
+NewDeleteDelegateMemoryResource::NewDeleteDelegateMemoryResource(
+    const std::uint64_t mem_res_id,
+    score::cpp::pmr::memory_resource* upstream_resource) noexcept
     : ManagedMemoryResource{},
       upstream_resource_{upstream_resource},
       memory_resource_id_{mem_res_id},
@@ -48,7 +49,8 @@ NewDeleteDelegateMemoryResource::NewDeleteDelegateMemoryResource(const std::uint
       current_upstream_allocations_{}
 {
     auto result = MemoryResourceRegistry::getInstance().insert_resource({memory_resource_id_, this});
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(result, "memory resource id clash! Inserting NewDeleteDelegateMemoryResource failed.");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        result, "memory resource id clash! Inserting NewDeleteDelegateMemoryResource failed.");
 }
 
 NewDeleteDelegateMemoryResource::~NewDeleteDelegateMemoryResource()
@@ -94,7 +96,11 @@ const void* NewDeleteDelegateMemoryResource::getEndAddress() const noexcept
 
 const MemoryResourceProxy* NewDeleteDelegateMemoryResource::getMemoryResourceProxy() noexcept
 {
-    // Suppress "AUTOSAR C++14 A9-3-1" rule finding: "Member functions shall not return non-const “raw” pointers or
+    // coverity[autosar_cpp14_a9_3_1_violation]
+    return &proxy_;
+}
+const MemoryResourceProxy* NewDeleteDelegateMemoryResource::getMemoryResourceProxy() const noexcept
+{  // Suppress "AUTOSAR C++14 A9-3-1" rule finding: "Member functions shall not return non-const “raw” pointers or
     // references to private or protected data owned by the class.".
     // The function provides controlled access to the internal 'proxy_' member. 'proxy_' is part of the class's
     // implementation details and is not meant for direct external access.
@@ -119,9 +125,9 @@ void* NewDeleteDelegateMemoryResource::do_allocate(const std::size_t bytes, std:
     // the real allocation gets forwarded to upstream new-delete res.
     auto* const result = upstream_resource_->allocate(bytes, alignment);
 
-    // LCOV_EXCL_START (Defensive programming: score::cpp::pmr::memory_resource already asserts that the allocate call on the
-    // underlying allocator does not return a nullptr so this branch can never be entered)
-    // LCOV_EXCL_BR_START (See line coverage suppression explanation)
+    // LCOV_EXCL_START (Defensive programming: score::cpp::pmr::memory_resource already asserts that the allocate call
+    // on the underlying allocator does not return a nullptr so this branch can never be entered) LCOV_EXCL_BR_START
+    // (See line coverage suppression explanation)
     if (result == nullptr)
     {
         score::mw::log::LogError("shm")
@@ -134,7 +140,8 @@ void* NewDeleteDelegateMemoryResource::do_allocate(const std::size_t bytes, std:
 
     const auto emplace_result = current_upstream_allocations_.emplace(
         std::piecewise_construct, std::forward_as_tuple(result), std::forward_as_tuple(bytes, alignment));
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(emplace_result.second, "Could not emplace allocation in allocation map.");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(emplace_result.second,
+                                                "Could not emplace allocation in allocation map.");
 
     // calculation of how many bytes will be effectively needed is done here
     //  at the basis of how our (real) shared-mem resource allocation behavior! So the following alloc-approach exactly
@@ -155,7 +162,8 @@ void* NewDeleteDelegateMemoryResource::do_allocate(const std::size_t bytes, std:
         safe_math::Add(bytes, alignment).and_then([](const auto max_required_padding) noexcept {
             return safe_math::Subtract(max_required_padding, 1U);
         });
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(max_required_padding_result.has_value(), "Calculating max required padding overflowed!");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(max_required_padding_result.has_value(),
+                                                "Calculating max required padding overflowed!");
 
     void* const end_memory_buffer =
         // In our architecture we have a one-to-one mapping between pointers and integral values.
@@ -173,7 +181,8 @@ void* NewDeleteDelegateMemoryResource::do_allocate(const std::size_t bytes, std:
         safe_math::Add(bytes, static_cast<std::size_t>(padding)).and_then([this](const auto allocated_bytes) noexcept {
             return safe_math::Add(sum_allocated_bytes_, allocated_bytes);
         });
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(allocated_bytes_result.has_value(), "Calculating allocated bytes overflowed!");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(allocated_bytes_result.has_value(),
+                                                "Calculating allocated bytes overflowed!");
     sum_allocated_bytes_ = allocated_bytes_result.value();
 
     return result;

--- a/score/memory/shared/new_delete_delegate_resource.h
+++ b/score/memory/shared/new_delete_delegate_resource.h
@@ -52,7 +52,11 @@ class NewDeleteDelegateMemoryResource : public score::memory::shared::ManagedMem
 
     ~NewDeleteDelegateMemoryResource() override;
 
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
     const MemoryResourceProxy* getMemoryResourceProxy() noexcept override;
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override;
     void* getBaseAddress() const noexcept override;
     void* getUsableBaseAddress() const noexcept override;
 

--- a/score/memory/shared/polymorphic_offset_ptr_allocator.h
+++ b/score/memory/shared/polymorphic_offset_ptr_allocator.h
@@ -44,7 +44,7 @@ class PolymorphicOffsetPtrAllocator
 
     // Non-explicit constructor is good enough for maintaining required implicit conversion
     // NOLINTNEXTLINE(google-explicit-constructor): Tolerated, discard explicit.
-    PolymorphicOffsetPtrAllocator(ManagedMemoryResource& resource) noexcept : proxy_{resource.getMemoryResourceProxy()}
+    PolymorphicOffsetPtrAllocator(ManagedMemoryResource& resource) noexcept : proxy_{std::as_const(resource).getMemoryResourceProxy()}
     {
     }
 

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -22,6 +22,9 @@
 #include "score/language/safecpp/safe_math/safe_math.h"
 
 #include "score/bitmanipulation/bitmask_operators.h"
+#include "score/mw/log/log_stream.h"
+#include "score/mw/log/log_types.h"
+#include "score/mw/log/logging.h"
 #include "score/os/errno.h"
 #include "score/os/errno_logging.h"
 #include "score/os/fcntl.h"
@@ -29,9 +32,6 @@
 #include "score/os/stat.h"
 #include "score/os/unistd.h"
 #include "score/os/utils/acl/i_access_control_list.h"
-#include "score/mw/log/log_stream.h"
-#include "score/mw/log/log_types.h"
-#include "score/mw/log/logging.h"
 
 #include <score/assert.hpp>
 #include <score/hash.hpp>
@@ -300,7 +300,8 @@ SharedMemoryResource::~SharedMemoryResource()
     if (this->file_descriptor_ != -1)
     {
         this->deinitalizeInternalsInSharedMemory();
-        score::cpp::ignore = ::score::os::Mman::instance().munmap(this->base_address_, virtual_address_space_to_reserve_);
+        score::cpp::ignore =
+            ::score::os::Mman::instance().munmap(this->base_address_, virtual_address_space_to_reserve_);
         // The reason for banning is, because it's error-prone to use. One should use abstractions e.g. provided by
         // the C++ standard library. For Shared Memory handling there is no abstraction, which is why we created this
         // library.
@@ -361,7 +362,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     if (!result.has_value())
     {
         score::mw::log::LogError("shm") << "Unexpected error while creating Shared Memory Resource with errno"
-                                      << result.error();
+                                        << result.error();
 
         return score::cpp::make_unexpected(result.error());
     }
@@ -384,7 +385,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     if (!result.has_value())
     {
         score::mw::log::LogError("shm") << "Unexpected error while creating anonymous shared-memory resource with errno"
-                                      << result.error();
+                                        << result.error();
 
         return score::cpp::make_unexpected(result.error());
     }
@@ -406,8 +407,8 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     const auto result = resource->CreateOrOpenImpl(user_space_to_reserve, std::move(initialize_callback), permissions);
     if (!result.has_value())
     {
-        score::mw::log::LogError("shm") << "Unexpected error while creating or opening shared-memory resource with errno"
-                                      << result.error();
+        score::mw::log::LogError("shm")
+            << "Unexpected error while creating or opening shared-memory resource with errno" << result.error();
 
         return score::cpp::make_unexpected(result.error());
     }
@@ -425,8 +426,9 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     const auto result = resource->OpenImpl(is_read_write);
     if (!result.has_value())
     {
-        score::mw::log::LogError("shm") << __func__ << __LINE__ << "Unexpected error while opening shared-memory resource"
-                                      << resource->GetIdentifier() << "with errno" << result.error();
+        score::mw::log::LogError("shm") << __func__ << __LINE__
+                                        << "Unexpected error while opening shared-memory resource"
+                                        << resource->GetIdentifier() << "with errno" << result.error();
         return score::cpp::make_unexpected(result.error());
     }
     return resource;
@@ -473,10 +475,10 @@ SharedMemoryResource::SharedMemoryResource(std::variant<std::string, std::uint64
       log_identification_{std::holds_alternative<std::string>(identifier)
                               ? "file: " + std::get<std::string>(identifier)
                               : "id: " + std::to_string(std::get<std::uint64_t>(identifier))},
-      memory_identifier_{
-          std::holds_alternative<std::string>(identifier)
-              ? score::cpp::hash_bytes(std::get<std::string>(identifier).data(), std::get<std::string>(identifier).size())
-              : std::get<std::uint64_t>(identifier)},
+      memory_identifier_{std::holds_alternative<std::string>(identifier)
+                             ? score::cpp::hash_bytes(std::get<std::string>(identifier).data(),
+                                                      std::get<std::string>(identifier).size())
+                             : std::get<std::uint64_t>(identifier)},
       shared_memory_resource_identifier_{identifier},
       start_{nullptr}
 {
@@ -493,8 +495,8 @@ SharedMemoryResource::SharedMemoryResource(std::variant<std::string, std::uint64
 // std::terminate call.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 score::cpp::expected_blank<Error> SharedMemoryResource::CreateImpl(const std::size_t user_space_to_reserve,
-                                                            const InitializeCallback initialize_callback,
-                                                            const UserPermissions& permissions) noexcept
+                                                                   const InitializeCallback initialize_callback,
+                                                                   const UserPermissions& permissions) noexcept
 {
     this->opening_mode_ = Fcntl::Open::kReadWrite;
     this->map_mode_ = ::score::os::Mman::Protection::kRead | ::score::os::Mman::Protection::kWrite;
@@ -547,8 +549,8 @@ score::cpp::expected_blank<Error> SharedMemoryResource::CreateImpl(const std::si
 }
 
 score::cpp::expected_blank<Error> SharedMemoryResource::CreateOrOpenImpl(const std::size_t user_space_to_reserve,
-                                                                  InitializeCallback initialize_callback,
-                                                                  const UserPermissions& permissions) noexcept
+                                                                         InitializeCallback initialize_callback,
+                                                                         const UserPermissions& permissions) noexcept
 {
     const auto* const path = std::get_if<std::string>(&shared_memory_resource_identifier_);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(path != nullptr, "shm-object file path is not set.");
@@ -560,8 +562,9 @@ score::cpp::expected_blank<Error> SharedMemoryResource::CreateOrOpenImpl(const s
     {
         if (open_result.error() == Error::Code::kNoSuchFileOrDirectory)
         {
-            score::mw::log::LogDebug("shm") << "Could not open shared-memory resource with path" << *path << "with errno"
-                                          << open_result.error() << "Attempting to create it now instead.";
+            score::mw::log::LogDebug("shm")
+                << "Could not open shared-memory resource with path" << *path << "with errno" << open_result.error()
+                << "Attempting to create it now instead.";
 
             const auto creation_result = CreateImpl(user_space_to_reserve, std::move(initialize_callback), permissions);
             // If the shared memory segment could not be created because another process has created it or has acquired
@@ -571,9 +574,10 @@ score::cpp::expected_blank<Error> SharedMemoryResource::CreateOrOpenImpl(const s
                 // Create() should terminate for any other error
                 std::stringstream s{};
                 s << "Creating shared memory region failed with errno:" << creation_result.error();
-                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(((creation_result.error() == Error::Code::kDeviceOrResourceBusy) ||
-                                        (creation_result.error() == Error::Code::kObjectExists)),
-                                       s.str().c_str());
+                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+                    ((creation_result.error() == Error::Code::kDeviceOrResourceBusy) ||
+                     (creation_result.error() == Error::Code::kObjectExists)),
+                    s.str().c_str());
 
                 score::mw::log::LogDebug("shm")
                     << "Could not create shared-memory region with errno:" << creation_result.error()
@@ -678,10 +682,19 @@ auto SharedMemoryResource::GetLockFilePath(const std::string& input_path) noexce
 }
 
 // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
+auto SharedMemoryResource::getMemoryResourceProxy() const noexcept -> const MemoryResourceProxy*
+{
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        this->control_block_ != nullptr, "Control block containing MemoryResourceProxy has not yet been created.");
+
+    return &this->control_block_->memoryResourceProxy;
+}
+
+// coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
 auto SharedMemoryResource::getMemoryResourceProxy() noexcept -> const MemoryResourceProxy*
 {
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(this->control_block_ != nullptr,
-                           "Control block containing MemoryResourceProxy has not yet been created.");
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        this->control_block_ != nullptr, "Control block containing MemoryResourceProxy has not yet been created.");
 
     return &this->control_block_->memoryResourceProxy;
 }
@@ -748,14 +761,12 @@ auto SharedMemoryResource::getBaseAddress() const noexcept -> void*
     // hence the warning is suppressed.
     // Suppress "AUTOSAR C++14 M9-3-1" rule finding: "Const member functions shall not return non-const pointers or
     // references to class-data."
-    // Rationale: In the long term, this function will return a pointer to const (will be done in Ticket-170815). However,
-    // since we have many users of this function whose code would need to be updated, this isn't a priority for the
-    // moment. While this function returns a non-const pointer to shared memory, our safety requirements and high level
-    // design ensure that modifying this data (by a QM process for example) cannot lead to violations of safety goals
-    // (e.g. through restricting write access of certain processes, bounds checking etc.). Therefore, we suppress this
-    // warning for now.
-    // coverity[autosar_cpp14_m9_3_1_violation]
-    // coverity[autosar_cpp14_a9_3_1_violation]
+    // Rationale: In the long term, this function will return a pointer to const (will be done in Ticket-170815).
+    // However, since we have many users of this function whose code would need to be updated, this isn't a priority for
+    // the moment. While this function returns a non-const pointer to shared memory, our safety requirements and high
+    // level design ensure that modifying this data (by a QM process for example) cannot lead to violations of safety
+    // goals (e.g. through restricting write access of certain processes, bounds checking etc.). Therefore, we suppress
+    // this warning for now. coverity[autosar_cpp14_m9_3_1_violation] coverity[autosar_cpp14_a9_3_1_violation]
     return this->base_address_;
 }
 
@@ -839,8 +850,8 @@ void SharedMemoryResource::CompensateUmask(const os::Stat::Mode target_rights) c
         auto result = score::os::Stat::instance().fchmod(file_descriptor_, target_rights);
         if (!result.has_value())
         {
-            score::mw::log::LogWarn("shm") << "Unable to fchmod on shm-object" << log_identification_ << ": "
-                                         << std::move(result).error();
+            score::mw::log::LogWarn("shm")
+                << "Unable to fchmod on shm-object" << log_identification_ << ": " << std::move(result).error();
         }
     }
 }
@@ -851,15 +862,15 @@ auto SharedMemoryResource::ApplyPermissions(const UserPermissions& permissions) 
     if (std::holds_alternative<UserPermissionsMap>(permissions))
     {
         const auto& permission_map_ptr = std::get_if<UserPermissionsMap>(&permissions);
-        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(permission_map_ptr != nullptr, "Could not get user permissions map");
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(permission_map_ptr != nullptr,
+                                                          "Could not get user permissions map");
 
         // Suppress "AUTOSAR C++14 A18-5-8" rule finding. This rule states: "Objects that do not outlive a function
         // shall
         // have automatic storage duration".
-        // The acl_factory_ is an score::cpp::callback which returns a std::unique_ptr. We return a unique_ptr since we want to
-        // be able to use dynamic dispatch to mock the IAccessControlList but also want the caller of the callback to be
-        // the sole owner of the IAccessControlList.
-        // coverity[autosar_cpp14_a18_5_8_violation]
+        // The acl_factory_ is an score::cpp::callback which returns a std::unique_ptr. We return a unique_ptr since we
+        // want to be able to use dynamic dispatch to mock the IAccessControlList but also want the caller of the
+        // callback to be the sole owner of the IAccessControlList. coverity[autosar_cpp14_a18_5_8_violation]
         auto acl = acl_factory_(file_descriptor_);
         for (const auto& permission : *permission_map_ptr)
         {
@@ -883,8 +894,8 @@ auto SharedMemoryResource::reserveSharedMemory() const noexcept -> void
     if (!truncation_result.has_value())
     {
         score::mw::log::LogFatal("shm") << __func__ << __LINE__ << "Could not ftruncate file to size"
-                                      << virtual_address_space_to_reserve_ << "for" << log_identification_
-                                      << "with error" << truncation_result.error();
+                                        << virtual_address_space_to_reserve_ << "for" << log_identification_
+                                        << "with error" << truncation_result.error();
         std::terminate();
     }
 }
@@ -893,17 +904,17 @@ auto SharedMemoryResource::mapMemoryIntoProcess() noexcept -> void
 {
     // get all the memory _we_ need
     const auto result = ::score::os::Mman::instance().mmap(nullptr,
-                                                         virtual_address_space_to_reserve_,
-                                                         this->map_mode_,
-                                                         ::score::os::Mman::Map::kShared,
-                                                         this->file_descriptor_,
-                                                         0);
+                                                           virtual_address_space_to_reserve_,
+                                                           this->map_mode_,
+                                                           ::score::os::Mman::Map::kShared,
+                                                           this->file_descriptor_,
+                                                           0);
 
     if (!result.has_value())
     {
         score::mw::log::LogFatal("shm") << __func__ << __LINE__
-                                      << "Unexpected error while mapping memory into process for" << log_identification_
-                                      << "with errno" << result.error() << ". Terminating.";
+                                        << "Unexpected error while mapping memory into process for"
+                                        << log_identification_ << "with errno" << result.error() << ". Terminating.";
         std::terminate();
     }
 
@@ -964,11 +975,11 @@ score::cpp::expected_blank<score::os::Error> SharedMemoryResource::CreateLockFil
     lock_file = LockFile::Create(this->lock_file_path_.value());
     if (!lock_file.has_value())
     {
-        score::mw::log::LogWarn("shm") << __func__ << __LINE__
-                                     << "Unexpected error while creating Shared Memory Resource with"
-                                     << log_identification_
-                                     << ". The lock file is already locked indicating that the shared memory region is "
-                                        "already being created.";
+        score::mw::log::LogWarn("shm")
+            << __func__ << __LINE__ << "Unexpected error while creating Shared Memory Resource with"
+            << log_identification_
+            << ". The lock file is already locked indicating that the shared memory region is "
+               "already being created.";
         return score::cpp::make_unexpected(Error::createFromErrno(EBUSY));
     }
     return {};
@@ -1005,8 +1016,8 @@ void SharedMemoryResource::AllocateInTypedMemory(const UserPermissions& permissi
         {
             is_shm_in_typed_memory_ = true;
             file_descriptor_ = allocate_anonymous_typed_memory_result.value();
-            score::mw::log::LogInfo("shm") << __func__ << __LINE__
-                                         << "Successfully allocated anonymous shared-memory in typed memory";
+            score::mw::log::LogInfo("shm")
+                << __func__ << __LINE__ << "Successfully allocated anonymous shared-memory in typed memory";
         }
         else
         {
@@ -1019,7 +1030,7 @@ void SharedMemoryResource::AllocateInTypedMemory(const UserPermissions& permissi
 }
 
 score::cpp::expected_blank<score::os::Error> SharedMemoryResource::OpenSharedMemory(const Fcntl::Open& flags,
-                                                                           Stat::Mode mode) noexcept
+                                                                                    Stat::Mode mode) noexcept
 {
     const auto* const path = std::get_if<std::string>(&shared_memory_resource_identifier_);
     if (path != nullptr)
@@ -1039,7 +1050,7 @@ score::cpp::expected_blank<score::os::Error> SharedMemoryResource::OpenSharedMem
             else
             {
                 score::mw::log::LogFatal("shm") << "Unexpected error while opening shared-memory Resource using"
-                                              << log_identification_ << "with errno" << result.error();
+                                                << log_identification_ << "with errno" << result.error();
                 std::terminate();
             }
         }
@@ -1056,7 +1067,7 @@ score::cpp::expected_blank<score::os::Error> SharedMemoryResource::OpenSharedMem
             if (!shm_open_result.has_value())
             {
                 score::mw::log::LogFatal("shm") << "Unexpected error while opening anonymous shared-memory Resource"
-                                              << "with errno" << shm_open_result.error();
+                                                << "with errno" << shm_open_result.error();
                 std::terminate();
             }
             else

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -61,7 +61,12 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     SharedMemoryResource& operator=(SharedMemoryResource&&) = delete;
 
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
     const MemoryResourceProxy* getMemoryResourceProxy() noexcept override;
+    // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override;
 
     /**
      * @brief Get the start address of the memory region that this memory resource is managing
@@ -343,15 +348,15 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     /// \return in case of error an score::os::Error is returned.
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     score::cpp::expected_blank<score::os::Error> CreateImpl(const std::size_t user_space_to_reserve,
-                                                   const InitializeCallback initialize_callback,
-                                                   const UserPermissions& permissions) noexcept;
+                                                            const InitializeCallback initialize_callback,
+                                                            const UserPermissions& permissions) noexcept;
 
     /// \brief Called by SharedMemoryResource::CreateOrOpen() after calling the constructor.
     /// \return in case of error an score::os::Error is returned.
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     score::cpp::expected_blank<score::os::Error> CreateOrOpenImpl(const std::size_t user_space_to_reserve,
-                                                         InitializeCallback initialize_callback,
-                                                         const UserPermissions& permissions) noexcept;
+                                                                  InitializeCallback initialize_callback,
+                                                                  const UserPermissions& permissions) noexcept;
 
     /// \brief Called by SharedMemoryResource::Open() after calling the constructor.
     /// \details Despite being an "open" operation, this method creates a temporary lock file to prevent a race
@@ -421,7 +426,8 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     bool do_is_equal(const memory_resource& other) const noexcept override;
 
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-    score::cpp::expected_blank<score::os::Error> CreateLockFileForNamedSharedMemory(std::optional<LockFile>& lock_file) noexcept;
+    score::cpp::expected_blank<score::os::Error> CreateLockFileForNamedSharedMemory(
+        std::optional<LockFile>& lock_file) noexcept;
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     void AllocateInTypedMemory(const UserPermissions& permissions, os::Fcntl::Open& flags) noexcept;
 
@@ -447,7 +453,8 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     /// \todo This method needs refactoring
     /// \return Empty result in case of success, score::os::Error in case of error.
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-    score::cpp::expected_blank<score::os::Error> OpenSharedMemory(const os::Fcntl::Open& flags, os::Stat::Mode mode) noexcept;
+    score::cpp::expected_blank<score::os::Error> OpenSharedMemory(const os::Fcntl::Open& flags,
+                                                                  os::Stat::Mode mode) noexcept;
     void SealAnonymousOrReserveNamedSharedMemory() noexcept;
 };
 

--- a/score/memory/shared/shared_memory_resource_heap_allocator_mock.h
+++ b/score/memory/shared/shared_memory_resource_heap_allocator_mock.h
@@ -46,6 +46,14 @@ class SharedMemoryResourceHeapAllocatorMock : public ISharedMemoryResource
 
     MOCK_METHOD(std::string_view, GetIdentifier, (), (const, noexcept, override));
 
+    const MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
+    {
+        return resource_.getMemoryResourceProxy();
+    }
+
+    [[deprecated(
+        "SCORE_DEPRECATION: Please use const getMemoryResourceProxy() const noexcept instead, which is the "
+        "non-deprecated version of this function. This function will be removed in a future release.")]]
     const MemoryResourceProxy* getMemoryResourceProxy() noexcept override
     {
         return resource_.getMemoryResourceProxy();

--- a/score/memory/shared/shared_memory_resource_mock.h
+++ b/score/memory/shared/shared_memory_resource_mock.h
@@ -14,8 +14,8 @@
 #define SCORE_LIB_MEMORY_SHARED_SHARED_MEMORY_RESOURCE_MOCK_H
 
 #include "score/memory/shared/i_shared_memory_resource.h"
-#include <score/memory_resource.hpp>
 #include <gmock/gmock.h>
+#include <score/memory_resource.hpp>
 
 #include <string>
 
@@ -25,7 +25,9 @@ namespace score::memory::shared
 class SharedMemoryResourceMock : public ISharedMemoryResource
 {
   public:
-    MOCK_METHOD(MemoryResourceProxy*, getMemoryResourceProxy, (), (noexcept, override));
+    MOCK_METHOD(const MemoryResourceProxy*, getMemoryResourceProxy, (), (noexcept, override));
+
+    MOCK_METHOD(const MemoryResourceProxy*, getMemoryResourceProxy, (), (const, noexcept, override));
 
     MOCK_METHOD(void*, getBaseAddress, (), (const, noexcept, override));
 

--- a/score/memory/shared/shared_memory_test_resources.cpp
+++ b/score/memory/shared/shared_memory_test_resources.cpp
@@ -95,7 +95,7 @@ const void* ManagedMemoryResourceTestAttorney::getEndAddress() const noexcept
 
 const MemoryResourceProxy* ManagedMemoryResourceTestAttorney::getMemoryResourceProxy() const noexcept
 {
-    return resource_.getMemoryResourceProxy();
+    return std::as_const(resource_).getMemoryResourceProxy();
 }
 
 SharedMemoryResourceTestAttorney::SharedMemoryResourceTestAttorney(SharedMemoryResource& resource) noexcept


### PR DESCRIPTION
initially this was created in score but, this was failing here with following err
<img width="1368" height="509" alt="image" src="https://github.com/user-attachments/assets/d818aba7-acbc-48e5-94cb-2c52e8b4a70f" />

now the internal repo is just an alias to score symbols, creating a PR here again.



mw::com PR : https://github.com/eclipse-score/communication/pull/314