### PR TITLE
Update baselibs component requirements for feature requirement changes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -125,6 +125,14 @@ git_override(
 
 bazel_dep(name = "score_platform", version = "0.6.2", dev_dependency = True)
 
+# Needed until a release of score_platform includes
+# https://github.com/eclipse-score/score/pull/3071 (merged to main).
+git_override(
+    module_name = "score_platform",
+    commit = "c97388c6da1f5b3233d4b73bffa196ff75e801cd",
+    remote = "https://github.com/eclipse-score/score",
+)
+
 ## Configure the python toolchain
 
 bazel_dep(name = "rules_python", version = "1.8.3", dev_dependency = True)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1025,8 +1025,6 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.6.0/MODULE.bazel": "d5fbfed7b9bd65f10830e2290045dea639a8cfcaf9f9f0f7a1b12888c14e7d2b",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.6.1/MODULE.bazel": "0dae734ea8a99970a7417829b3115af02717b29f0fc40a8ebd3c1afcc71e1e21",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.6.1/source.json": "3299daf219b15ba4aff6ca801385abebe0aaf364f71e391cd76cf9d38f3741f6",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_platform/0.6.2/MODULE.bazel": "e88e7d086a08e1b451a68b60038b8b1f3c028aae7efc0bc9d8b39b6261ba040d",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_platform/0.6.2/source.json": "87edd5be1382fec29c3276a7df3034d918f1d047e4814981d2ca725906460629",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_process/1.6.0/MODULE.bazel": "2496bc24311f69f49449ee85d8bb38e3b970cbfcf10d0a7f19b2d5262ce80e8d",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_process/2.0.1/MODULE.bazel": "88bff0ed46da79d87f8c441a6bf6b760ee7c194b282e7e54a8b7db6ea2354db9",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_process/2.0.1/source.json": "61a928568125351da7918bbf842a7237ac061e244bd25d4ab6147f76c4e336f1",

--- a/docs/baselibs/components/abi_compatible_data_types/docs/requirements/index.rst
+++ b/docs/baselibs/components/abi_compatible_data_types/docs/requirements/index.rst
@@ -36,9 +36,9 @@ Restrictions on Native Types
 .. comp_req:: Restrict boolean size
    :id: comp_req__abi_compatible_data_types__bool_sz
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -49,9 +49,9 @@ Restrictions on Native Types
 .. comp_req:: Fixed-width integers
    :id: comp_req__abi_compatible_data_types__int_fix
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -62,9 +62,9 @@ Restrictions on Native Types
 .. comp_req:: Limit floating-point sizes
    :id: comp_req__abi_compatible_data_types__flt_sz
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -75,9 +75,9 @@ Restrictions on Native Types
 .. comp_req:: Characters
    :id: comp_req__abi_compatible_data_types__char
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -88,9 +88,9 @@ Restrictions on Native Types
 .. comp_req:: Fixed-size arrays
    :id: comp_req__abi_compatible_data_types__arr_fix
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -101,9 +101,9 @@ Restrictions on Native Types
 .. comp_req:: Struct and tuple ABI layout
    :id: comp_req__abi_compatible_data_types__st_tpl
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -114,9 +114,9 @@ Restrictions on Native Types
 .. comp_req:: Explicit enum representation
    :id: comp_req__abi_compatible_data_types__enum_udr
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -127,9 +127,9 @@ Restrictions on Native Types
 .. comp_req:: Disallow pointers and metadata
    :id: comp_req__abi_compatible_data_types__nop_mt
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -140,9 +140,9 @@ Restrictions on Native Types
 .. comp_req:: Compiler-agnostic ABI
    :id: comp_req__abi_compatible_data_types__compabi
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -159,9 +159,9 @@ Vector
 .. comp_req:: Provide AbiVec<T,N>
    :id: comp_req__abi_compatible_data_types__prv_abv
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -189,9 +189,9 @@ Vector
 .. comp_req:: AbiVec field semantics
    :id: comp_req__abi_compatible_data_types__abv_fld
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -202,9 +202,9 @@ Vector
 .. comp_req:: AbiVec API
    :id: comp_req__abi_compatible_data_types__abv_noa
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -215,9 +215,9 @@ Vector
 .. comp_req:: AbiVec overflow check
    :id: comp_req__abi_compatible_data_types__abv_ovf
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -231,9 +231,9 @@ String
 .. comp_req:: Provide AbiString<N>
    :id: comp_req__abi_compatible_data_types__prv_abs
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -261,9 +261,9 @@ String
 .. comp_req:: AbiString field semantics
    :id: comp_req__abi_compatible_data_types__abs_fld
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -274,9 +274,9 @@ String
 .. comp_req:: AbiString API
    :id: comp_req__abi_compatible_data_types__abs_noa
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -287,9 +287,9 @@ String
 .. comp_req:: AbiString overflow check
    :id: comp_req__abi_compatible_data_types__abs_ovf
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -303,9 +303,9 @@ Option
 .. comp_req:: Provide AbiOption<T>
    :id: comp_req__abi_compatible_data_types__prv_abo
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -333,9 +333,9 @@ Option
 .. comp_req:: AbiOption is_some flag
    :id: comp_req__abi_compatible_data_types__abo_flg
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -346,9 +346,9 @@ Option
 .. comp_req:: AbiOption API
    :id: comp_req__abi_compatible_data_types__abo_api
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -362,9 +362,9 @@ Result
 .. comp_req:: Provide AbiResult<T,E>
    :id: comp_req__abi_compatible_data_types__prv_ari
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -401,9 +401,9 @@ Result
 .. comp_req:: AbiResult is_err flag
    :id: comp_req__abi_compatible_data_types__ari_flg
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1
@@ -414,9 +414,9 @@ Result
 .. comp_req:: AbiResult API
    :id: comp_req__abi_compatible_data_types__ari_api
    :reqtype: Functional
-   :security: NO
-   :safety: QM
-   :derived_from: feat_req__baselibs__core_utilities
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__abi_containers
    :satisfied_by: comp__baselibs_abi_compatible_data_types
    :status: valid
    :version: 1

--- a/docs/baselibs/components/bitmanipulation/docs/requirements/index.rst
+++ b/docs/baselibs/components/bitmanipulation/docs/requirements/index.rst
@@ -32,7 +32,7 @@ Functional Requirements
 .. comp_req:: Support for Bit Operations
    :id: comp_req__bitmanipulation__bit_operations
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__bitmanipulation
    :status: valid
@@ -44,7 +44,7 @@ Functional Requirements
 .. comp_req:: Support for Byte and Half-Byte Operations
    :id: comp_req__bitmanipulation__byte_operations
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__bitmanipulation
    :status: valid
@@ -56,7 +56,7 @@ Functional Requirements
 .. comp_req:: Support for Bitmask Operators for Enum Classes
    :id: comp_req__bitmanipulation__bitmask_operators
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__bitmanipulation
    :status: valid
@@ -68,7 +68,7 @@ Functional Requirements
 .. comp_req:: Bounds and Safety Checks
    :id: comp_req__bitmanipulation__bounds_safety
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__bitmanipulation
    :status: valid

--- a/docs/baselibs/components/concurrency/docs/requirements/index.rst
+++ b/docs/baselibs/components/concurrency/docs/requirements/index.rst
@@ -30,9 +30,9 @@ Functional Requirements
 .. comp_req:: Asynchronous Task Execution
    :id: comp_req__concurrency__task_interface
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -41,9 +41,9 @@ Functional Requirements
 .. comp_req:: Task Cancellation
    :id: comp_req__concurrency__task_cancellation
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -52,9 +52,9 @@ Functional Requirements
 .. comp_req:: Simple Task Implementation
    :id: comp_req__concurrency__simple_task
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -63,9 +63,9 @@ Functional Requirements
 .. comp_req:: Task Result Management
    :id: comp_req__concurrency__task_result
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -74,9 +74,9 @@ Functional Requirements
 .. comp_req:: Periodic Task Execution
    :id: comp_req__concurrency__periodic_task
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -85,9 +85,9 @@ Functional Requirements
 .. comp_req:: Delayed Task Execution
    :id: comp_req__concurrency__delayed_task
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -96,9 +96,9 @@ Functional Requirements
 .. comp_req:: Executor Interface
    :id: comp_req__concurrency__executor_interface
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__consistent_apis
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -107,9 +107,9 @@ Functional Requirements
 .. comp_req:: Thread Pool Implementation
    :id: comp_req__concurrency__thread_pool
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -118,9 +118,9 @@ Functional Requirements
 .. comp_req:: Interruptible Condition Variable
    :id: comp_req__concurrency__condition_variable
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -129,9 +129,9 @@ Functional Requirements
 .. comp_req:: Interruptible Wait Utilities
    :id: comp_req__concurrency__interruptible_wait
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -140,9 +140,9 @@ Functional Requirements
 .. comp_req:: Notification Mechanism
    :id: comp_req__concurrency__notification
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -151,9 +151,9 @@ Functional Requirements
 .. comp_req:: Synchronized Queue
    :id: comp_req__concurrency__synchronized_queue
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 
@@ -162,9 +162,9 @@ Functional Requirements
 .. comp_req:: Long-Running Threads Container
    :id: comp_req__concurrency__long_running_threads
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__concurrency_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__concurrency_library
    :status: valid
    :satisfied_by: comp__baselibs_concurrency
 

--- a/docs/baselibs/components/containers/docs/requirements/index.rst
+++ b/docs/baselibs/components/containers/docs/requirements/index.rst
@@ -29,9 +29,9 @@ Functional Requirements
 .. comp_req:: Dynamic Array
    :id: comp_req__containers__dynamic_array
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__containers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__containers_library
    :status: valid
    :satisfied_by: comp__baselibs_containers
 
@@ -40,9 +40,9 @@ Functional Requirements
 .. comp_req:: Intrusive List
    :id: comp_req__containers__intrusive_list
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__containers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__containers_library
    :status: valid
    :satisfied_by: comp__baselibs_containers
 
@@ -51,9 +51,9 @@ Functional Requirements
 .. comp_req:: Type Safety
    :id: comp_req__containers__type_safety
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__consistent_apis, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__containers_library
    :status: valid
    :satisfied_by: comp__baselibs_containers
 
@@ -62,9 +62,9 @@ Functional Requirements
 .. comp_req:: Non-Relocatable Vector
    :id: comp_req__containers__non_relocatable_vector
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__containers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__containers_library
    :status: valid
    :satisfied_by: comp__baselibs_containers
 
@@ -77,9 +77,9 @@ Non-Functional Requirements
 .. comp_req:: Deterministic Behavior
    :id: comp_req__containers__deterministic_behavior
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__containers_library
    :status: valid
    :satisfied_by: comp__baselibs_containers
 

--- a/docs/baselibs/components/filesystem/docs/requirements/index.rst
+++ b/docs/baselibs/components/filesystem/docs/requirements/index.rst
@@ -29,9 +29,9 @@ Functional Requirements
 .. comp_req:: Standard Filesystem Abstraction
    :id: comp_req__filesystem__api_abstraction
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__consistent_apis, feat_req__baselibs__filesystem_library
+   :derived_from: feat_req__baselibs__filesystem_library
    :status: valid
    :satisfied_by: comp__baselibs_filesystem
 
@@ -40,9 +40,9 @@ Functional Requirements
 .. comp_req:: Path Manipulation Utilities
    :id: comp_req__filesystem__path_utilities
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__consistent_apis, feat_req__baselibs__filesystem_library
+   :derived_from: feat_req__baselibs__filesystem_library
    :status: valid
    :satisfied_by: comp__baselibs_filesystem
 

--- a/docs/baselibs/components/flatbuffers/docs/requirements/index.rst
+++ b/docs/baselibs/components/flatbuffers/docs/requirements/index.rst
@@ -27,9 +27,9 @@ FlatBuffers Tooling Requirements
 
 .. tool_req:: FlatBuffers Code Generation for C++
    :id: tool_req__flatbuffers_codegen_cpp
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :satisfies: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety, feat_req__baselibs__multi_language_apis
+   :satisfies: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__multi_language_apis
    :status: valid
    :implemented: NO
 
@@ -37,9 +37,9 @@ FlatBuffers Tooling Requirements
 
 .. tool_req:: FlatBuffers Code Generation for Rust
    :id: tool_req__flatbuffers_codegen_rust
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :satisfies: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety, feat_req__baselibs__multi_language_apis
+   :satisfies: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__multi_language_apis
    :status: valid
    :implemented: NO
 
@@ -47,7 +47,7 @@ FlatBuffers Tooling Requirements
 
 .. tool_req:: FlatBuffers Code Generation for Python
    :id: tool_req__flatbuffers_codegen_python
-   :security: NO
+   :security: YES
    :safety: QM
    :satisfies: feat_req__baselibs__flatbuffers_library
    :status: valid
@@ -60,9 +60,9 @@ FlatBuffers Tooling Requirements
 
 .. tool_req:: FlatBuffers Binary Creation from JSON
    :id: tool_req__flatbuffers_tooling_json_to_bin
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :satisfies: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :satisfies: feat_req__baselibs__flatbuffers_library
    :status: valid
    :implemented: NO
 
@@ -72,7 +72,7 @@ FlatBuffers Tooling Requirements
 
 .. tool_req:: FlatBuffers Data Constraint Validation
    :id: tool_req__flatbuffers_tooling_data_validate
-   :security: NO
+   :security: YES
    :safety: QM
    :satisfies: feat_req__baselibs__flatbuffers_library
    :status: valid
@@ -91,7 +91,7 @@ FlatBuffers Tooling Requirements
 
 .. tool_req:: FlatBuffers Schema Evolution Check
    :id: tool_req__flatbuffers_tooling_evolution
-   :security: NO
+   :security: YES
    :safety: QM
    :satisfies: feat_req__baselibs__flatbuffers_library
    :status: valid
@@ -112,9 +112,9 @@ FlatBuffers Library Requirements
 .. comp_req:: FlatBuffers Serialization
    :id: comp_req__flatbuffers__serialization
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__flatbuffers_library
    :status: valid
    :satisfied_by: comp__baselibs_flatbuffers
 
@@ -127,9 +127,9 @@ FlatBuffers Library Requirements
 .. comp_req:: FlatBuffers Access
    :id: comp_req__flatbuffers__access
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__flatbuffers_library
    :status: valid
    :satisfied_by: comp__baselibs_flatbuffers
 
@@ -141,9 +141,9 @@ FlatBuffers Library Requirements
 .. comp_req:: FlatBuffers Verification
    :id: comp_req__flatbuffers__verification
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__flatbuffers_library
    :status: valid
    :satisfied_by: comp__baselibs_flatbuffers
 
@@ -159,9 +159,9 @@ Buffer Identification and Versioning
 .. comp_req:: Common Buffer Identification
    :id: comp_req__flatbuffers__buffer_identification
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__flatbuffers_library
    :status: valid
    :satisfied_by: comp__baselibs_flatbuffers
 
@@ -171,9 +171,9 @@ Buffer Identification and Versioning
 .. comp_req:: Common Version Check
    :id: comp_req__flatbuffers__version_check
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__flatbuffers_library
    :status: valid
    :satisfied_by: comp__baselibs_flatbuffers
 
@@ -186,9 +186,9 @@ Safety Impact
 .. comp_req:: FlatBuffers library ASIL level
    :id: comp_req__flatbuffers__asil
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__flatbuffers_library, feat_req__baselibs__multi_language_apis
    :status: valid
    :satisfied_by: comp__baselibs_flatbuffers
 

--- a/docs/baselibs/components/hash/docs/requirements/index.rst
+++ b/docs/baselibs/components/hash/docs/requirements/index.rst
@@ -37,7 +37,7 @@ Functional Requirements
 .. comp_req:: Hash Computation from Byte Data
    :id: comp_req__hash__calculation_interface
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__hash_library
    :status: valid
@@ -50,7 +50,7 @@ Functional Requirements
 .. comp_req:: Hash Value Retrieval as Raw Bytes
    :id: comp_req__hash__value_retrieval_bytes
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__hash_library
    :status: valid
@@ -61,7 +61,7 @@ Functional Requirements
 .. comp_req:: Hash Value Retrieval as Hexadecimal String
    :id: comp_req__hash__value_retrieval_hex
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__hash_library
    :status: valid
@@ -73,7 +73,7 @@ Functional Requirements
 .. comp_req:: Algorithm Selection via Factory
    :id: comp_req__hash__factory_interface
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__hash_library
    :status: valid
@@ -87,7 +87,7 @@ Functional Requirements
 .. comp_req:: Cryptographic Hash Algorithms
    :id: comp_req__hash__sha_algorithms
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__hash_library
    :status: valid
@@ -99,7 +99,7 @@ Functional Requirements
 .. comp_req:: CRC-32 Checksum Algorithm
    :id: comp_req__hash__crc32_algorithm
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__hash_library
    :status: valid
@@ -110,9 +110,9 @@ Functional Requirements
 .. comp_req:: Exception-Free Error Propagation
    :id: comp_req__hash__safe_computation
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__hash_library
    :status: valid
    :satisfied_by: comp__baselibs_hash
 

--- a/docs/baselibs/components/json/docs/requirements/index.rst
+++ b/docs/baselibs/components/json/docs/requirements/index.rst
@@ -28,7 +28,7 @@ General Requirements
 .. comp_req:: JSON Deserialization
    :id: comp_req__json__deserialization
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -40,7 +40,7 @@ General Requirements
 .. comp_req:: JSON Serialization
    :id: comp_req__json__serialization
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -51,7 +51,7 @@ General Requirements
 .. comp_req:: Return data in user format
    :id: comp_req__json__user_format
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -67,9 +67,9 @@ User friendly API for information exchange
 .. comp_req:: Support for programming language idioms
    :id: comp_req__json__lang_idioms
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__json_library, feat_req__baselibs__consistent_apis
+   :derived_from: feat_req__baselibs__json_library
    :status: valid
    :satisfied_by: comp__baselibs_json
 
@@ -78,7 +78,7 @@ User friendly API for information exchange
 .. comp_req:: Use programming language infrastructure
    :id: comp_req__json__lang_infra
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -92,7 +92,7 @@ User friendly API for information exchange
 .. comp_req:: Enforce strict type compatibility
    :id: comp_req__json__type_compatibility
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -109,7 +109,7 @@ Full testability for the user facing API
 .. comp_req:: Fully testable public API
    :id: comp_req__json__full_testability
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -125,9 +125,9 @@ Safety Impact
 .. comp_req:: JSON library ASIL level
    :id: comp_req__json__asil
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__json_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__json_library
    :status: valid
    :satisfied_by: comp__baselibs_json
 

--- a/docs/baselibs/components/json/docs/vajson/requirements/index.rst
+++ b/docs/baselibs/components/json/docs/vajson/requirements/index.rst
@@ -32,7 +32,7 @@ In addition, the following VaJson-specific requirements apply:
 .. comp_req:: JSON Validation
    :id: comp_req__vajson__validation
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -44,7 +44,7 @@ In addition, the following VaJson-specific requirements apply:
 .. comp_req:: JSON Deserialization RFC extension trailing commas
    :id: comp_req__vajson__trailing_commas
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -56,7 +56,7 @@ In addition, the following VaJson-specific requirements apply:
 .. comp_req:: JSON Deserialization RFC extension hexadecimal integers
    :id: comp_req__vajson__hex_integers
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -68,7 +68,7 @@ In addition, the following VaJson-specific requirements apply:
 .. comp_req:: Unicode Support
    :id: comp_req__vajson__unicode
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid
@@ -82,7 +82,7 @@ Safety Impact
 .. comp_req:: VaJson library ASIL level
    :id: comp_req__vajson__asil
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__json_library
    :status: valid

--- a/docs/baselibs/components/language/safecpp/docs/requirements/index.rst
+++ b/docs/baselibs/components/language/safecpp/docs/requirements/index.rst
@@ -31,7 +31,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_safecpp
 
@@ -47,7 +47,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_safecpp
 
@@ -61,7 +61,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_safecpp
 
@@ -70,9 +70,9 @@ Functional Requirements
 .. comp_req:: Null-Terminated String
    :id: comp_req__safecpp__nullstring
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_safecpp
 
@@ -84,7 +84,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_safecpp
 
@@ -96,9 +96,9 @@ Non-Functional Requirements
 .. comp_req:: Code Coverage Termination
    :id: comp_req__safecpp__coverage_termination
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__maintainable_design
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_safecpp
 

--- a/docs/baselibs/components/memory_shared/docs/requirements/index.rst
+++ b/docs/baselibs/components/memory_shared/docs/requirements/index.rst
@@ -31,7 +31,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -42,7 +42,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -53,7 +53,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -64,7 +64,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -75,7 +75,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety, feat_req__baselibs__memory_library
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -84,9 +84,9 @@ Functional Requirements
 .. comp_req:: Endianness Conversion
    :id: comp_req__memory__endianness
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -97,7 +97,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety, feat_req__baselibs__memory_library, feat_req__baselibs__security
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -108,7 +108,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety, feat_req__baselibs__memory_library
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -117,9 +117,9 @@ Functional Requirements
 .. comp_req:: Memory Resource Registry
    :id: comp_req__memory__resource_registry
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -128,9 +128,9 @@ Functional Requirements
 .. comp_req:: String Utilities
    :id: comp_req__memory__string_utils
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__memory_library
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -141,7 +141,7 @@ Functional Requirements
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__memory_library, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -154,9 +154,9 @@ Non-Functional Requirements
 .. comp_req:: Deterministic Memory Allocation
    :id: comp_req__memory__deterministic_alloc
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 
@@ -167,7 +167,7 @@ Non-Functional Requirements
    :reqtype: Non-Functional
    :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__safety, feat_req__baselibs__memory_library
+   :derived_from: feat_req__baselibs__memory_library
    :status: valid
    :satisfied_by: comp__baselibs_memory_shared
 

--- a/docs/baselibs/components/result/docs/requirements/index.rst
+++ b/docs/baselibs/components/result/docs/requirements/index.rst
@@ -29,7 +29,7 @@ Functional Requirements
 .. comp_req:: Result-Based Error Handling
    :id: comp_req__result__error_handling
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid
@@ -41,7 +41,7 @@ Functional Requirements
 .. comp_req:: Set Result
    :id: comp_req__result__set_result
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid
@@ -53,7 +53,7 @@ Functional Requirements
 .. comp_req:: Domain-Specific Error Information
    :id: comp_req__result__domain_error_information
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid
@@ -65,7 +65,7 @@ Functional Requirements
 .. comp_req:: Type-Safe Error Handling
    :id: comp_req__result__type_safety
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid
@@ -77,7 +77,7 @@ Functional Requirements
 .. comp_req:: Standard Library Integration
    :id: comp_req__result__std_integration
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid
@@ -92,7 +92,7 @@ Non-Functional Requirements
 .. comp_req:: Deterministic Behavior
    :id: comp_req__result__deterministic_behavior
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid
@@ -104,7 +104,7 @@ Non-Functional Requirements
 .. comp_req:: Exception-Free Operation
    :id: comp_req__result__exception_free_operation
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
    :derived_from: feat_req__baselibs__result_library
    :status: valid

--- a/docs/baselibs/components/static_reflection_with_serialization/docs/requirements/index.rst
+++ b/docs/baselibs/components/static_reflection_with_serialization/docs/requirements/index.rst
@@ -26,9 +26,9 @@ Requirements
 .. comp_req:: Static Reflection Support
    :id: comp_req__static_reflect_serial__reflect
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__static_reflection_library
    :satisfied_by: comp__baselibs_static_reflection
    :status: valid
    :tags: baselibs
@@ -38,9 +38,9 @@ Requirements
 .. comp_req:: Generic Visitor Pattern
    :id: comp_req__static_reflect_serial__visitor
    :reqtype: Interface
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__consistent_apis, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__static_reflection_library
    :satisfied_by: comp__baselibs_static_reflection
    :status: valid
    :tags: baselibs
@@ -50,9 +50,9 @@ Requirements
 .. comp_req:: Automatic Container Iteration
    :id: comp_req__static_reflect_serial__container
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__static_reflection_library
    :satisfied_by: comp__baselibs_static_reflection
    :status: valid
    :tags: baselibs
@@ -62,9 +62,9 @@ Requirements
 .. comp_req:: Nested Type Support
    :id: comp_req__static_reflect_serial__nested
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__static_reflection_library
    :satisfied_by: comp__baselibs_static_reflection
    :status: valid
    :tags: baselibs
@@ -74,9 +74,9 @@ Requirements
 .. comp_req:: Header-Only Implementation
    :id: comp_req__static_reflect_serial__header_only
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__static_reflection_library
    :satisfied_by: comp__baselibs_static_reflection
    :status: valid
    :tags: baselibs
@@ -86,9 +86,9 @@ Requirements
 .. comp_req:: Compile-Time Efficiency
    :id: comp_req__static_reflect_serial__compile_eff
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__static_reflection_library
    :satisfied_by: comp__baselibs_static_reflection
    :status: valid
    :tags: baselibs

--- a/docs/baselibs/components/utils/docs/requirements/index.rst
+++ b/docs/baselibs/components/utils/docs/requirements/index.rst
@@ -29,9 +29,9 @@ Functional Requirements
 .. comp_req:: Base64 Encoding and Decoding
    :id: comp_req__utils__base64
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_utils
 
@@ -40,9 +40,9 @@ Functional Requirements
 .. comp_req:: Scoped Operation Management
    :id: comp_req__utils__scoped_operation
    :reqtype: Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_utils
 
@@ -54,9 +54,9 @@ Non-Functional Requirements
 .. comp_req:: Deterministic Behavior
    :id: comp_req__utils__deterministic_behavior
    :reqtype: Non-Functional
-   :security: NO
+   :security: YES
    :safety: ASIL_B
-   :derived_from: feat_req__baselibs__core_utilities, feat_req__baselibs__safety
+   :derived_from: feat_req__baselibs__utils_library
    :status: valid
    :satisfied_by: comp__baselibs_utils
 

--- a/docs/baselibs/feature/architecture/index.rst
+++ b/docs/baselibs/feature/architecture/index.rst
@@ -31,7 +31,7 @@ A brief overview of Baselibs is described :need:`doc__baselibs`.
 Description
 -----------
 
-A detailed description of the Baselibs module requirements is located :need:`feat_req__baselibs__core_utilities`.
+A detailed description of the Baselibs module requirements is located :need:`doc__baselibs_requirements`.
 
 The Baselibs module provides foundational software utilities, safety mechanisms and robust infrastructure components. It comprises essential libraries organized into functional categories:
 
@@ -84,12 +84,16 @@ The decomposition of Baselibs into modular libraries is motivated by the need fo
 Static Architecture
 -------------------
 
+   ..
+      The fulfils in feat_arc_sta and feat_arc_dyn should be optional.
+      Issue: https://github.com/eclipse-score/process_description/issues/642
+
 .. feat_arc_sta:: Baselibs Static View
    :id: feat_arc_sta__baselibs__static_view_arch
    :security: YES
    :safety: ASIL_B
    :status: valid
-   :fulfils: feat_req__baselibs__core_utilities
+   :fulfils: feat_req__baselibs__abi_containers, feat_req__baselibs__bitmanipulation, feat_req__baselibs__concurrency_library, feat_req__baselibs__containers_library, feat_req__baselibs__utils_library, feat_req__baselibs__filesystem_library, feat_req__baselibs__flatbuffers_library, feat_req__baselibs__json_library, feat_req__baselibs__memory_library, feat_req__baselibs__result_library
    :includes: logic_arc_int__baselibs__json, logic_arc_int__baselibs__memory_shared, logic_arc_int__baselibs__result, logic_arc_int__baselibs__bit_manipulation, logic_arc_int__baselibs__bit_mask_operator, logic_arc_int__baselibs__dynamic_array, logic_arc_int__baselibs__intrusive_list, logic_arc_int__baselibs__filesystem, logic_arc_int__baselibs__utils_base64, logic_arc_int__baselibs__utils_scoped_op, logic_arc_int__baselibs__promise, logic_arc_int__baselibs__future, logic_arc_int__baselibs__shared_future, logic_arc_int__baselibs__executor, logic_arc_int__baselibs__task, logic_arc_int__baselibs__task_result, logic_arc_int__baselibs__synchronized_queue, logic_arc_int__baselibs__condition_variable, logic_arc_int__baselibs__aborts_upon_ex, logic_arc_int__baselibs__coverage_termination, logic_arc_int__baselibs__safemath, logic_arc_int__baselibs__safeatomics, logic_arc_int__baselibs__scoped_function, logic_arc_int__baselibs__string_view
    :tags: inspected
    :belongs_to: feat__baselibs
@@ -105,7 +109,7 @@ Static Architecture
    :security: YES
    :safety: ASIL_B
    :status: valid
-   :fulfils: feat_req__baselibs__core_utilities
+   :fulfils: feat_req__baselibs__abi_containers, feat_req__baselibs__bitmanipulation, feat_req__baselibs__concurrency_library, feat_req__baselibs__containers_library, feat_req__baselibs__utils_library, feat_req__baselibs__filesystem_library, feat_req__baselibs__flatbuffers_library, feat_req__baselibs__json_library, feat_req__baselibs__memory_library, feat_req__baselibs__result_library
    :belongs_to: feat__baselibs
 
    not needed, simple caller/callee sequence

--- a/docs/baselibs/module/manual/safety_manual.rst
+++ b/docs/baselibs/module/manual/safety_manual.rst
@@ -50,7 +50,8 @@ So for Baselibs the definition of the assumed safety requirement(s) of each of t
 - json library: :need:`feat_req__baselibs__json_library`
 - memory library: :need:`feat_req__baselibs__memory_library`
 - result library: :need:`feat_req__baselibs__result_library`
-- safecpp, static_reflection_with_serialization, utils :need:`feat_req__baselibs__core_utilities`
+- safecpp, utils: :need:`feat_req__baselibs__utils_library`
+- static_reflection_with_serialization: :need:`feat_req__baselibs__static_reflection_library`
 
 Assumptions of Use
 ------------------


### PR DESCRIPTION
Updates baselibs component requirements to match the feature requirement changes from eclipse-score/score#3071, which removed several generic feature requirements (core_utilities, safety, consistent_apis,
maintainable_design, security) in favor of more specific ones (utils_library, static_reflection_library, etc.) and set security=YES across the board.