### PR TITLE
analysis/tracing - Remove usage of score::cpp::variant from service_instance_element

### DIFF
--- a/score/analysis/tracing/generic_trace_library/interface_types/service_instance_element.cpp
+++ b/score/analysis/tracing/generic_trace_library/interface_types/service_instance_element.cpp
@@ -23,37 +23,13 @@ ServiceInstanceElement::ServiceInstanceElement(ServiceIdType input_service_id,
                                                std::uint32_t input_major_version,
                                                std::uint32_t input_minor_version,
                                                InstanceIdType input_instance_id,
-                                               VariantType input_element_id)
+                                               StdVariantType input_element_id)
     : service_id{input_service_id},
       major_version{input_major_version},
       minor_version{input_minor_version},
       instance_id{input_instance_id},
       element_id{input_element_id}
 {
-}
-
-ServiceInstanceElement::ServiceInstanceElement(ServiceIdType input_service_id,
-                                               std::uint32_t input_major_version,
-                                               std::uint32_t input_minor_version,
-                                               InstanceIdType input_instance_id,
-                                               StdVariantType input_element_id)
-    : service_id{input_service_id},
-      major_version{input_major_version},
-      minor_version{input_minor_version},
-      instance_id{input_instance_id}
-{
-    if (std::holds_alternative<EventId>(input_element_id))
-    {
-        element_id = VariantType{score::cpp::in_place_type<EventIdType>, std::get<EventId>(input_element_id).value};
-    }
-    else if (std::holds_alternative<FieldId>(input_element_id))
-    {
-        element_id = VariantType{score::cpp::in_place_type<FieldIdType>, std::get<FieldId>(input_element_id).value};
-    }
-    else
-    {
-        element_id = VariantType{score::cpp::in_place_type<MethodIdType>, std::get<MethodId>(input_element_id).value};
-    }
 }
 
 bool operator==(const ServiceInstanceElement::EventId& lhs, const ServiceInstanceElement::EventId& rhs)

--- a/score/analysis/tracing/generic_trace_library/interface_types/service_instance_element.h
+++ b/score/analysis/tracing/generic_trace_library/interface_types/service_instance_element.h
@@ -15,7 +15,6 @@
 
 #include <score/utility.hpp>
 #include <score/variant.hpp>
-
 #include <cstdint>
 #include <variant>
 
@@ -65,13 +64,6 @@ class ServiceInstanceElement
     /// @brief Default constructor
     ServiceInstanceElement() = default;
 
-    /// @brief Constructor accepting VariantType (score::cpp::variant)
-    ServiceInstanceElement(ServiceIdType input_service_id,
-                           std::uint32_t input_major_version,
-                           std::uint32_t input_minor_version,
-                           InstanceIdType input_instance_id,
-                           VariantType input_element_id);
-
     /// @brief Constructor accepting StdVariantType (std::variant, new type-safe interface)
     ServiceInstanceElement(ServiceIdType input_service_id,
                            std::uint32_t input_major_version,
@@ -93,7 +85,7 @@ class ServiceInstanceElement
     InstanceIdType instance_id;
     // No harm to declare the members as public
     //  coverity[autosar_cpp14_m11_0_1_violation]
-    VariantType element_id;
+    StdVariantType element_id;
 };
 
 /// @brief Comparison operator for ServiceInstanceElement


### PR DESCRIPTION
ServiceInstanceElement used element_id of score::cpp::variant type. changed it to std::variant 