### PR TITLE
Add bounded lock-free allocation using atomic bump pointer

### DIFF
--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -688,49 +688,87 @@ auto SharedMemoryResource::getMemoryResourceProxy() noexcept -> const MemoryReso
 
 auto SharedMemoryResource::do_allocate(const std::size_t bytes, const std::size_t alignment) -> void*
 {
-    std::lock_guard<score::os::InterprocessMutex> lock(this->control_block_->mutex);
     /**
      * For the proof of concept we agreed to use a monotonic allocation algorithm.
      * So there is no need for any fancy logic.
+     *
+     * The bump pointer (alreadyAllocatedBytes) is advanced with a lock-free compare-exchange
+     * loop instead of a process-shared mutex. This keeps concurrent allocations correct even
+     * when several processes -- or several VMs sharing a single physical region such as a QEMU
+     * ivshmem PCI BAR -- allocate at the same time, and it removes the process-shared pthread
+     * mutex, which cannot be locked on device memory and cannot synchronize separate kernels.
      */
-    const std::size_t already_allocated_bytes = this->control_block_->alreadyAllocatedBytes.load();
-    void* const allocation_start_address =
-        // In our architecture we have a one-to-one mapping between pointers and integral values.
-        // Therefore, casting between the two is well-defined.
-        // The base_adress_ points to the start of the memory arena for the allocation and alreadyAllocatedBytes is
-        // ensured by this class to not exceed the size of the memory arena.
-        // Therefore, the resulting pointer will always point into the memory arena.
-        // In C++23 std::start_lifetime_as_array can be used to inform the compiler.
-        // NOLINTNEXTLINE(score-banned-function) see above
-        AddOffsetToPointer(this->base_address_, already_allocated_bytes);
+
+    constexpr std::size_t max_retries = 32U;
+
     // In our architecture we have a one-to-one mapping between pointers and integral values.
     // Therefore, casting between the two is well-defined.
     // This pointer is not dereferenced.
     // NOLINTNEXTLINE(score-banned-function) see above
     void* const allocation_end_address = AddOffsetToPointer(this->base_address_, virtual_address_space_to_reserve_);
-    void* const new_address_aligned =
-        detail::do_allocation_algorithm(allocation_start_address, allocation_end_address, bytes, alignment);
 
-    if (new_address_aligned == nullptr)
+    std::size_t already_allocated_bytes =
+        this->control_block_->alreadyAllocatedBytes.load(std::memory_order_acquire);
+
+    for (std::size_t retry_count = 0U; retry_count < max_retries; ++retry_count)
     {
-        score::mw::log::LogFatal("shm")
-            << "Cannot allocate shared memory block of size" << bytes << "with alignment " << alignment
-            << " at: ["
-            // In our architecture we have a one-to-one mapping between pointers and integral values.
-            // Therefore, casting between the two is well-defined.
-            // The resulting pointer is used for logging and is not dereferenced.
+        void* const allocation_start_address =
+            // The base_address_ points to the start of the memory arena for the allocation and
+            // alreadyAllocatedBytes is ensured by this class to not exceed the size of the memory arena.
+            // Therefore, the resulting pointer will always point into the memory arena.
             // NOLINTNEXTLINE(score-banned-function) see above
-            << PointerToLogValue(allocation_start_address) << ":" << PointerToLogValue(allocation_end_address)
-            << "]. Does not fit within shared memory segment: [" << PointerToLogValue(this->base_address_) << ":"
-            << PointerToLogValue(this->getEndAddress()) << "]. Already allocated bytes: " << already_allocated_bytes
-            << ". Virtual address space to reserve: " << virtual_address_space_to_reserve_;
-        std::terminate();
-    }
-    const auto padding = SubtractPointersBytes(new_address_aligned, allocation_start_address);
+            AddOffsetToPointer(this->base_address_, already_allocated_bytes);
 
-    const auto total_allocated_bytes = safe_math::Add(bytes, padding).value();
-    this->control_block_->alreadyAllocatedBytes += total_allocated_bytes;
-    return new_address_aligned;
+        void* const new_address_aligned =
+            detail::do_allocation_algorithm(allocation_start_address,
+                                            allocation_end_address,
+                                            bytes,
+                                            alignment);
+
+        if (new_address_aligned == nullptr)
+        {
+            score::mw::log::LogFatal("shm")
+                << "Cannot allocate shared memory block of size " << bytes
+                << " with alignment " << alignment
+                << " at: ["
+                // The resulting pointer is used for logging and is not dereferenced.
+                // NOLINTNEXTLINE(score-banned-function) see above
+                << PointerToLogValue(allocation_start_address) << ":"
+                << PointerToLogValue(allocation_end_address)
+                << "]. Does not fit within shared memory segment: ["
+                << PointerToLogValue(this->base_address_) << ":"
+                << PointerToLogValue(this->getEndAddress())
+                << "]. Already allocated bytes: " << already_allocated_bytes
+                << ". Virtual address space to reserve: "
+                << virtual_address_space_to_reserve_;
+            std::terminate();
+        }
+
+        const auto padding =
+            SubtractPointersBytes(new_address_aligned, allocation_start_address);
+
+        const auto total_allocated_bytes =
+            safe_math::Add(bytes, padding).value();
+
+        const std::size_t new_already_allocated_bytes =
+            safe_math::Add(already_allocated_bytes, total_allocated_bytes).value();
+
+        // Atomically publish the advanced bump pointer. If another allocator updated the
+        // bump pointer first, compare_exchange_weak updates already_allocated_bytes with the
+        // latest value and the next loop iteration recalculates the allocation.
+        if (this->control_block_->alreadyAllocatedBytes.compare_exchange_weak(
+                already_allocated_bytes,
+                new_already_allocated_bytes,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire))
+        {
+            return new_address_aligned;
+        }
+    }
+
+    score::mw::log::LogFatal("shm")
+        << "Failed to reserve shared memory after " << max_retries << " attempts.";
+    std::terminate();
 }
 
 auto SharedMemoryResource::getBaseAddress() const noexcept -> void*

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -377,7 +377,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     class ControlBlock
     {
       public:
-        explicit ControlBlock(const std::size_t id) noexcept : mutex{}, alreadyAllocatedBytes{}, memoryResourceProxy{id}
+        explicit ControlBlock(const std::size_t id) noexcept : alreadyAllocatedBytes{}, memoryResourceProxy{id}
         {
         }
 
@@ -385,8 +385,6 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
         // be private.".
         // Rationale: There are no class invariants to maintain which could be violated by directly accessing these
         // member variables.
-        // coverity[autosar_cpp14_m11_0_1_violation]
-        score::os::InterprocessMutex mutex;
         // coverity[autosar_cpp14_m11_0_1_violation]
         std::atomic<std::size_t> alreadyAllocatedBytes;
         // coverity[autosar_cpp14_m11_0_1_violation]


### PR DESCRIPTION
- Replace InterprocessMutex protection with compare_exchange_weak
- Limit CAS attempts to 32 for deterministic execution
- Handle allocation failure after retry exhaustion

Issue: https://github.com/eclipse-score/baselibs/issues/348