### PR TITLE
third_party/acl: uplift libacl to 2.3.1-1 for PIC (AArch64 PIE)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -165,14 +165,14 @@ deb = use_repo_rule("@download_utils//download/deb:defs.bzl", "download_deb")
 deb(
     name = "acl-deb",
     build = "//third_party/acl:acl.BUILD",
-    urls = ["https://archive.ubuntu.com/ubuntu/pool/main/a/acl/libacl1-dev_2.2.52-3build1_amd64.deb"],
+    urls = ["https://archive.ubuntu.com/ubuntu/pool/main/a/acl/libacl1-dev_2.3.1-1_amd64.deb"],
     visibility = ["//visibility:public"],
 )
 
 deb(
     name = "acl-deb-aarch64",
     build = "//third_party/acl:acl.BUILD",
-    urls = ["https://ports.ubuntu.com/ubuntu-ports/pool/main/a/acl/libacl1-dev_2.2.52-3build1_arm64.deb"],
+    urls = ["https://ports.ubuntu.com/ubuntu-ports/pool/main/a/acl/libacl1-dev_2.3.1-1_arm64.deb"],
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/acl/acl.BUILD
+++ b/third_party/acl/acl.BUILD
@@ -16,8 +16,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "acl",
     srcs = select({
-        "@platforms//cpu:aarch64": ["usr/lib/libacl.a"],
-        "@platforms//cpu:x86_64": ["usr/lib/libacl.a"],
+        "@platforms//cpu:aarch64": ["usr/lib/aarch64-linux-gnu/libacl.a"],
+        "@platforms//cpu:x86_64": ["usr/lib/x86_64-linux-gnu/libacl.a"],
     }),
     hdrs = [
         "usr/include/acl/libacl.h",


### PR DESCRIPTION
The pinned libacl1-dev was 2.2.52-3build1, a static archive built in 2017 without -fPIC. On AArch64 its objects reach `__stack_chk_guard` via absolute ADRP addressing (R_AARCH64_ADR_PREL_PG_HI21), which cannot be resolved when linking into a position-independent executable. Since rustc produces PIE binaries by default, any rust_binary that transitively links score/os:acl (e.g. via score/memory/shared) fails on the linux_aarch64 GCC toolchain:

```
    relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `__stack_chk_guard'
    which may bind externally can not be used when making a shared object;
    recompile with -fPIC
```

Bump both the amd64 and aarch64 debs to libacl1-dev 2.3.1-1, whose static libacl.a is PIC (it addresses __stack_chk_guard through the GOT: R_AARCH64_ADR_GOT_PAGE / R_AARCH64_LD64_GOT_LO12_NC), so it links cleanly into a PIE. The archive path also moved to the multiarch location, so acl.BUILD is updated to usr/lib/<triple>/libacl.a accordingly.

2.3.1-1 is deliberately chosen over the newest 2.3.2: the 2.3.2 build references the glibc 2.38 C23 symbol __isoc23_strtol, which the toolchain's older glibc sysroot does not provide. 2.3.1-1 is the newest version that is both PIC and free of __isoc23_* symbols.

Verified end-to-end with the score aarch64 GCC toolchain: a -pie link against the 2.3.1-1 archive produces a valid PIE (ELF DYN), while the same link against the old 2017 archive still fails with the relocation error above.

Refs: eclipse-score/baselibs#172, eclipse-score/communication#328