### PR TITLE
score_log: score_log for sync and allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,6 +5,9 @@ version = 4
 [[package]]
 name = "allocator"
 version = "0.0.1"
+dependencies = [
+ "score_log",
+]
 
 [[package]]
 name = "containers"
@@ -109,6 +112,7 @@ name = "sync"
 version = "0.0.1"
 dependencies = [
  "allocator",
+ "score_log",
 ]
 
 [[package]]

--- a/score/allocator/BUILD
+++ b/score/allocator/BUILD
@@ -18,6 +18,9 @@ rust_library(
     srcs = glob(["**/*.rs"]),
     edition = "2021",
     visibility = ["//visibility:public"],
+    deps = [
+        "//score/log_rust/score_log",
+    ],
 )
 
 rust_test(

--- a/score/allocator/Cargo.toml
+++ b/score/allocator/Cargo.toml
@@ -22,5 +22,8 @@ license-file.workspace = true
 [lib]
 path = "lib.rs"
 
+[dependencies]
+score_log.workspace = true
+
 [lints]
 workspace = true

--- a/score/allocator/allocator_traits.rs
+++ b/score/allocator/allocator_traits.rs
@@ -13,9 +13,10 @@
 
 use core::alloc::Layout;
 use core::ptr::NonNull;
+use score_log::ScoreDebug;
 
 /// Allocation errors.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, ScoreDebug, Clone, Copy)]
 pub enum AllocationError {
     /// Memory allocation failed due to insufficient memory.
     OutOfMemory,

--- a/score/allocator/heap_allocator.rs
+++ b/score/allocator/heap_allocator.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 use alloc::alloc::{alloc, dealloc};
 use core::alloc::Layout;
 use core::ptr::NonNull;
+use score_log::ScoreDebug;
 
 use crate::allocator_traits::{AllocationError, BasicAllocator};
 
@@ -23,7 +24,7 @@ use crate::allocator_traits::{AllocationError, BasicAllocator};
 pub static GLOBAL_ALLOCATOR: HeapAllocator = HeapAllocator;
 
 /// Proxy to global heap allocation in Rust.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, ScoreDebug, Default, Clone, Copy)]
 pub struct HeapAllocator;
 
 impl BasicAllocator for HeapAllocator {

--- a/score/sync/BUILD
+++ b/score/sync/BUILD
@@ -20,6 +20,7 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
         "//score/allocator",
+        "//score/log_rust/score_log",
     ],
 )
 

--- a/score/sync/Cargo.toml
+++ b/score/sync/Cargo.toml
@@ -23,7 +23,8 @@ license-file.workspace = true
 path = "lib.rs"
 
 [dependencies]
-allocator = { workspace = true }
+allocator.workspace = true
+score_log.workspace = true
 
 [lints]
 workspace = true

--- a/score/sync/arc_in.rs
+++ b/score/sync/arc_in.rs
@@ -13,12 +13,13 @@
 
 use core::alloc::Layout;
 use core::cmp::Ordering;
-use core::fmt;
+use core::fmt as core_fmt;
 use core::hash::{Hash, Hasher};
 use core::ops::Deref;
 use core::ptr::{drop_in_place, NonNull};
 use core::sync::atomic;
 use core::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+use score_log::fmt as score_fmt;
 
 use allocator::BasicAllocator;
 
@@ -96,9 +97,15 @@ impl<T: Default, A: BasicAllocator + Clone + Default> Default for ArcIn<T, A> {
     }
 }
 
-impl<T: fmt::Debug, A: BasicAllocator> fmt::Debug for ArcIn<T, A> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<T: core_fmt::Debug, A: BasicAllocator> core_fmt::Debug for ArcIn<T, A> {
+    fn fmt(&self, f: &mut core_fmt::Formatter<'_>) -> core_fmt::Result {
         self.deref().fmt(f)
+    }
+}
+
+impl<T: score_fmt::ScoreDebug, A: BasicAllocator> score_fmt::ScoreDebug for ArcIn<T, A> {
+    fn fmt(&self, f: score_fmt::Writer, spec: &score_fmt::FormatSpec) -> score_fmt::Result {
+        self.deref().fmt(f, spec)
     }
 }
 


### PR DESCRIPTION
Add `score_log` implementations to `sync` and `allocator`.