### PR TITLE
Add size_bytes() method to span

### DIFF
--- a/score/language/futurecpp/include/score/span.hpp
+++ b/score/language/futurecpp/include/score/span.hpp
@@ -291,7 +291,10 @@ public:
 
     /// \brief Returns the size of the row in bytes.
     ///
-    /// \return  Size of the row in bytes.
+    /// \note Counts only `size() * sizeof(T)`. Heap storage owned by allocator-aware element types
+    /// (e.g. `std::vector`) is not included, consistent with `std::span::size_bytes`.
+    ///
+    /// \return Size of the row in bytes.
     size_type size_bytes() const noexcept { return base_.size() * sizeof(T); }
 
     /// \brief checks if the span is empty

--- a/score/language/futurecpp/include/score/span.hpp
+++ b/score/language/futurecpp/include/score/span.hpp
@@ -289,6 +289,11 @@ public:
     /// \return  Number of elements in the row.
     size_type size() const noexcept { return base_.size(); }
 
+    /// \brief Returns the size of the row in bytes.
+    ///
+    /// \return  Size of the row in bytes.
+    size_type size_bytes() const noexcept { return base_.size() * sizeof(T); }
+
     /// \brief checks if the span is empty
     ///
     /// @return true if span is empty (size==0); false otherwise.

--- a/score/language/futurecpp/tests/span_test.cpp
+++ b/score/language/futurecpp/tests/span_test.cpp
@@ -477,6 +477,32 @@ TEST(span, DereferencingNullptrShallTriggerContracViolation)
 
 /// @testmethods TM_REQUIREMENT
 /// @requirement CB-#9338069
+TEST(span, SizeBytes)
+{
+    {
+        const std::int32_t data[]{23, 42, 72};
+        const span<const std::int32_t> view{data};
+        EXPECT_EQ(3U, view.size());
+        EXPECT_EQ(3U * sizeof(std::int32_t), view.size_bytes());
+    }
+    {
+        const std::int32_t data[]{23, 42, 72};
+        const span<const std::int32_t, 3U> view{data};
+        EXPECT_EQ(3U * sizeof(std::int32_t), view.size_bytes());
+    }
+    {
+        const double data[]{1.0, 2.0};
+        const span<const double> view{data};
+        EXPECT_EQ(2U * sizeof(double), view.size_bytes());
+    }
+    {
+        const span<const std::int32_t> view{};
+        EXPECT_EQ(0U, view.size_bytes());
+    }
+}
+
+/// @testmethods TM_REQUIREMENT
+/// @requirement CB-#9338069
 TEST(span, AsBytes)
 {
     const std::int32_t data[]{0x0A0A0A0A, 0x0B0B0B0B};
@@ -880,6 +906,7 @@ TEST(span, that_noexcept_api_is_compatible_with_std20_span)
     static_assert(noexcept(GivenSpan()));
     static_assert(noexcept(GivenSpan(x)));
     static_assert(noexcept(GivenSpan().size()));
+    static_assert(noexcept(GivenSpan().size_bytes()));
     static_assert(noexcept(GivenSpan().empty()));
     static_assert(noexcept(GivenSpan().data()));
 

--- a/score/language/futurecpp/tests/span_test.cpp
+++ b/score/language/futurecpp/tests/span_test.cpp
@@ -491,6 +491,11 @@ TEST(span, SizeBytes)
         EXPECT_EQ(3U * sizeof(std::int32_t), view.size_bytes());
     }
     {
+        alignas(64) const std::int32_t data[]{23, 42, 72};
+        const span<const std::int32_t, 3U> view{data};
+        EXPECT_EQ(3U * sizeof(std::int32_t), view.size_bytes());
+    }
+    {
         const double data[]{1.0, 2.0};
         const span<const double> view{data};
         EXPECT_EQ(2U * sizeof(double), view.size_bytes());


### PR DESCRIPTION
Add size_bytes() method support for span to be compliant with std::span (C++20).