### PR TITLE
analysis/tracing: Use std::variant instead of score::cpp::variant

### DIFF
--- a/score/analysis/tracing/generic_trace_library/interface_types/generic_trace_api.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/generic_trace_api.h
@@ -141,7 +141,7 @@ class GenericTraceAPI
     /// kRingBufferFullRecoverable, kRingBufferNoEmptyElementRecoverable, kRingBufferNoReadyElementRecoverable,
     /// kClientNotFoundRecoverable) in case where trace operation was not successful
     static TraceResult Trace(const TraceClientId client,
-                             const MetaInfoVariants::Type& meta_info,
+                             const MetaInfoVariants::StdType& meta_info,
                              ShmDataChunkList& data,
                              TraceContextId context_id);
 
@@ -161,7 +161,7 @@ class GenericTraceAPI
     /// kRingBufferFullRecoverable, kRingBufferNoEmptyElementRecoverable, kRingBufferNoReadyElementRecoverable,
     /// kClientNotFoundRecoverable) in case where trace operation was not successful
     static TraceResult Trace(const TraceClientId client,
-                             const MetaInfoVariants::Type& meta_info,
+                             const MetaInfoVariants::StdType& meta_info,
                              LocalDataChunkList& data) noexcept;
 
   private:

--- a/score/analysis/tracing/generic_trace_library/interface_types/i_trace_library.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/i_trace_library.h
@@ -41,11 +41,11 @@ class ITraceLibrary
     virtual RegisterTraceDoneCallBackResult RegisterTraceDoneCB(const TraceClientId trace_client_id,
                                                                 TraceDoneCallBackType trace_done_callback) = 0;
     virtual TraceResult Trace(const TraceClientId trace_client_id,
-                              const MetaInfoVariants::Type& meta_info,
+                              const MetaInfoVariants::StdType& meta_info,
                               ShmDataChunkList& data,
                               TraceContextId context_id) = 0;
     virtual TraceResult Trace(const TraceClientId trace_client_id,
-                              const MetaInfoVariants::Type& meta_info,
+                              const MetaInfoVariants::StdType& meta_info,
                               LocalDataChunkList& data) noexcept = 0;
 };
 

--- a/score/analysis/tracing/generic_trace_library/mock/trace_library_mock.h
+++ b/score/analysis/tracing/generic_trace_library/mock/trace_library_mock.h
@@ -55,13 +55,13 @@ class TraceLibraryMock : public ITraceLibrary
     MOCK_METHOD(TraceResult,
                 Trace,
                 (const TraceClientId client,
-                 const MetaInfoVariants::Type& meta_info,
+                 const MetaInfoVariants::StdType& meta_info,
                  ShmDataChunkList& data,
                  TraceContextId context_id),
                 (override));
     MOCK_METHOD(TraceResult,
                 Trace,
-                (const TraceClientId client, const MetaInfoVariants::Type& meta_info, LocalDataChunkList& data),
+                (const TraceClientId client, const MetaInfoVariants::StdType& meta_info, LocalDataChunkList& data),
                 (noexcept, override));
 };
 

--- a/score/analysis/tracing/generic_trace_library/stub_implementation/generic_trace_api_stub.cpp
+++ b/score/analysis/tracing/generic_trace_library/stub_implementation/generic_trace_api_stub.cpp
@@ -70,7 +70,7 @@ RegisterTraceDoneCallBackResult GenericTraceAPI::RegisterTraceDoneCB(const Trace
 }
 
 TraceResult GenericTraceAPI::Trace(const TraceClientId client,
-                                   const MetaInfoVariants::Type& meta_info,
+                                   const MetaInfoVariants::StdType& meta_info,
                                    ShmDataChunkList& data,
                                    TraceContextId context_id)
 {
@@ -82,7 +82,7 @@ TraceResult GenericTraceAPI::Trace(const TraceClientId client,
 }
 
 TraceResult GenericTraceAPI::Trace(const TraceClientId client,
-                                   const MetaInfoVariants::Type& meta_info,
+                                   const MetaInfoVariants::StdType& meta_info,
                                    LocalDataChunkList& data) noexcept
 {
     if (gMock != nullptr)


### PR DESCRIPTION
This PR changes the generic_trace_api's interfaces and stubs to use std::variant instead of score::cpp::variant.

std::variant is denoted by the type MetaInfoVariants::StdType in meta_info_variants.h

Also, Corresponding helper functions like holds_alternative were changed to the std version.

NOTE: I have checked compiling communication with this change, and this change does NOT affect communication i.e users of generic_trace_api