### PR TITLE
Provide Rust wrapper for memory resouces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "memres"
+version = "0.0.1"
+
+[[package]]
 name = "pal"
 version = "0.0.1"
 dependencies = [
@@ -71,18 +75,18 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -136,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ default-members = [
     "score/language/rust/libcpp",
     "score/language/rust/libcpp_derive",
     "score/result/rust",
+    "score/language/rust/memres",
 ]
 # Include tests and examples as a member for IDE support and Bazel builds.
 members = [
@@ -35,6 +36,7 @@ members = [
     "score/allocator",
     "score/pal",
     "score/thread",
+    "score/language/rust/memres",
     "score/log_rust/score_log",
     "score/log_rust/score_log_fmt",
     "score/log_rust/score_log_fmt_macro",
@@ -66,6 +68,7 @@ pal = { path = "score/pal" }
 thread = { path = "score/thread" }
 libcpp = { path = "score/language/rust/libcpp" }
 libcpp_derive = { path = "score/language/rust/libcpp_derive" }
+memres = { path = "score/language/rust/memres" }
 
 [workspace.lints.clippy]
 std_instead_of_core = "warn"

--- a/score/language/rust/memres/BUILD
+++ b/score/language/rust/memres/BUILD
@@ -1,0 +1,88 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@score_baselibs//:bazel/unit_tests.bzl", "cc_unit_test_suites_for_host_and_qnx")
+load("//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+
+cc_library(
+    name = "guarded_upstream",
+    srcs = ["cpp/guarded_upstream.cpp"],
+    hdrs = ["cpp/guarded_upstream.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/language/futurecpp",
+        "//score/mw/log",
+        "//score/mw/log:frontend",
+    ],
+)
+
+cc_library(
+    name = "memory_resource_handle",
+    srcs = ["cpp/memory_resource_handle.cpp"],
+    hdrs = ["cpp/memory_resource_handle.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [":guarded_upstream"],
+)
+
+cc_library(
+    name = "memres_cpp",
+    srcs = ["cpp/ffi.cpp"],
+    hdrs = ["cpp/ffi.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [":memory_resource_handle"],
+)
+
+rust_library(
+    name = "memres",
+    srcs = ["src/lib.rs"],
+    crate_root = "src/lib.rs",
+    edition = "2021",
+    tags = ["FFI"],
+    visibility = ["//visibility:public"],
+    deps = [":memres_cpp"],
+)
+
+cc_test(
+    name = "memres_test",
+    srcs = ["test/memres_test.cpp"],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["unit"],
+    deps = [
+        ":memres_cpp",
+        "//score/language/futurecpp",
+        "@googletest//:gtest_main",
+    ],
+)
+
+rust_test(
+    name = "memres_rust_test",
+    srcs = ["test/memres_rust_test.rs"],
+    crate_root = "test/memres_rust_test.rs",
+    edition = "2021",
+    features = ["link_std_cpp_lib"],
+    tags = ["unit"],
+    deps = [
+        ":memres",
+        "//score/language/rust/memres/example:example_helpers",
+    ],
+)
+
+cc_unit_test_suites_for_host_and_qnx(
+    name = "unit_test_suite",
+    cc_unit_tests = [
+        ":memres_test",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/score/language/rust/memres/Cargo.toml
+++ b/score/language/rust/memres/Cargo.toml
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+[package]
+name = "memres"
+version.workspace = true
+authors.workspace = true
+readme.workspace = true
+edition.workspace = true
+license-file.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/score/language/rust/memres/README.md
+++ b/score/language/rust/memres/README.md
@@ -1,0 +1,211 @@
+# memres — PMR Memory Resource Bridge
+
+`memres` provides Rust code with owned, RAII handles to
+[`score::cpp::pmr::memory_resource`](https://isocpp.org/files/papers/P0339R6.pdf)
+objects from the `score::cpp` (futurecpp) C++ library.  It targets use-cases
+where allocation behaviour must be tightly controlled — for example, preventing
+any runtime heap use after initialisation.
+
+---
+
+## Purpose
+
+`score::cpp::pmr` (Polymorphic Memory Resource) is the C++ standard-library
+mechanism for decoupling containers from the allocator strategy used for their
+storage.  `memres` makes two of those strategies available to Rust callers:
+
+| Strategy | C++ type | Rust variant |
+|---|---|---|
+| Monotonic buffer | `score::cpp::pmr::monotonic_buffer_resource` | `ResourceKind::Monotonic { size }` |
+| Single-threaded pool | `score::cpp::pmr::unsynchronized_pool_resource` | `ResourceKind::UnsynchronizedPool(PoolOptions)` |
+
+Both strategies are wrapped in a `GuardedUpstream` that controls what happens
+when the resource runs out of memory (see [Hermetic mode](#hermetic-mode) below).
+
+---
+
+## Hermetic mode
+
+Both resource kinds accept a `hermetic` flag that determines the behaviour when
+the resource can no longer serve an allocation from its own storage:
+
+| `hermetic` | Overflow behaviour |
+|---|---|
+| `true` | Logs a **fatal** message (via `score::mw::log`) and calls `std::abort()`. No allocation ever escapes to the system heap. |
+| `false` | Logs a **warning** and delegates to `score::cpp::pmr::new_delete_resource()` (the system heap). |
+
+Hermetic mode is intended for safety-sensitive contexts where latency guarantees
+or memory-isolation requirements forbid runtime heap use after start-up.
+
+---
+
+## Usage
+
+### C FFI API
+
+The C++ side exposes a plain C interface (`cpp/ffi.h`) that is consumed both by
+the Rust crate and directly from C++ tests:
+
+```c
+void* memres_new_monotonic(size_t size, bool hermetic);
+void* memres_new_unsynchronized_pool(
+    size_t max_blocks_per_chunk,      // 0 = implementation default
+    size_t largest_required_pool_block, // 0 = implementation default
+    bool hermetic);
+void* memres_new_default();
+void  memres_destroy(void* handle);
+void* memres_as_memory_resource(void* handle);
+```
+
+All functions are `noexcept`.  `memres_destroy(nullptr)` is a no-op.  The
+pointer returned by `memres_as_memory_resource` is valid until `memres_destroy`
+is called on the same handle.
+
+### Rust API
+
+```rust
+use memres::{MemoryResource, PoolOptions, ResourceKind};
+
+// Monotonic buffer of 1024 bytes; aborts on overflow (hermetic).
+let mr = MemoryResource::new(ResourceKind::Monotonic { size: 1024 }, true);
+
+// Pool resource with implementation-chosen defaults; falls back to the heap.
+let mr = MemoryResource::new(
+    ResourceKind::UnsynchronizedPool(PoolOptions::default()),
+    false,
+);
+
+// Pass `ptr.as_ptr()` to any C++ function that accepts
+// `score::cpp::pmr::memory_resource*`.
+let ptr = mr.as_memory_resource_ptr();
+some_cpp_function(ptr.as_ptr());
+
+// `ptr` (and its borrow of `mr`) are dropped before `mr` goes out of scope.
+// `mr` drops here; the C++ resource and all its storage are freed.
+```
+
+`MemoryResource::as_memory_resource_ptr()` returns a `MemoryResourcePtr<'_>`
+that borrows `self` for the duration of the binding.  The borrow checker
+prevents `mr` from being moved or dropped while the pointer is live, making
+dangling-pointer use a **compile-time error** rather than undefined behaviour
+at runtime.  Call `.as_ptr()` on the wrapper to obtain the raw
+`*mut ScoreMemoryResource` to pass to C++.  Any C++ object whose storage was
+allocated from that resource must be destroyed **before** `mr` is dropped.
+
+### Thread safety
+
+`MemoryResource<S>` carries a compile-time marker `S` (`Local` or `Shared`):
+
+- `MemoryResource::new(...)` returns `MemoryResource<Local>` — the monotonic and
+  pool resources are single-threaded, so the handle is `!Send + !Sync`.
+- `MemoryResource::<Shared>::default_resource()` wraps
+  `score::cpp::pmr::get_default_resource()`.  That resource forwards to the
+  data-race-free global `operator new`/`operator delete`, so the handle is
+  `Send + Sync`.
+
+## Design
+
+### Layer overview
+
+```
+┌─────────────────────────────────────────┐
+│  Rust crate  (src/lib.rs)               │
+│  MemoryResource, ResourceKind,          │
+│  PoolOptions                            │
+└──────────────────┬──────────────────────┘
+                   │ extern "C" FFI
+┌──────────────────▼──────────────────────┐
+│  C FFI layer  (cpp/ffi.h / ffi.cpp)     │
+│  memres_new_*  memres_destroy           │
+│  memres_as_memory_resource              │
+└──────────────────┬──────────────────────┘
+                   │
+┌──────────────────▼──────────────────────┐
+│  Handle layer  (memory_resource_handle) │
+│  MemResHandle (abstract base)           │
+│  MonotonicHandle                        │
+│  UnsynchronizedPoolHandle               │
+│  DefaultHandle                          │
+└──────────────────┬──────────────────────┘
+                   │ upstream pointer
+┌──────────────────▼──────────────────────┐
+│  GuardedUpstream                        │
+│  Intercepts overflow; aborts or warns   │
+└─────────────────────────────────────────┘
+```
+
+### Handle ownership and destruction order
+
+Each concrete handle class stores its members in a specific order to guarantee
+safe destruction:
+
+**`MonotonicHandle`**
+```
+upstream_  ← constructed first, destroyed last
+buffer_    ← backing byte array; must outlive inner_
+inner_     ← constructed last, destroyed first; calls upstream_ on overflow
+```
+
+**`UnsynchronizedPoolHandle`**
+```
+upstream_  ← constructed first, destroyed last
+inner_     ← constructed last, destroyed first; releases blocks to upstream_ on destruction
+```
+
+C++ destroys members in reverse declaration order, so `inner_` is always torn
+down before `upstream_`, ensuring all pool-release calls reach a still-valid
+object.
+
+### Critical lifetime invariant
+
+Any object whose element storage was allocated from a `MemoryResource` (or the
+equivalent C++ handle) **must be destroyed before** that `MemoryResource` is
+destroyed.
+
+In Rust this is enforced naturally by LIFO drop order for local variables.  In
+C++ tests, ensure PMR-backed containers go out of scope (or are explicitly
+destroyed) before calling `memres_destroy()`.  Violating this rule causes a
+use-after-free when the container's destructor tries to return memory to an
+already-freed pool.
+
+---
+
+## Bazel targets
+
+| Target | Kind | Description |
+|---|---|---|
+| `:guarded_upstream` | `cc_library` | `GuardedUpstream` C++ class |
+| `:memory_resource_handle` | `cc_library` | Handle class hierarchy |
+| `:memres_cpp` | `cc_library` | C FFI (`ffi.h` / `ffi.cpp`); tagged `FFI` |
+| `:memres` | `rust_library` | Rust crate |
+| `:memres_test` | `cc_test` | C++ unit tests (GoogleTest) |
+| `:memres_rust_test` | `rust_test` | Rust unit tests |
+
+Run all tests:
+
+```sh
+bazel test //score/language/rust/memres/...
+```
+
+---
+
+## Directory structure
+
+```
+memres/
+├── BUILD                      Bazel build file
+├── README.md                  This file
+├── cpp/
+│   ├── ffi.h / ffi.cpp        Plain-C API consumed by Rust and C++ callers
+│   ├── guarded_upstream.h/.cpp  Overflow-interception memory resource
+│   └── memory_resource_handle.h/.cpp  Concrete handle classes
+├── example/
+│   ├── main.rs                Rust binary demonstrating hermetic abort
+│   ├── example_helpers.h/.cpp C++ helpers used by the example and Rust tests
+│   └── BUILD
+├── src/
+│   └── lib.rs                 Rust crate root
+└── test/
+    ├── memres_test.cpp         C++ GoogleTest tests
+    └── memres_rust_test.rs     Rust unit tests
+```

--- a/score/language/rust/memres/cpp/ffi.cpp
+++ b/score/language/rust/memres/cpp/ffi.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#include "score/language/rust/memres/cpp/ffi.h"
+
+#include "score/language/rust/memres/cpp/memory_resource_handle.h"
+
+#include <score/memory_resource.hpp>
+#include <cstddef>
+#include <new>
+
+extern "C" {
+
+score::language::rust::memres::MemResHandle* memres_new_monotonic(std::size_t size, bool hermetic) noexcept
+{
+    return new (std::nothrow) score::language::rust::memres::MonotonicHandle{size, hermetic};
+}
+
+score::language::rust::memres::MemResHandle* memres_new_unsynchronized_pool(std::size_t max_blocks_per_chunk,
+                                                                            std::size_t largest_required_pool_block,
+                                                                            bool hermetic) noexcept
+{
+    const score::cpp::pmr::pool_options opts{max_blocks_per_chunk, largest_required_pool_block};
+    return new (std::nothrow) score::language::rust::memres::UnsynchronizedPoolHandle{opts, hermetic};
+}
+
+void memres_destroy(score::language::rust::memres::MemResHandle* handle) noexcept
+{
+    delete handle;
+}
+
+score::language::rust::memres::MemResHandle* memres_new_default() noexcept
+{
+    return new (std::nothrow) score::language::rust::memres::DefaultHandle{};
+}
+
+score::cpp::pmr::memory_resource* memres_as_memory_resource(
+    score::language::rust::memres::MemResHandle* handle) noexcept
+{
+    return handle->resource();
+}
+
+}  // extern "C"

--- a/score/language/rust/memres/cpp/ffi.h
+++ b/score/language/rust/memres/cpp/ffi.h
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#ifndef SCORE_LANGUAGE_RUST_MEMRES_CPP_FFI_H
+#define SCORE_LANGUAGE_RUST_MEMRES_CPP_FFI_H
+
+#include <cstddef>
+
+// Forward-declare the C++ types exposed through the extern "C" interface so
+// that callers do not need to include the full implementation headers.
+namespace score::language::rust::memres
+{
+class MemResHandle;
+}
+namespace score::cpp::pmr
+{
+class memory_resource;
+}
+
+extern "C" {
+
+/// Creates a `monotonic_buffer_resource` backed by a C++-allocated buffer of
+/// `size` bytes. Returns a typed handle that must be freed with
+/// `memres_destroy()`. Returns `nullptr` if the initial allocation fails.
+score::language::rust::memres::MemResHandle* memres_new_monotonic(std::size_t size, bool hermetic) noexcept;
+
+/// Creates an `unsynchronized_pool_resource` (single-threaded pool allocator).
+/// Pass `0` for `max_blocks_per_chunk` or `largest_required_pool_block` to use
+/// the implementation defaults. Returns a typed handle that must be freed with
+/// `memres_destroy()`. Returns `nullptr` if allocation fails.
+score::language::rust::memres::MemResHandle* memres_new_unsynchronized_pool(std::size_t max_blocks_per_chunk,
+                                                                            std::size_t largest_required_pool_block,
+                                                                            bool hermetic) noexcept;
+
+/// Destroys a handle previously returned by one of the `memres_new_*` functions
+/// and frees all associated storage. Passing `nullptr` is safe (no-op).
+void memres_destroy(score::language::rust::memres::MemResHandle* handle) noexcept;
+
+/// Returns a pointer to the `score::cpp::pmr::memory_resource` owned by `handle`.
+/// The returned pointer is valid for the lifetime of `handle`.
+score::cpp::pmr::memory_resource* memres_as_memory_resource(
+    score::language::rust::memres::MemResHandle* handle) noexcept;
+
+/// Creates a thin handle wrapping the process-global default memory resource
+/// (`score::cpp::pmr::get_default_resource()`).  The handle must be freed with
+/// `memres_destroy()`, which releases only the wrapper object; the underlying
+/// resource has process lifetime and is not deleted.  Returns `nullptr` if the
+/// wrapper allocation fails.
+score::language::rust::memres::MemResHandle* memres_new_default() noexcept;
+
+}  // extern "C"
+
+#endif  // SCORE_LANGUAGE_RUST_MEMRES_CPP_FFI_H

--- a/score/language/rust/memres/cpp/guarded_upstream.cpp
+++ b/score/language/rust/memres/cpp/guarded_upstream.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#include "score/language/rust/memres/cpp/guarded_upstream.h"
+
+#include "score/mw/log/logging.h"
+
+#include <score/memory_resource.hpp>
+#include <cstdlib>
+
+namespace score::language::rust::memres
+{
+
+GuardedUpstream::GuardedUpstream(bool hermetic) noexcept : hermetic_{hermetic} {}
+
+void* GuardedUpstream::do_allocate(std::size_t bytes, std::size_t alignment)
+{
+    if (hermetic_)
+    {
+        score::mw::log::LogFatal("memres") << "Memory resource exhausted in hermetic mode: requested" << bytes
+                                           << "bytes with alignment" << alignment << ". Aborting.";
+        std::abort();
+    }
+    score::mw::log::LogWarn("memres") << "Memory resource exhausted: requested" << bytes << "bytes with alignment"
+                                      << alignment << ". Falling back to system heap.";
+    return score::cpp::pmr::new_delete_resource()->allocate(bytes, alignment);
+}
+
+void GuardedUpstream::do_deallocate(void* ptr, std::size_t bytes, std::size_t alignment)
+{
+    if (!hermetic_)
+    {
+        score::cpp::pmr::new_delete_resource()->deallocate(ptr, bytes, alignment);
+    }
+    // hermetic: do_allocate never returns (calls abort), so do_deallocate is
+    // unreachable for hermetic-mode upstream allocations.
+}
+
+bool GuardedUpstream::do_is_equal(const score::cpp::pmr::memory_resource& other) const noexcept
+{
+    return this == &other;
+}
+
+}  // namespace score::language::rust::memres

--- a/score/language/rust/memres/cpp/guarded_upstream.h
+++ b/score/language/rust/memres/cpp/guarded_upstream.h
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#ifndef SCORE_LANGUAGE_RUST_MEMRES_CPP_GUARDED_UPSTREAM_H
+#define SCORE_LANGUAGE_RUST_MEMRES_CPP_GUARDED_UPSTREAM_H
+
+#include <score/memory_resource.hpp>
+#include <cstddef>
+
+namespace score::language::rust::memres
+{
+
+/// An `score::cpp::pmr::memory_resource` that intercepts upstream allocation
+/// requests from an inner PMR resource and enforces a hermetic boundary.
+///
+/// When constructed with `hermetic = true`:
+///   - Any `do_allocate` call logs a fatal message and calls `std::abort()`.
+///     This guarantees that no allocations beyond the pre-allocated pool ever
+///     reach the system heap.
+///
+/// When constructed with `hermetic = false`:
+///   - Any `do_allocate` call logs a warning and then delegates to
+///     `score::cpp::pmr::new_delete_resource()`, allowing fallback to the heap.
+class GuardedUpstream final : public score::cpp::pmr::memory_resource
+{
+  public:
+    explicit GuardedUpstream(bool hermetic) noexcept;
+    ~GuardedUpstream() override = default;
+
+    GuardedUpstream(const GuardedUpstream&) = delete;
+    GuardedUpstream& operator=(const GuardedUpstream&) = delete;
+    GuardedUpstream(GuardedUpstream&&) = delete;
+    GuardedUpstream& operator=(GuardedUpstream&&) = delete;
+
+  private:
+    void* do_allocate(std::size_t bytes, std::size_t alignment) override;
+    void do_deallocate(void* ptr, std::size_t bytes, std::size_t alignment) override;
+    bool do_is_equal(const score::cpp::pmr::memory_resource& other) const noexcept override;
+
+    bool hermetic_;
+};
+
+}  // namespace score::language::rust::memres
+
+#endif  // SCORE_LANGUAGE_RUST_MEMRES_CPP_GUARDED_UPSTREAM_H

--- a/score/language/rust/memres/cpp/memory_resource_handle.cpp
+++ b/score/language/rust/memres/cpp/memory_resource_handle.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#include "score/language/rust/memres/cpp/memory_resource_handle.h"
+
+namespace score::language::rust::memres
+{
+
+// ---- MonotonicHandle -------------------------------------------------------
+
+MonotonicHandle::MonotonicHandle(std::size_t size, bool hermetic)
+    : upstream_{hermetic}, buffer_{std::make_unique<std::byte[]>(size)}, inner_{buffer_.get(), size, &upstream_}
+{
+}
+
+score::cpp::pmr::memory_resource* MonotonicHandle::resource() noexcept
+{
+    return &inner_;
+}
+
+// ---- UnsynchronizedPoolHandle ----------------------------------------------
+
+UnsynchronizedPoolHandle::UnsynchronizedPoolHandle(score::cpp::pmr::pool_options opts, bool hermetic)
+    : upstream_{hermetic}, inner_{opts, &upstream_}
+{
+}
+
+score::cpp::pmr::memory_resource* UnsynchronizedPoolHandle::resource() noexcept
+{
+    return &inner_;
+}
+
+// ---- DefaultHandle ---------------------------------------------------------
+
+DefaultHandle::DefaultHandle() noexcept : resource_{score::cpp::pmr::get_default_resource()} {}
+
+score::cpp::pmr::memory_resource* DefaultHandle::resource() noexcept
+{
+    return resource_;
+}
+
+}  // namespace score::language::rust::memres

--- a/score/language/rust/memres/cpp/memory_resource_handle.h
+++ b/score/language/rust/memres/cpp/memory_resource_handle.h
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#ifndef SCORE_LANGUAGE_RUST_MEMRES_CPP_MEMORY_RESOURCE_HANDLE_H
+#define SCORE_LANGUAGE_RUST_MEMRES_CPP_MEMORY_RESOURCE_HANDLE_H
+
+#include "score/language/rust/memres/cpp/guarded_upstream.h"
+
+#include <score/memory_resource.hpp>
+#include <cstddef>
+#include <memory>
+
+namespace score::language::rust::memres
+{
+
+/// Abstract base for owned memory resource handles.
+///
+/// Concrete subclasses hold a `GuardedUpstream` and the inner
+/// `score::cpp::pmr::memory_resource` together. Destruction via a base pointer
+/// is safe because the destructor is virtual.
+class MemResHandle
+{
+  public:
+    virtual ~MemResHandle() = default;
+    virtual score::cpp::pmr::memory_resource* resource() noexcept = 0;
+
+  protected:
+    MemResHandle() = default;
+    MemResHandle(const MemResHandle&) = delete;
+    MemResHandle& operator=(const MemResHandle&) = delete;
+    MemResHandle(MemResHandle&&) = delete;
+    MemResHandle& operator=(MemResHandle&&) = delete;
+};
+
+/// Handle for `score::cpp::pmr::monotonic_buffer_resource`.
+///
+/// Member declaration order is significant for construction/destruction:
+///   1. `upstream_`  — constructed first, destroyed last
+///   2. `buffer_` — backing storage; must outlive `inner_`
+///   3. `inner_`  — constructed last, destroyed first; calls `upstream_` on overflow
+class MonotonicHandle final : public MemResHandle
+{
+  public:
+    explicit MonotonicHandle(std::size_t size, bool hermetic);
+    score::cpp::pmr::memory_resource* resource() noexcept override;
+
+  private:
+    GuardedUpstream upstream_;
+    std::unique_ptr<std::byte[]> buffer_;
+    score::cpp::pmr::monotonic_buffer_resource inner_;
+};
+
+/// Handle for `score::cpp::pmr::unsynchronized_pool_resource` (single-threaded).
+///
+/// Member declaration order: `upstream_` before `inner_` so that `inner_` is
+/// destroyed first and can release blocks back to `upstream_` safely.
+class UnsynchronizedPoolHandle final : public MemResHandle
+{
+  public:
+    explicit UnsynchronizedPoolHandle(score::cpp::pmr::pool_options opts, bool hermetic);
+    score::cpp::pmr::memory_resource* resource() noexcept override;
+
+  private:
+    GuardedUpstream upstream_;
+    score::cpp::pmr::unsynchronized_pool_resource inner_;
+};
+
+/// Handle for the process-global default memory resource returned by
+/// `score::cpp::pmr::get_default_resource()`.
+///
+/// This handle does **not** own the resource; destroying it only frees the
+/// thin wrapper object.  The resource itself has process lifetime and must not
+/// be deleted.
+class DefaultHandle final : public MemResHandle
+{
+  public:
+    DefaultHandle() noexcept;
+    score::cpp::pmr::memory_resource* resource() noexcept override;
+
+  private:
+    score::cpp::pmr::memory_resource* resource_;
+};
+
+}  // namespace score::language::rust::memres
+
+#endif  // SCORE_LANGUAGE_RUST_MEMRES_CPP_MEMORY_RESOURCE_HANDLE_H

--- a/score/language/rust/memres/example/BUILD
+++ b/score/language/rust/memres/example/BUILD
@@ -1,0 +1,40 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+
+cc_library(
+    name = "example_helpers",
+    srcs = ["example_helpers.cpp"],
+    hdrs = ["example_helpers.h"],
+    features = COMPILER_WARNING_FEATURES,
+    visibility = ["//score/language/rust/memres:__pkg__"],
+    deps = ["//score/language/futurecpp"],
+)
+
+# Demonstrates MemoryResource in hermetic monotonic mode.
+# Running this binary intentionally terminates the process via std::abort()
+# to show the hermetic boundary in action.
+rust_binary(
+    name = "memres_example",
+    srcs = ["main.rs"],
+    crate_root = "main.rs",
+    edition = "2021",
+    features = ["link_std_cpp_lib"],
+    deps = [
+        ":example_helpers",
+        "//score/language/rust/memres",
+    ],
+)

--- a/score/language/rust/memres/example/example_helpers.cpp
+++ b/score/language/rust/memres/example/example_helpers.cpp
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#include "score/language/rust/memres/example/example_helpers.h"
+
+#include <score/memory_resource.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace
+{
+using ScorePmrVec = std::vector<std::int32_t, score::cpp::pmr::polymorphic_allocator<std::int32_t>>;
+}  // namespace
+
+/// Concrete definition of the opaque handle type declared in the header.
+struct MemresExampleVec
+{
+    ScorePmrVec vec;
+    explicit MemresExampleVec(score::cpp::pmr::memory_resource* mr)
+        : vec{score::cpp::pmr::polymorphic_allocator<std::int32_t>{mr}}
+    {
+    }
+};
+
+extern "C" {
+
+std::size_t memres_example_bytes_needed(std::size_t count) noexcept
+{
+    // One contiguous allocation of `count` int32_t values after reserve().
+    return sizeof(std::int32_t) * count;
+}
+
+MemresExampleVec* memres_example_fill(score::cpp::pmr::memory_resource* mr_ptr, std::size_t count) noexcept
+{
+    // The vector *object* lives on the heap (managed by make_unique).
+    // The element *storage* is requested from `mr_ptr` (the PMR).
+    auto handle = std::make_unique<MemresExampleVec>(mr_ptr);
+    handle->vec.reserve(count);
+    for (std::size_t i = 0U; i < count; ++i)
+    {
+        handle->vec.push_back(static_cast<std::int32_t>(i * i));
+    }
+    return handle.release();  // ownership transferred to caller
+}
+
+void memres_example_vec_destroy(MemresExampleVec* vec_handle) noexcept
+{
+    delete vec_handle;
+}
+
+const std::int32_t* memres_example_vec_data(const MemresExampleVec* vec_handle) noexcept
+{
+    return vec_handle->vec.data();
+}
+
+std::size_t memres_example_vec_len(const MemresExampleVec* vec_handle) noexcept
+{
+    return vec_handle->vec.size();
+}
+
+}  // extern "C"

--- a/score/language/rust/memres/example/example_helpers.h
+++ b/score/language/rust/memres/example/example_helpers.h
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#ifndef SCORE_LANGUAGE_RUST_MEMRES_EXAMPLE_EXAMPLE_HELPERS_H
+#define SCORE_LANGUAGE_RUST_MEMRES_EXAMPLE_EXAMPLE_HELPERS_H
+
+#include <cstddef>
+#include <cstdint>
+
+// Forward declarations for types used in the extern "C" interface.
+namespace score::cpp::pmr
+{
+class memory_resource;
+}
+
+/// Opaque handle for the PMR-backed `vector<int32_t>` allocated by
+/// `memres_example_fill()`.  The concrete layout is private to the
+/// implementation.
+struct MemresExampleVec;
+
+extern "C" {
+
+/// Returns the number of bytes that `memres_example_fill()` will request from
+/// the PMR when called with `count` elements.  The caller uses this to size the
+/// monotonic buffer that is passed as `mr_ptr`.
+///
+/// This is necessary because the element layout is determined by C++ (including
+/// any padding/alignment that `std::pmr::vector` may add).
+std::size_t memres_example_bytes_needed(std::size_t count) noexcept;
+
+/// Heap-allocates a PMR-backed `vector<int32_t>` (via `std::make_unique`), uses
+/// `mr_ptr` as the element allocator, reserves `count` slots, and fills the
+/// vector with the squares of 0..count-1.
+///
+/// The vector *object* lives on the heap (allocated by `make_unique`).
+/// The element *storage* is allocated from `mr_ptr` (the PMR).
+///
+/// Returns a typed handle.  The caller owns the vector and must destroy it
+/// exactly once with `memres_example_vec_destroy()`.
+MemresExampleVec* memres_example_fill(score::cpp::pmr::memory_resource* mr_ptr, std::size_t count) noexcept;
+
+/// Destroys the vector handle returned by `memres_example_fill()`.
+/// Passing `nullptr` is safe (no-op).
+void memres_example_vec_destroy(MemresExampleVec* vec_handle) noexcept;
+
+/// Returns a pointer to the first element of the vector.
+/// Valid only while the handle is alive.
+const std::int32_t* memres_example_vec_data(const MemresExampleVec* vec_handle) noexcept;
+
+/// Returns the number of elements in the vector.
+std::size_t memres_example_vec_len(const MemresExampleVec* vec_handle) noexcept;
+
+}  // extern "C"
+
+#endif  // SCORE_LANGUAGE_RUST_MEMRES_EXAMPLE_EXAMPLE_HELPERS_H

--- a/score/language/rust/memres/example/main.rs
+++ b/score/language/rust/memres/example/main.rs
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+//! Demonstrates `MemoryResource` in hermetic monotonic mode.
+//!
+//! Execution sequence:
+//!  1. Ask C++ how many bytes one `vector<i32>` with `ELEMENT_COUNT` elements needs.
+//!  2. Create a monotonic `MemoryResource` of exactly that size in hermetic mode.
+//!  3. Call C++, which heap-allocates a PMR-backed `vector<int32_t>` whose element
+//!     buffer lives inside our PMR.  Rust wraps the returned handle in `FilledVec`,
+//!     which implements `Deref<Target=[i32]>` and destroys the C++ vector on drop.
+//!  4. Print the contents, then drop `FilledVec`.
+//!  5. Attempt to fill a second vector using the same (exhausted) resource.
+//!     The monotonic buffer does not reclaim deallocated memory, so `GuardedUpstream`
+//!     intercepts the overflow allocation, logs a fatal message, and calls
+//!     `std::abort()`.  The process terminates here.
+
+use memres::{MemoryResource, ResourceKind};
+use std::ops::Deref;
+
+mod helpers {
+    use core::marker::PhantomData;
+    use memres::ScoreMemoryResource;
+
+    /// Opaque handle corresponding to `MemresExampleVec` on the C++ side.
+    #[repr(C)]
+    pub struct ExampleVec {
+        _data: [u8; 0],
+        _marker: PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+    }
+
+    #[link(name = "example_helpers")]
+    unsafe extern "C" {
+        pub fn memres_example_bytes_needed(count: usize) -> usize;
+        pub fn memres_example_fill(mr_ptr: *mut ScoreMemoryResource, count: usize) -> *mut ExampleVec;
+        pub fn memres_example_vec_destroy(vec_handle: *mut ExampleVec);
+        pub fn memres_example_vec_data(vec_handle: *const ExampleVec) -> *const i32;
+        pub fn memres_example_vec_len(vec_handle: *const ExampleVec) -> usize;
+    }
+}
+
+/// Owns a heap-allocated C++ PMR-backed `vector<int32_t>`.
+/// The element storage lives inside the `MemoryResource` that was passed to
+/// `memres_example_fill()`; it is the caller's responsibility to ensure that
+/// `MemoryResource` outlives every `FilledVec` derived from it.
+struct FilledVec {
+    handle: *mut helpers::ExampleVec,
+}
+
+impl FilledVec {
+    fn new(mr: &MemoryResource, count: usize) -> Self {
+        // SAFETY: The raw pointer is valid for the duration of this call;
+        // `MemoryResourcePtr<'_>` borrows `mr` and enforces this at compile time.
+        let handle = unsafe { helpers::memres_example_fill(mr.as_memory_resource_ptr().as_ptr(), count) };
+        assert!(!handle.is_null(), "memres_example_fill: allocation failed");
+        Self { handle }
+    }
+}
+
+impl Deref for FilledVec {
+    type Target = [i32];
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: handle is non-null and we have unique ownership; the
+        // underlying memory is valid for our lifetime.
+        unsafe {
+            let data = helpers::memres_example_vec_data(self.handle);
+            let len = helpers::memres_example_vec_len(self.handle);
+            std::slice::from_raw_parts(data, len)
+        }
+    }
+}
+
+impl Drop for FilledVec {
+    fn drop(&mut self) {
+        // SAFETY: handle is non-null and we are the sole owner.
+        unsafe { helpers::memres_example_vec_destroy(self.handle) }
+    }
+}
+
+const ELEMENT_COUNT: usize = 10;
+
+fn main() {
+    // Step 1 — query the required buffer size from C++.
+    let bytes_needed = unsafe { helpers::memres_example_bytes_needed(ELEMENT_COUNT) };
+    println!(
+        "Bytes needed for one vector<i32> with {} elements: {}",
+        ELEMENT_COUNT, bytes_needed
+    );
+
+    // Step 2 — allocate a monotonic buffer of exactly that size in hermetic mode.
+    let mr = MemoryResource::new(ResourceKind::Monotonic { size: bytes_needed }, true);
+
+    // Step 3 — C++ heap-allocates the vector; its element buffer lives in `mr`.
+    // `FilledVec` is dropped (and the C++ vector destroyed) before `mr` thanks
+    // to Rust's LIFO drop order for local variables.
+    let filled = FilledVec::new(&mr, ELEMENT_COUNT);
+    println!("First fill succeeded. Contents: {:?}", &*filled);
+    drop(filled); // explicit drop to make the order clear
+
+    // Step 4 — second fill: the monotonic buffer is exhausted.  GuardedUpstream
+    // intercepts the overflow allocation, logs a fatal message, and calls
+    // std::abort().
+    println!(
+        "Attempting a second fill on the exhausted resource (hermetic mode) — \
+         the process will now abort:"
+    );
+    let _aborts = FilledVec::new(&mr, ELEMENT_COUNT);
+
+    // Unreachable: std::abort() was called inside FilledVec::new above.
+    println!("UNREACHABLE");
+}

--- a/score/language/rust/memres/src/lib.rs
+++ b/score/language/rust/memres/src/lib.rs
@@ -1,0 +1,279 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+//! Safe Rust wrapper for C++ `score::cpp::pmr::memory_resource` handles.
+//!
+//! This crate exposes three kinds of PMR resources from the `score::cpp`
+//! library:
+//!
+//! - [`ResourceKind::Monotonic`]: a monotonic buffer resource backed by a
+//!   C++-allocated buffer of a fixed size.
+//! - [`ResourceKind::UnsynchronizedPool`]: a single-threaded pool resource.
+//! - The process-global default resource returned by
+//!   `score::cpp::pmr::get_default_resource()`, created via
+//!   [`MemoryResource::default_resource()`].
+//!
+//! Each resource carries a compile-time [`thread_safety`] marker (`Local` or
+//! `Shared`) so that `Send`/`Sync` propagate soundly to every borrower; see
+//! the [`MemoryResource`] documentation.
+//!
+//! Both owned resource kinds support a **hermetic** mode. When `hermetic =
+//! true`, any attempt to allocate beyond the pre-allocated pool logs a fatal
+//! message and calls `std::abort()` on the C++ side, preventing any fallback
+//! to the system heap.  When `hermetic = false`, a warning is logged and the
+//! allocation falls back to `score::cpp::pmr::new_delete_resource()`.
+
+mod ffi {
+    /// Opaque handle type corresponding to
+    /// `score::language::rust::memres::MemResHandle` on the C++ side.
+    ///
+    /// Only pointers to this type are meaningful; it cannot be constructed in
+    /// Rust.
+    #[repr(C)]
+    pub struct MemResHandle {
+        _data: [u8; 0],
+    }
+
+    /// Opaque resource type corresponding to
+    /// `score::cpp::pmr::memory_resource` on the C++ side.
+    ///
+    /// Only pointers to this type are meaningful; it cannot be constructed in
+    /// Rust.  Expose via [`crate::ScoreMemoryResource`].
+    #[repr(C)]
+    pub struct ScoreMemoryResource {
+        _data: [u8; 0],
+    }
+
+    #[link(name = "memres_cpp")]
+    unsafe extern "C" {
+        pub safe fn memres_new_monotonic(size: usize, hermetic: bool) -> *mut MemResHandle;
+        pub safe fn memres_new_unsynchronized_pool(
+            max_blocks_per_chunk: usize,
+            largest_required_pool_block: usize,
+            hermetic: bool,
+        ) -> *mut MemResHandle;
+        pub safe fn memres_new_default() -> *mut MemResHandle;
+
+        // These two methods are explicitly not marked `safe` because their safety can only be guaranteed
+        // by their callees (as the callee will provide a pointer, that may or may not be safe).
+        // Therefore, each usage of them will need an `unsafe` block and justification.
+        pub fn memres_destroy(handle: *mut MemResHandle);
+        pub fn memres_as_memory_resource(handle: *mut MemResHandle) -> *mut ScoreMemoryResource;
+    }
+}
+
+use core::marker::PhantomData;
+pub use ffi::ScoreMemoryResource;
+
+/// Compile-time markers describing whether a [`MemoryResource`] may cross
+/// thread boundaries.
+///
+/// The thread-safety of a PMR resource is a property of the concrete C++
+/// resource, not something the runtime can recover from an erased
+/// `score::cpp::pmr::memory_resource*`.  Encoding it as a type parameter lets
+/// the compiler propagate `Send`/`Sync` correctly to every borrower of the
+/// resource instead of relying on an unconditional, easily-unsound
+/// `unsafe impl`.
+pub mod thread_safety {
+    mod sealed {
+        pub trait Sealed {}
+    }
+
+    /// Marker for a resource whose backing C++ resource synchronises
+    /// internally and may therefore be sent to / shared between threads.
+    pub struct Shared;
+
+    /// Marker for a single-threaded resource that must not cross thread
+    /// boundaries.
+    pub struct Local;
+
+    /// Sealed marker trait implemented only by [`Shared`] and [`Local`].
+    pub trait ThreadSafety: sealed::Sealed {}
+
+    impl sealed::Sealed for Shared {}
+    impl ThreadSafety for Shared {}
+
+    impl sealed::Sealed for Local {}
+    impl ThreadSafety for Local {}
+}
+
+pub use thread_safety::{Local, Shared, ThreadSafety};
+
+/// Options for pool-based memory resources.
+///
+/// A value of `0` for any field lets the C++ implementation choose a default.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PoolOptions {
+    /// Maximum number of blocks per chunk allocated from upstream.
+    /// `0` uses the implementation default.
+    pub max_blocks_per_chunk: usize,
+    /// Largest single allocation served by the pool; requests above this size
+    /// go directly to upstream. `0` uses the implementation default.
+    pub largest_required_pool_block: usize,
+}
+
+/// The kind of C++ PMR resource to create.
+pub enum ResourceKind {
+    /// A monotonic buffer resource backed by a C++-allocated buffer of `size`
+    /// bytes. Allocations are served sequentially; individual deallocations are
+    /// no-ops. When the buffer is exhausted, the `GuardedUpstream` is called.
+    Monotonic { size: usize },
+    /// An unsynchronized (single-threaded) pool resource.
+    UnsynchronizedPool(PoolOptions),
+}
+
+/// A lifetime-bound raw pointer to the underlying
+/// `score::cpp::pmr::memory_resource`.
+///
+/// This wrapper ties the pointer's validity to the borrow of the originating
+/// [`MemoryResource`] via [`PhantomData`].  The borrow checker therefore
+/// prevents the `MemoryResource` from being moved or dropped while this value
+/// is live, eliminating the use-after-free hazard that a bare `*mut` pointer
+/// would expose.
+///
+/// Obtain a value of this type via [`MemoryResource::as_memory_resource_ptr`].
+pub struct MemoryResourcePtr<'a> {
+    ptr: *mut ScoreMemoryResource,
+    _marker: PhantomData<&'a ()>,
+}
+
+impl MemoryResourcePtr<'_> {
+    /// Returns the underlying raw pointer to the
+    /// `score::cpp::pmr::memory_resource`.
+    ///
+    /// The pointer is valid for as long as the originating [`MemoryResource`]
+    /// is alive, which the borrow checker enforces through the lifetime `'a`
+    /// on [`MemoryResourcePtr`].  Do not store this pointer beyond the scope
+    /// in which `MemoryResourcePtr` lives.
+    pub fn as_ptr(&self) -> *mut ScoreMemoryResource {
+        self.ptr
+    }
+}
+
+/// An owned handle to a C++ `score::cpp::pmr::memory_resource`.
+///
+/// On drop, the underlying C++ resource and all associated storage are freed.
+///
+/// # Thread safety
+///
+/// The marker type parameter `S` encodes whether the backing C++ resource is
+/// safe to use across threads:
+///
+/// - [`Shared`]: the backing resource performs its own internal
+///   synchronisation (currently only the process-global default resource,
+///   whose `allocate`/`deallocate` forward to the data-race-free global
+///   `operator new`/`operator delete`).  `MemoryResource<Shared>` is therefore
+///   `Send + Sync`.
+/// - [`Local`] (the default): the backing resource is single-threaded
+///   (`monotonic_buffer_resource`, `unsynchronized_pool_resource`).  Concurrent
+///   access would be a data race, so `MemoryResource<Local>` is `!Send + !Sync`
+///   and the compiler prevents it from crossing thread boundaries.
+pub struct MemoryResource<S: ThreadSafety = Local> {
+    handle: *mut ffi::MemResHandle,
+    _marker: PhantomData<S>,
+}
+
+// SAFETY: A `Shared` resource is backed by the process-global default
+// resource, whose allocate/deallocate forward to the global `operator new`/
+// `operator delete`. The C++ standard requires those to be data-race free, so
+// the handle may be sent to and shared between threads soundly.
+unsafe impl Send for MemoryResource<Shared> {}
+unsafe impl Sync for MemoryResource<Shared> {}
+
+impl MemoryResource<Local> {
+    /// Creates a new single-threaded memory resource of the given kind.
+    ///
+    /// The resulting resource is `!Send + !Sync`: both [`ResourceKind`]
+    /// variants (`Monotonic`, `UnsynchronizedPool`) wrap a C++ resource that
+    /// must not be accessed from more than one thread.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the C++ side fails to allocate the handle. This indicates an
+    /// unrecoverable out-of-memory condition during initialisation.
+    pub fn new(kind: ResourceKind, hermetic: bool) -> Self {
+        // SAFETY: All FFI functions transfer ownership of the returned pointer
+        // to this struct. They are noexcept on the C++ side. The pointer is
+        // non-null on success and null only if the initial heap allocation
+        // fails, which we assert below.
+        let handle = match kind {
+            ResourceKind::Monotonic { size } => ffi::memres_new_monotonic(size, hermetic),
+            ResourceKind::UnsynchronizedPool(opts) => ffi::memres_new_unsynchronized_pool(
+                opts.max_blocks_per_chunk,
+                opts.largest_required_pool_block,
+                hermetic,
+            ),
+        };
+        assert!(
+            !handle.is_null(),
+            "memres: C++ failed to allocate memory resource handle"
+        );
+        Self {
+            handle,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl MemoryResource<Shared> {
+    /// Returns a handle backed by the process-global default memory resource
+    /// (`score::cpp::pmr::get_default_resource()`).
+    ///
+    /// The default resource synchronises internally, so the returned handle is
+    /// `Send + Sync` and may be shared across threads.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the C++ side fails to allocate the thin wrapper handle.
+    pub fn default_resource() -> Self {
+        // SAFETY: memres_new_default allocates a thin non-owning wrapper around
+        // the global default resource; ownership of the wrapper is transferred
+        // to this struct and released via memres_destroy on drop.
+        let handle = ffi::memres_new_default();
+        assert!(
+            !handle.is_null(),
+            "memres: C++ failed to allocate default resource handle"
+        );
+        Self {
+            handle,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S: ThreadSafety> MemoryResource<S> {
+    /// Returns a lifetime-bound pointer to the underlying
+    /// `score::cpp::pmr::memory_resource`.
+    ///
+    /// The returned [`MemoryResourcePtr`] borrows `self` for `'_`, preventing
+    /// this `MemoryResource` from being moved or dropped while the pointer is
+    /// live.  Call [`.as_ptr()`][MemoryResourcePtr::as_ptr] to obtain the
+    /// typed raw pointer to pass to C++.
+    pub fn as_memory_resource_ptr(&self) -> MemoryResourcePtr<'_> {
+        MemoryResourcePtr {
+            // SAFETY: handle is non-null (ensured by the constructors) and
+            // uniquely owned.
+            ptr: unsafe { ffi::memres_as_memory_resource(self.handle) },
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S: ThreadSafety> Drop for MemoryResource<S> {
+    fn drop(&mut self) {
+        // SAFETY: handle is non-null and uniquely owned;
+        // It has been obtained from a call to ffi::memres_new_...;
+        // this is the sole place it is freed.
+        unsafe { ffi::memres_destroy(self.handle) }
+    }
+}

--- a/score/language/rust/memres/src/lib.rs
+++ b/score/language/rust/memres/src/lib.rs
@@ -95,7 +95,18 @@ pub mod thread_safety {
 
     /// Marker for a single-threaded resource that must not cross thread
     /// boundaries.
-    pub struct Local;
+    /// The PhantomData that it inherits from is a way to tell the compiler
+    /// not to derive neither `Send` nor `Sync` for this type.
+    /// Although this is not strictly needed for MemoryResource's case,
+    /// as it's by definition not `Send` nor `Sync` as it carries a mutable
+    /// pointer, other types _could_ implement overloads with `Local` and
+    /// those could have the undesired automatic `Send + Sync` derivation.
+    /// AI detected this possibility on its review, and I decided to follow
+    /// its suggestion to make it really explicit that this struct shall
+    /// never be `Send + Sync`. I cannot use use negative implementation of
+    /// traits because that feature is currently only available on unstable,
+    /// therefore the option of using a compile-time only marker was made.
+    pub struct Local(core::marker::PhantomData<std::rc::Rc<()>>);
 
     /// Sealed marker trait implemented only by [`Shared`] and [`Local`].
     pub trait ThreadSafety: sealed::Sealed {}

--- a/score/language/rust/memres/test/memres_rust_test.rs
+++ b/score/language/rust/memres/test/memres_rust_test.rs
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+//! Rust-level unit tests for the `memres` crate.
+//!
+//! These tests exercise the Rust API (`MemoryResource`, `ResourceKind`,
+//! `PoolOptions`) and verify the end-to-end path through the C++ FFI layer.
+//!
+//! The hermetic abort scenario (second fill in hermetic mode → `std::abort()`)
+//! cannot be tested directly from a Rust `#[test]` because `std::abort()` is
+//! an OS-level process termination that cannot be caught by the Rust test
+//! harness.  That scenario is covered by the C++ `EXPECT_DEATH` tests in
+//! `memres_test.cpp`.
+
+use memres::{MemoryResource, PoolOptions, ResourceKind};
+use std::ops::Deref;
+
+// ---------------------------------------------------------------------------
+// C++ fill helpers (re-declared here so the test binary can link them)
+// ---------------------------------------------------------------------------
+
+mod helpers {
+    use core::marker::PhantomData;
+    use memres::ScoreMemoryResource;
+
+    /// Opaque handle corresponding to `MemresExampleVec` on the C++ side.
+    #[repr(C)]
+    pub struct ExampleVec {
+        _data: [u8; 0],
+        _marker: PhantomData<(*mut u8, core::marker::PhantomPinned)>,
+    }
+
+    #[link(name = "example_helpers")]
+    unsafe extern "C" {
+        pub fn memres_example_bytes_needed(count: usize) -> usize;
+        pub fn memres_example_fill(mr_ptr: *mut ScoreMemoryResource, count: usize) -> *mut ExampleVec;
+        pub fn memres_example_vec_destroy(vec_handle: *mut ExampleVec);
+        pub fn memres_example_vec_data(vec_handle: *const ExampleVec) -> *const i32;
+        pub fn memres_example_vec_len(vec_handle: *const ExampleVec) -> usize;
+    }
+}
+
+/// RAII wrapper around the opaque C++ PMR-backed `vector<int32_t>` handle.
+struct FilledVec(*mut helpers::ExampleVec);
+
+impl FilledVec {
+    fn new(mr: &MemoryResource, count: usize) -> Self {
+        let handle = unsafe { helpers::memres_example_fill(mr.as_memory_resource_ptr().as_ptr(), count) };
+        assert!(!handle.is_null());
+        Self(handle)
+    }
+}
+
+impl Deref for FilledVec {
+    type Target = [i32];
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let data = helpers::memres_example_vec_data(self.0);
+            let len = helpers::memres_example_vec_len(self.0);
+            std::slice::from_raw_parts(data, len)
+        }
+    }
+}
+
+impl Drop for FilledVec {
+    fn drop(&mut self) {
+        unsafe { helpers::memres_example_vec_destroy(self.0) }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handle creation and pointer validity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn monotonic_resource_ptr_is_non_null() {
+    let mr = MemoryResource::new(ResourceKind::Monotonic { size: 1024 }, false);
+    assert!(!mr.as_memory_resource_ptr().as_ptr().is_null());
+}
+
+#[test]
+fn unsynchronized_pool_resource_ptr_is_non_null() {
+    let mr = MemoryResource::new(ResourceKind::UnsynchronizedPool(PoolOptions::default()), false);
+    assert!(!mr.as_memory_resource_ptr().as_ptr().is_null());
+}
+
+/// Two independently created resources must have distinct backing pointers.
+#[test]
+fn two_monotonic_resources_have_distinct_ptrs() {
+    let mr1 = MemoryResource::new(ResourceKind::Monotonic { size: 256 }, false);
+    let mr2 = MemoryResource::new(ResourceKind::Monotonic { size: 256 }, false);
+    assert_ne!(
+        mr1.as_memory_resource_ptr().as_ptr(),
+        mr2.as_memory_resource_ptr().as_ptr()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PoolOptions default contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pool_options_default_fields_are_zero() {
+    let opts = PoolOptions::default();
+    assert_eq!(opts.max_blocks_per_chunk, 0);
+    assert_eq!(opts.largest_required_pool_block, 0);
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end fill: values are correct
+// ---------------------------------------------------------------------------
+
+#[test]
+fn monotonic_first_fill_produces_correct_squares() {
+    const COUNT: usize = 10;
+    let bytes = unsafe { helpers::memres_example_bytes_needed(COUNT) };
+    let mr = MemoryResource::new(ResourceKind::Monotonic { size: bytes }, false);
+
+    let filled = FilledVec::new(&mr, COUNT);
+    assert_eq!(filled.len(), COUNT);
+    for (i, &val) in filled.iter().enumerate() {
+        assert_eq!(val, (i * i) as i32, "element {i}");
+    }
+}
+
+/// Non-hermetic mode: when the monotonic buffer is exhausted the
+/// `GuardedUpstream` warns and falls back to the system heap.  No abort occurs.
+#[test]
+fn monotonic_non_hermetic_overflow_does_not_abort() {
+    const COUNT: usize = 10;
+    let bytes = unsafe { helpers::memres_example_bytes_needed(COUNT) };
+    let mr = MemoryResource::new(ResourceKind::Monotonic { size: bytes }, false);
+
+    let first = FilledVec::new(&mr, COUNT);
+    assert_eq!(first.len(), COUNT);
+    drop(first); // exhausts the PMR buffer (monotonic: dealloc is a no-op)
+
+    // Second fill: GuardedUpstream delegates to new_delete_resource() — no abort.
+    let second = FilledVec::new(&mr, COUNT);
+    assert_eq!(second.len(), COUNT);
+    for (i, &val) in second.iter().enumerate() {
+        assert_eq!(val, (i * i) as i32, "element {i}");
+    }
+}

--- a/score/language/rust/memres/test/memres_test.cpp
+++ b/score/language/rust/memres/test/memres_test.cpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#include "score/language/rust/memres/cpp/ffi.h"
+
+#include <score/memory_resource.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace
+{
+
+constexpr std::size_t kElementCount{10U};
+
+/// Number of bytes consumed by one PMR-backed `vector<int32_t>` with
+/// `kElementCount` elements when `reserve()` is called before any push_back.
+/// This is exactly the allocation requested from the memory resource.
+constexpr std::size_t kBufferBytes{sizeof(std::int32_t) * kElementCount};
+
+using ScorePmrVec = std::vector<std::int32_t, score::cpp::pmr::polymorphic_allocator<std::int32_t>>;
+
+/// Allocates a score::cpp PMR-backed `vector<int32_t>` from the memory resource
+/// owned by `handle`, reserves `kElementCount` slots, and fills it with the
+/// squares of 0..kElementCount-1.
+void FillVector(score::language::rust::memres::MemResHandle* handle)
+{
+    auto* mr = memres_as_memory_resource(handle);
+    ScorePmrVec v{score::cpp::pmr::polymorphic_allocator<std::int32_t>{mr}};
+    v.reserve(kElementCount);
+    for (std::size_t i = 0U; i < kElementCount; ++i)
+    {
+        v.push_back(static_cast<std::int32_t>(i * i));
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Handle creation
+// ---------------------------------------------------------------------------
+
+TEST(MemResMonotonicTest, HandleCreationReturnsNonNull)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_monotonic(kBufferBytes, /*hermetic=*/true);
+    ASSERT_NE(handle, nullptr);
+    memres_destroy(handle);
+}
+
+TEST(MemResUnsynchronizedPoolTest, HandleCreationReturnsNonNull)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_unsynchronized_pool(
+        /*max_blocks_per_chunk=*/0, /*largest_required_pool_block=*/0, /*hermetic=*/false);
+    ASSERT_NE(handle, nullptr);
+    memres_destroy(handle);
+}
+
+// ---------------------------------------------------------------------------
+// Hermetic monotonic: allocation within capacity succeeds
+// ---------------------------------------------------------------------------
+
+TEST(MemResMonotonicHermeticTest, FirstFillSucceeds)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_monotonic(kBufferBytes, /*hermetic=*/true);
+    ASSERT_NE(handle, nullptr);
+    FillVector(handle);
+    memres_destroy(handle);
+}
+
+TEST(MemResMonotonicHermeticTest, FirstFillProducesCorrectValues)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_monotonic(kBufferBytes, /*hermetic=*/true);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        auto* mr = memres_as_memory_resource(handle);
+        ScorePmrVec v{score::cpp::pmr::polymorphic_allocator<std::int32_t>{mr}};
+        v.reserve(kElementCount);
+        for (std::size_t i = 0U; i < kElementCount; ++i)
+        {
+            v.push_back(static_cast<std::int32_t>(i * i));
+        }
+
+        ASSERT_EQ(v.size(), kElementCount);
+        for (std::size_t i = 0U; i < kElementCount; ++i)
+        {
+            EXPECT_EQ(v[i], static_cast<std::int32_t>(i * i));
+        }
+    }
+
+    memres_destroy(handle);
+}
+
+// ---------------------------------------------------------------------------
+// Hermetic monotonic: overflow aborts (buffer exhausted, no fallback)
+// ---------------------------------------------------------------------------
+
+TEST(MemResMonotonicHermeticTest, SecondFillAbortsDueToExhaustion)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_monotonic(kBufferBytes, /*hermetic=*/true);
+    ASSERT_NE(handle, nullptr);
+
+    // The monotonic buffer is now full after the first fill. Monotonic buffer
+    // resources do not reclaim deallocated memory (deallocate is a no-op), so a
+    // second allocation attempt triggers GuardedUpstream::do_allocate() which
+    // logs a fatal message and calls std::abort().
+    FillVector(handle);
+    EXPECT_DEATH(FillVector(handle), "");
+
+    memres_destroy(handle);
+}
+
+// ---------------------------------------------------------------------------
+// Non-hermetic monotonic: overflow falls back to the heap (no abort)
+// ---------------------------------------------------------------------------
+
+TEST(MemResMonotonicNonHermeticTest, OverflowFallsBackToHeap)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_monotonic(kBufferBytes, /*hermetic=*/false);
+    ASSERT_NE(handle, nullptr);
+
+    FillVector(handle);  // served from the PMR buffer
+    FillVector(handle);  // buffer exhausted → GuardedUpstream warns and uses new_delete_resource
+
+    memres_destroy(handle);
+}
+
+// ---------------------------------------------------------------------------
+// Pool resources: basic fill
+// ---------------------------------------------------------------------------
+
+TEST(MemResUnsynchronizedPoolTest, FillSucceeds)
+{
+    score::language::rust::memres::MemResHandle* handle = memres_new_unsynchronized_pool(0, 0, /*hermetic=*/false);
+    ASSERT_NE(handle, nullptr);
+
+    {
+        auto* mr = memres_as_memory_resource(handle);
+        ScorePmrVec v{score::cpp::pmr::polymorphic_allocator<std::int32_t>{mr}};
+        v.reserve(kElementCount);
+        for (std::size_t i = 0U; i < kElementCount; ++i)
+        {
+            v.push_back(static_cast<std::int32_t>(i * i));
+        }
+        ASSERT_EQ(v.size(), kElementCount);
+    }  // v is destroyed here while mr is still alive; its destructor calls mr->deallocate safely
+
+    memres_destroy(handle);
+}


### PR DESCRIPTION
This allows Rust applications that interface with C++ to obtain memory resources to pass back to C++, such that the C++ code will allocate from them, allowing for controlling the memory allocation between the languages.