### PR TITLE
containers_rust: remove &'alloc from allocator use

### DIFF
--- a/score/containers_rust/fixed_capacity/queue.rs
+++ b/score/containers_rust/fixed_capacity/queue.rs
@@ -22,11 +22,11 @@ use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 ///
 /// The queue can hold between 0 and `CAPACITY` elements, and behaves similarly to Rust's `VecDeque`,
 /// except that it allocates memory immediately on construction, and can't shrink or grow.
-pub struct FixedCapacityQueueIn<'alloc, T, A: BasicAllocator> {
-    inner: GenericQueue<T, Heap<'alloc, T, A>>,
+pub struct FixedCapacityQueueIn<T, A: BasicAllocator> {
+    inner: GenericQueue<T, Heap<T, A>>,
 }
 
-impl<'alloc, T, A: BasicAllocator> FixedCapacityQueueIn<'alloc, T, A> {
+impl<T, A: BasicAllocator> FixedCapacityQueueIn<T, A> {
     /// Creates an empty queue and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
     ///
     /// # Panics
@@ -34,7 +34,7 @@ impl<'alloc, T, A: BasicAllocator> FixedCapacityQueueIn<'alloc, T, A> {
     /// - Panics if `capacity > u32::MAX`.
     /// - Panics if the memory allocation fails.
     #[must_use]
-    pub fn new(capacity: usize, alloc: &'alloc A) -> Self {
+    pub fn new(capacity: usize, alloc: A) -> Self {
         assert!(
             capacity <= u32::MAX as usize,
             "FixedQueue can hold at most u32::MAX elements"
@@ -46,33 +46,33 @@ impl<'alloc, T, A: BasicAllocator> FixedCapacityQueueIn<'alloc, T, A> {
     }
 }
 
-impl<T, A: BasicAllocator> Drop for FixedCapacityQueueIn<'_, T, A> {
+impl<T, A: BasicAllocator> Drop for FixedCapacityQueueIn<T, A> {
     fn drop(&mut self) {
         self.inner.clear();
     }
 }
 
-impl<'alloc, T, A: BasicAllocator> ops::Deref for FixedCapacityQueueIn<'alloc, T, A> {
-    type Target = GenericQueue<T, Heap<'alloc, T, A>>;
+impl<T, A: BasicAllocator> ops::Deref for FixedCapacityQueueIn<T, A> {
+    type Target = GenericQueue<T, Heap<T, A>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<T, A: BasicAllocator> ops::DerefMut for FixedCapacityQueueIn<'_, T, A> {
+impl<T, A: BasicAllocator> ops::DerefMut for FixedCapacityQueueIn<T, A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<T: fmt::Debug, A: BasicAllocator> fmt::Debug for FixedCapacityQueueIn<'_, T, A> {
+impl<T: fmt::Debug, A: BasicAllocator> fmt::Debug for FixedCapacityQueueIn<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.inner, f)
     }
 }
 
-impl<T: ScoreDebug, A: BasicAllocator> ScoreDebug for FixedCapacityQueueIn<'_, T, A> {
+impl<T: ScoreDebug, A: BasicAllocator> ScoreDebug for FixedCapacityQueueIn<T, A> {
     fn fmt(&self, f: Writer, spec: &FormatSpec) -> ScoreLogResult {
         ScoreDebug::fmt(&self.inner, f, spec)
     }
@@ -80,7 +80,7 @@ impl<T: ScoreDebug, A: BasicAllocator> ScoreDebug for FixedCapacityQueueIn<'_, T
 
 /// A fixed-capacity queue, using global allocator.
 /// Refer to [`FixedCapacityQueueIn`] for more information.
-pub struct FixedCapacityQueue<T>(FixedCapacityQueueIn<'static, T, HeapAllocator>);
+pub struct FixedCapacityQueue<T>(FixedCapacityQueueIn<T, HeapAllocator>);
 
 impl<T> FixedCapacityQueue<T> {
     /// Creates an empty queue and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
@@ -91,12 +91,12 @@ impl<T> FixedCapacityQueue<T> {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        Self(FixedCapacityQueueIn::new(capacity, &GLOBAL_ALLOCATOR))
+        Self(FixedCapacityQueueIn::new(capacity, GLOBAL_ALLOCATOR))
     }
 }
 
 impl<T> ops::Deref for FixedCapacityQueue<T> {
-    type Target = GenericQueue<T, Heap<'static, T, HeapAllocator>>;
+    type Target = GenericQueue<T, Heap<T, HeapAllocator>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0.inner

--- a/score/containers_rust/fixed_capacity/string.rs
+++ b/score/containers_rust/fixed_capacity/string.rs
@@ -24,11 +24,11 @@ use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 ///
 /// The string can hold between 0 and `CAPACITY` **bytes**, and behaves similarly to Rust's `String`,
 /// except that it allocates memory immediately on construction, and can't shrink or grow.
-pub struct FixedCapacityStringIn<'alloc, A: BasicAllocator> {
-    inner: GenericString<Heap<'alloc, u8, A>>,
+pub struct FixedCapacityStringIn<A: BasicAllocator> {
+    inner: GenericString<Heap<u8, A>>,
 }
 
-impl<'alloc, A: BasicAllocator> FixedCapacityStringIn<'alloc, A> {
+impl<A: BasicAllocator> FixedCapacityStringIn<A> {
     /// Creates an empty string and allocates memory for up to `capacity` bytes, where `capacity <= u32::MAX`.
     ///
     /// Note that the string is encoded as UTF-8, so each character (Unicode codepoint) requires between 1 and 4 bytes of storage.
@@ -38,7 +38,7 @@ impl<'alloc, A: BasicAllocator> FixedCapacityStringIn<'alloc, A> {
     /// - Panics if `capacity > u32::MAX`.
     /// - Panics if the memory allocation fails.
     #[must_use]
-    pub fn new(capacity: usize, alloc: &'alloc A) -> Self {
+    pub fn new(capacity: usize, alloc: A) -> Self {
         assert!(
             capacity <= u32::MAX as usize,
             "FixedCapacityString can hold at most u32::MAX bytes"
@@ -55,7 +55,7 @@ impl<'alloc, A: BasicAllocator> FixedCapacityStringIn<'alloc, A> {
     ///
     /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
     #[must_use]
-    pub fn try_new(capacity: usize, alloc: &'alloc A) -> Option<Self> {
+    pub fn try_new(capacity: usize, alloc: A) -> Option<Self> {
         if capacity <= u32::MAX as usize {
             let storage = Heap::try_new(capacity as u32, alloc)?;
             let inner = GenericString::new(storage);
@@ -66,39 +66,39 @@ impl<'alloc, A: BasicAllocator> FixedCapacityStringIn<'alloc, A> {
     }
 }
 
-impl<A: BasicAllocator> Drop for FixedCapacityStringIn<'_, A> {
+impl<A: BasicAllocator> Drop for FixedCapacityStringIn<A> {
     fn drop(&mut self) {
         self.inner.clear();
     }
 }
 
-impl<'alloc, A: BasicAllocator> ops::Deref for FixedCapacityStringIn<'alloc, A> {
-    type Target = GenericString<Heap<'alloc, u8, A>>;
+impl<A: BasicAllocator> ops::Deref for FixedCapacityStringIn<A> {
+    type Target = GenericString<Heap<u8, A>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<A: BasicAllocator> ops::DerefMut for FixedCapacityStringIn<'_, A> {
+impl<A: BasicAllocator> ops::DerefMut for FixedCapacityStringIn<A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<A: BasicAllocator> fmt::Display for FixedCapacityStringIn<'_, A> {
+impl<A: BasicAllocator> fmt::Display for FixedCapacityStringIn<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
     }
 }
 
-impl<A: BasicAllocator> fmt::Debug for FixedCapacityStringIn<'_, A> {
+impl<A: BasicAllocator> fmt::Debug for FixedCapacityStringIn<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_str(), f)
     }
 }
 
-impl<A: BasicAllocator> ScoreDebug for FixedCapacityStringIn<'_, A> {
+impl<A: BasicAllocator> ScoreDebug for FixedCapacityStringIn<A> {
     fn fmt(&self, f: Writer, spec: &FormatSpec) -> ScoreLogResult {
         ScoreDebug::fmt(self.as_str(), f, spec)
     }
@@ -106,7 +106,7 @@ impl<A: BasicAllocator> ScoreDebug for FixedCapacityStringIn<'_, A> {
 
 /// A fixed-capacity Unicode string, using global allocator.
 /// Refer to [`FixedCapacityStringIn`] for more information.
-pub struct FixedCapacityString(FixedCapacityStringIn<'static, HeapAllocator>);
+pub struct FixedCapacityString(FixedCapacityStringIn<HeapAllocator>);
 
 impl FixedCapacityString {
     /// Creates an empty string and allocates memory for up to `capacity` bytes, where `capacity <= u32::MAX`.
@@ -119,7 +119,7 @@ impl FixedCapacityString {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        Self(FixedCapacityStringIn::new(capacity, &GLOBAL_ALLOCATOR))
+        Self(FixedCapacityStringIn::new(capacity, GLOBAL_ALLOCATOR))
     }
 
     /// Tries to create an empty string for up to `capacity` bytes, where `capacity <= u32::MAX`.
@@ -129,13 +129,13 @@ impl FixedCapacityString {
     /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
     #[must_use]
     pub fn try_new(capacity: usize) -> Option<Self> {
-        let inner = FixedCapacityStringIn::try_new(capacity, &GLOBAL_ALLOCATOR)?;
+        let inner = FixedCapacityStringIn::try_new(capacity, GLOBAL_ALLOCATOR)?;
         Some(Self(inner))
     }
 }
 
 impl ops::Deref for FixedCapacityString {
-    type Target = GenericString<Heap<'static, u8, HeapAllocator>>;
+    type Target = GenericString<Heap<u8, HeapAllocator>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0.inner

--- a/score/containers_rust/fixed_capacity/vec.rs
+++ b/score/containers_rust/fixed_capacity/vec.rs
@@ -22,11 +22,11 @@ use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 ///
 /// The vector can hold between 0 and `capacity` elements, and behaves similarly to Rust's `Vec`,
 /// except that it allocates memory immediately on construction, and can't shrink or grow.
-pub struct FixedCapacityVecIn<'alloc, T, A: BasicAllocator> {
-    inner: GenericVec<T, Heap<'alloc, T, A>>,
+pub struct FixedCapacityVecIn<T, A: BasicAllocator> {
+    inner: GenericVec<T, Heap<T, A>>,
 }
 
-impl<'alloc, T, A: BasicAllocator> FixedCapacityVecIn<'alloc, T, A> {
+impl<T, A: BasicAllocator> FixedCapacityVecIn<T, A> {
     /// Creates an empty vector and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
     ///
     /// # Panics
@@ -34,7 +34,7 @@ impl<'alloc, T, A: BasicAllocator> FixedCapacityVecIn<'alloc, T, A> {
     /// - Panics if `capacity > u32::MAX`.
     /// - Panics if the memory allocation fails.
     #[must_use]
-    pub fn new(capacity: usize, alloc: &'alloc A) -> Self {
+    pub fn new(capacity: usize, alloc: A) -> Self {
         assert!(
             capacity <= u32::MAX as usize,
             "FixedCapacityVec can hold at most u32::MAX elements"
@@ -49,7 +49,7 @@ impl<'alloc, T, A: BasicAllocator> FixedCapacityVecIn<'alloc, T, A> {
     ///
     /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
     #[must_use]
-    pub fn try_new(capacity: usize, alloc: &'alloc A) -> Option<Self> {
+    pub fn try_new(capacity: usize, alloc: A) -> Option<Self> {
         if capacity <= u32::MAX as usize {
             let storage = Heap::try_new(capacity as u32, alloc)?;
             let inner = GenericVec::new(storage);
@@ -60,33 +60,33 @@ impl<'alloc, T, A: BasicAllocator> FixedCapacityVecIn<'alloc, T, A> {
     }
 }
 
-impl<T, A: BasicAllocator> Drop for FixedCapacityVecIn<'_, T, A> {
+impl<T, A: BasicAllocator> Drop for FixedCapacityVecIn<T, A> {
     fn drop(&mut self) {
         self.inner.clear();
     }
 }
 
-impl<'alloc, T, A: BasicAllocator> ops::Deref for FixedCapacityVecIn<'alloc, T, A> {
-    type Target = GenericVec<T, Heap<'alloc, T, A>>;
+impl<T, A: BasicAllocator> ops::Deref for FixedCapacityVecIn<T, A> {
+    type Target = GenericVec<T, Heap<T, A>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<T, A: BasicAllocator> ops::DerefMut for FixedCapacityVecIn<'_, T, A> {
+impl<T, A: BasicAllocator> ops::DerefMut for FixedCapacityVecIn<T, A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<T: fmt::Debug, A: BasicAllocator> fmt::Debug for FixedCapacityVecIn<'_, T, A> {
+impl<T: fmt::Debug, A: BasicAllocator> fmt::Debug for FixedCapacityVecIn<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_slice(), f)
     }
 }
 
-impl<T: ScoreDebug, A: BasicAllocator> ScoreDebug for FixedCapacityVecIn<'_, T, A> {
+impl<T: ScoreDebug, A: BasicAllocator> ScoreDebug for FixedCapacityVecIn<T, A> {
     fn fmt(&self, f: Writer, spec: &FormatSpec) -> ScoreLogResult {
         ScoreDebug::fmt(self.as_slice(), f, spec)
     }
@@ -94,7 +94,7 @@ impl<T: ScoreDebug, A: BasicAllocator> ScoreDebug for FixedCapacityVecIn<'_, T, 
 
 /// A fixed-capacity vector, using global allocator.
 /// Refer to [`FixedCapacityVecIn`] for more information.
-pub struct FixedCapacityVec<T>(FixedCapacityVecIn<'static, T, HeapAllocator>);
+pub struct FixedCapacityVec<T>(FixedCapacityVecIn<T, HeapAllocator>);
 
 impl<T> FixedCapacityVec<T> {
     /// Creates an empty vector and allocates memory for up to `capacity` elements, where `capacity <= u32::MAX`.
@@ -105,7 +105,7 @@ impl<T> FixedCapacityVec<T> {
     /// - Panics if the memory allocation fails.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        Self(FixedCapacityVecIn::new(capacity, &GLOBAL_ALLOCATOR))
+        Self(FixedCapacityVecIn::new(capacity, GLOBAL_ALLOCATOR))
     }
 
     /// Tries to create an empty vector for up to `capacity` elements, where `capacity <= u32::MAX`.
@@ -113,13 +113,13 @@ impl<T> FixedCapacityVec<T> {
     /// Returns `None` if `capacity > u32::MAX`, or if the memory allocation fails.
     #[must_use]
     pub fn try_new(capacity: usize) -> Option<Self> {
-        let inner = FixedCapacityVecIn::try_new(capacity, &GLOBAL_ALLOCATOR)?;
+        let inner = FixedCapacityVecIn::try_new(capacity, GLOBAL_ALLOCATOR)?;
         Some(Self(inner))
     }
 }
 
 impl<T> ops::Deref for FixedCapacityVec<T> {
-    type Target = GenericVec<T, Heap<'static, T, HeapAllocator>>;
+    type Target = GenericVec<T, Heap<T, HeapAllocator>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0.inner

--- a/score/containers_rust/storage/heap.rs
+++ b/score/containers_rust/storage/heap.rs
@@ -20,7 +20,7 @@ use core::ptr;
 use core::ptr::NonNull;
 
 /// Fixed-capacity, heap-allocated storage.
-pub struct Heap<'alloc, T, A: BasicAllocator> {
+pub struct Heap<T, A: BasicAllocator> {
     /// Allocated capacity, in number of elements.
     capacity: u32,
     /// Pointer to the allocated memory.
@@ -28,14 +28,14 @@ pub struct Heap<'alloc, T, A: BasicAllocator> {
     /// If `self.capacity > 0`, this points to an allocated memory area of size `self.capacity * size_of<T>` and alignment `align_of<T>`.
     elements: NonNull<T>,
     /// Allocator used by the storage.
-    alloc: &'alloc A,
+    alloc: A,
     _marker: PhantomData<T>,
 }
 
 // SAFETY: `Heap<T>` can be sent to another thread if `T` can be sent to another thread and used allocator is send-safe.
-unsafe impl<T: Send, A: BasicAllocator + Send> Send for Heap<'_, T, A> {}
+unsafe impl<T: Send, A: BasicAllocator + Send> Send for Heap<T, A> {}
 
-impl<T, A: BasicAllocator> Heap<'_, T, A> {
+impl<T, A: BasicAllocator> Heap<T, A> {
     fn layout(capacity: u32) -> Option<Layout> {
         (capacity as usize)
             .checked_mul(size_of::<T>())
@@ -43,13 +43,13 @@ impl<T, A: BasicAllocator> Heap<'_, T, A> {
     }
 }
 
-impl<'alloc, T, A: BasicAllocator> Heap<'alloc, T, A> {
+impl<T, A: BasicAllocator> Heap<T, A> {
     /// Creates a new instance with capacity for exactly the given number of elements.
     ///
     /// # Panics
     ///
     /// Panics if the memory allocation failed.
-    pub fn new(capacity: u32, alloc: &'alloc A) -> Self {
+    pub fn new(capacity: u32, alloc: A) -> Self {
         Self::try_new(capacity, alloc).unwrap_or_else(|| {
             panic!(
                 "failed to allocate {capacity} elements of {typ}",
@@ -61,7 +61,7 @@ impl<'alloc, T, A: BasicAllocator> Heap<'alloc, T, A> {
     /// Tries to create a new instance with capacity for exactly the given number of elements.
     ///
     /// Returns `None` if the memory allocation failed.
-    pub fn try_new(capacity: u32, alloc: &'alloc A) -> Option<Self> {
+    pub fn try_new(capacity: u32, alloc: A) -> Option<Self> {
         let storage = if capacity > 0 {
             let layout = Self::layout(capacity)?;
             // SAFETY: `layout` has a non-zero size (because `capacity` is > 0)
@@ -78,7 +78,7 @@ impl<'alloc, T, A: BasicAllocator> Heap<'alloc, T, A> {
     }
 }
 
-impl<T, A: BasicAllocator> Storage<T> for Heap<'_, T, A> {
+impl<T, A: BasicAllocator> Storage<T> for Heap<T, A> {
     fn capacity(&self) -> u32 {
         self.capacity
     }
@@ -122,7 +122,7 @@ impl<T, A: BasicAllocator> Storage<T> for Heap<'_, T, A> {
     }
 }
 
-impl<T, A: BasicAllocator> Drop for Heap<'_, T, A> {
+impl<T, A: BasicAllocator> Drop for Heap<T, A> {
     fn drop(&mut self) {
         if self.capacity > 0 {
             let layout = Self::layout(self.capacity).unwrap();
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn subslice() {
         fn run_test(capacity: u32) {
-            let instance = Heap::<T, _>::new(capacity, &GLOBAL_ALLOCATOR);
+            let instance = Heap::<T, _>::new(capacity, GLOBAL_ALLOCATOR);
 
             let empty_slice = unsafe { instance.subslice(0, 0) };
             assert_eq!(empty_slice.len(), 0);
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn subslice_mut() {
         fn run_test(capacity: u32) {
-            let mut instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
+            let mut instance = Heap::<T, HeapAllocator>::new(capacity, GLOBAL_ALLOCATOR);
 
             let empty_slice = unsafe { instance.subslice_mut(0, 0) };
             assert_eq!(empty_slice.len(), 0);
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn element() {
         fn run_test(capacity: u32) {
-            let instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
+            let instance = Heap::<T, HeapAllocator>::new(capacity, GLOBAL_ALLOCATOR);
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element(0) };
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn element_mut() {
         fn run_test(capacity: u32) {
-            let mut instance = Heap::<T, HeapAllocator>::new(capacity, &GLOBAL_ALLOCATOR);
+            let mut instance = Heap::<T, HeapAllocator>::new(capacity, GLOBAL_ALLOCATOR);
 
             if capacity >= 1 {
                 let first_element = unsafe { instance.element_mut(0) };


### PR DESCRIPTION
Previous implementation caused 'alloc lifetime to propagate.