### PR TITLE
Refactor Bazel configuration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,41 +25,31 @@ common --http_timeout_scaling=2.0
 # directory is often deleted while the ANDROID_HOME environment variable remains set.
 common --action_env=ANDROID_HOME=""
 
+common --extra_toolchains=@score_gcc_x86_64_toolchain//:x86_64-linux-gcc_12.2.0
+common --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
+common --host_platform=@score_bazel_platforms//:x86_64-linux-gcc_12.2.0-posix
+common --//score/json:base_library=nlohmann
+common --//score/memory/shared/flags:use_typedshmd=False
+
 build --java_language_version=17
 build --tool_java_language_version=17
 build --java_runtime_version=remotejdk_17
 build --tool_java_runtime_version=remotejdk_17
 build --credential_helper="*.qnx.com=%workspace%/.github/tools/qnx_credential_helper.py"
+build --features=minimal_warnings --features=-strict_warnings --features=warnings_as_errors
+build --incompatible_strict_action_env
 
-# Ferrocene must be common compiler for HOST. To ensure metadata compatibility for proc macro crates!
-common --extra_toolchains=@score_gcc_x86_64_toolchain//:x86_64-linux-gcc_12.2.0
-common --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
-
-build:_bl_stub --//score/json:base_library=nlohmann
-build:_bl_stub --//score/memory/shared/flags:use_typedshmd=False
-
-build:_bl_stub --features=minimal_warnings --features=-strict_warnings --features=warnings_as_errors
-
-# Common baselibs flags for test
+# Common flags for tests
 test:_bl_common --build_tests_only
-test:_bl_common --test_tag_filters=-manual
-test:_bl_common --test_output=errors
-
-# Common BaseLibs Toolchain flags for build (do not use it in case of system toolchains!)
-build:_bl_toolchain_common --incompatible_strict_action_env
-build:_bl_toolchain_common --host_platform=@score_bazel_platforms//:x86_64-linux-gcc_12.2.0-posix
+test --test_output=errors
 
 # Target configuration for CPU:x86-64|OS:Linux build (do not use it in case of system toolchains!)
-build:bl-x86_64-linux --config=_bl_stub
-build:bl-x86_64-linux --config=_bl_toolchain_common
 build:bl-x86_64-linux --platforms=@score_bazel_platforms//:x86_64-linux-gcc_12.2.0-posix
 build:bl-x86_64-linux --extra_toolchains=@score_gcc_x86_64_toolchain//:x86_64-linux-gcc_12.2.0
 build:bl-x86_64-linux --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
 test:bl-x86_64-linux --config=_bl_common
 
 # Target configuration for CPU:AArch64|OS:Linux build (do not use it in case of system toolchains!)
-build:bl-aarch64-linux --config=_bl_stub
-build:bl-aarch64-linux --config=_bl_toolchain_common
 build:bl-aarch64-linux --platforms=@score_bazel_platforms//:aarch64-linux-gcc_12.2.0-posix
 build:bl-aarch64-linux --extra_toolchains=@score_gcc_aarch64_toolchain//:aarch64-linux-gcc_12.2.0
 build:bl-aarch64-linux --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_aarch64_unknown_linux_gnu
@@ -67,10 +57,7 @@ test:bl-aarch64-linux --config=_bl_common
 test:bl-aarch64-linux --test_timeout=300
 test:bl-aarch64-linux --run_under=//:qemu_aarch64
 
-
 # Target configuration for CPU:x86-64|OS:QNX build (do not use it in case of system toolchains!)
-build:bl-x86_64-qnx --config=_bl_stub
-build:bl-x86_64-qnx --config=_bl_toolchain_common
 build:bl-x86_64-qnx --platforms=@score_bazel_platforms//:x86_64-qnx-sdp_8.0.0-posix
 build:bl-x86_64-qnx --extra_toolchains=@score_qcc_x86_64_toolchain//:x86_64-qnx-sdp_8.0.0
 build:bl-x86_64-qnx --extra_toolchains=@score_qnx_x86_64_ifs_toolchain//:ifs-x86_64-qnx-sdp_8.0.0
@@ -81,9 +68,6 @@ test:bl-x86_64-qnx --test_tag_filters=
 test:bl-x86_64-qnx --test_lang_filters=cc,rust
 
 # Target configuration for CPU:AArch64|OS:QNX build (do not use it in case of system toolchains!)
-build:bl-aarch64-qnx --config=_bl_stub
-build:bl-aarch64-qnx --config=_bl_toolchain_common
-build:bl-aarch64-qnx --incompatible_strict_action_env
 build:bl-aarch64-qnx --platforms=@score_bazel_platforms//:aarch64-qnx-sdp_8.0.0-posix
 build:bl-aarch64-qnx --extra_toolchains=@score_qcc_aarch64_toolchain//:aarch64-qnx-sdp_8.0.0
 build:bl-aarch64-qnx --extra_toolchains=@score_qnx_aarch64_ifs_toolchain//:ifs-aarch64-qnx-sdp_8.0.0
@@ -126,11 +110,11 @@ test:asan_ubsan_lsan --platform_suffix=asan_ubsan_lsan
 test:asan_ubsan_lsan --test_env=ASAN_OPTIONS="exitcode=55 allow_addr2line=1 verbosity=1 coverage=1 check_initialization_order=1 detect_stack_use_after_return=1 print_stats=1 halt_on_error=1 allocator_may_return_null=1 detect_leaks=1"
 test:asan_ubsan_lsan --test_env=UBSAN_OPTIONS="exitcode=55 allow_addr2line=1 verbosity=1 coverage=1 print_stacktrace=1 halt_on_error=1"
 
-build:clang_tidy --config=_bl_stub
+# Clang-Tidy configuration for C++
 build:clang_tidy --@score_bazel_tools_cc//quality:quality_clang_tidy_config=//:clang_tidy_config
 build:clang_tidy --aspects=@score_bazel_tools_cc//quality:defs.bzl%quality_clang_tidy_aspect
 build:clang_tidy --build_tag_filters="-tidy_suite"
 build:clang_tidy --force_pic
-build:clang_tidy --incompatible_enable_cc_toolchain_resolution
 build:clang_tidy --output_groups=clang_tidy_output
+build:clang_tidy --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
 build:clang_tidy --verbose_failures

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -160,11 +160,6 @@ llvm.toolchain(
 )
 use_repo(llvm, "llvm_toolchain")
 
-register_toolchains(
-    "@llvm_toolchain//:all",
-    dev_dependency = True,
-)
-
 deb = use_repo_rule("@download_utils//download/deb:defs.bzl", "download_deb")
 
 deb(


### PR DESCRIPTION
- Do not register LLVM toolchain by default. Use it only for clang-tidy
- Clean bazelrc