### PR TITLE
hash: Transition to Result<void>

### DIFF
--- a/score/hash/code/core/hash_calculator_mock.h
+++ b/score/hash/code/core/hash_calculator_mock.h
@@ -29,9 +29,9 @@ class HashCalculatorMock final : public IHashCalculator
     HashCalculatorMock() = default;
     ~HashCalculatorMock() = default;
 
-    MOCK_METHOD(ResultBlank, Update, (const score::cpp::span<const std::uint8_t>), (noexcept, override));
-    MOCK_METHOD(ResultBlank, UpdateFromStream, (std::istream & input), (noexcept, override));
-    MOCK_METHOD(ResultBlank, UpdateFromStream, (std::istream & input, std::int64_t max_read), (override));
+    MOCK_METHOD(Result<void>, Update, (const score::cpp::span<const std::uint8_t>), (noexcept, override));
+    MOCK_METHOD(Result<void>, UpdateFromStream, (std::istream & input), (noexcept, override));
+    MOCK_METHOD(Result<void>, UpdateFromStream, (std::istream & input, std::int64_t max_read), (override));
     MOCK_METHOD(Hash, Finalize, (), (noexcept, override));
 };
 

--- a/score/hash/code/core/i_hash_calculator.cpp
+++ b/score/hash/code/core/i_hash_calculator.cpp
@@ -34,7 +34,7 @@ constexpr std::size_t kDataChunkSize{4096U};
 /// @brief Unlimited reading.
 constexpr std::int64_t kReadEndlessFromStream{-1};
 
-using UpdateMethodPtr = ResultBlank (IHashCalculator::*)(const score::cpp::span<const std::uint8_t>&);
+using UpdateMethodPtr = Result<void> (IHashCalculator::*)(const score::cpp::span<const std::uint8_t>&);
 
 /// @brief Auxiliary class for parsing Streams.
 /// @details Made a separated class to avoid keeping state on the interface level.
@@ -99,7 +99,7 @@ class StreamConsumer
     {
     }
 
-    ResultBlank Consume(std::istream& input)
+    Result<void> Consume(std::istream& input)
     {
         // GCOVR is unable to analyze line below. But all decision are taken in for while declaration.
         while (input.good() == true)  // LCOV_EXCL_BR_LINE rationale above
@@ -120,7 +120,7 @@ class StreamConsumer
             if (update_result.has_value() == false)
             {
                 mw::log::LogError() << "IHashCalculator::Input data might be invalid " << __func__;
-                return MakeUnexpected<score::Blank>(update_result.error());
+                return MakeUnexpected<void>(update_result.error());
             }
 
             accumulate();
@@ -138,12 +138,12 @@ class StreamConsumer
 
 }  // namespace
 
-ResultBlank IHashCalculator::UpdateFromStream(std::istream& input)
+Result<void> IHashCalculator::UpdateFromStream(std::istream& input)
 {
     return UpdateFromStream(input, kReadEndlessFromStream);
 }
 
-ResultBlank IHashCalculator::UpdateFromStream(std::istream& input, const std::int64_t max_read)
+Result<void> IHashCalculator::UpdateFromStream(std::istream& input, const std::int64_t max_read)
 {
     if (input.good() == false)
     {

--- a/score/hash/code/core/i_hash_calculator.h
+++ b/score/hash/code/core/i_hash_calculator.h
@@ -45,8 +45,8 @@ class IHashCalculator
     ///
     /// @param[in] data pointer to the block of data that should be added.
     ///
-    /// @return score::cpp::blank upon successful update, error otherwise
-    virtual ResultBlank Update(const score::cpp::span<const std::uint8_t> data) noexcept = 0;
+    /// @return void upon successful update, error otherwise
+    virtual Result<void> Update(const score::cpp::span<const std::uint8_t> data) noexcept = 0;
 
     /// @brief Update current hash calculation with input stream
     /// This method can be called multiple times for hash calculation
@@ -56,8 +56,8 @@ class IHashCalculator
     ///
     /// @param[in] input istream whose data should be used for update
     ///
-    /// @return score::cpp::blank upon successful update, error otherwise
-    virtual ResultBlank UpdateFromStream(std::istream& input);
+    /// @return void upon successful update, error otherwise
+    virtual Result<void> UpdateFromStream(std::istream& input);
 
     /// @brief Update current hash calculation with input stream
     /// This method can be called multiple times for hash calculation
@@ -68,8 +68,8 @@ class IHashCalculator
     /// @param[in] input istream whose data should be used for update
     /// @param[in] max_read the number of bytes that shall be read from the stream
     ///
-    /// @return score::cpp::blank upon successful update, error otherwise
-    virtual ResultBlank UpdateFromStream(std::istream& input, const std::int64_t max_read);
+    /// @return void upon successful update, error otherwise
+    virtual Result<void> UpdateFromStream(std::istream& input, const std::int64_t max_read);
 
     /// @brief Finalize hash calculation and retrieve computed hash value
     ///

--- a/score/hash/code/crc/crc32_ieee.cpp
+++ b/score/hash/code/crc/crc32_ieee.cpp
@@ -48,7 +48,7 @@ std::uint_fast32_t Crc32IeeeHashCalculator::GetChecksum() const noexcept
     return ~checksum_ & kAllOnes;
 }
 
-ResultBlank Crc32IeeeHashCalculator::Update(const score::cpp::span<const std::uint8_t> data) noexcept
+Result<void> Crc32IeeeHashCalculator::Update(const score::cpp::span<const std::uint8_t> data) noexcept
 {
     checksum_ = CalculateIeeeCrc32(checksum_, data.begin(), data.end());
     return {};

--- a/score/hash/code/crc/crc32_ieee.h
+++ b/score/hash/code/crc/crc32_ieee.h
@@ -28,7 +28,7 @@ class Crc32IeeeHashCalculator final : public ICrc32HashCalculator
 {
   public:
     Crc32IeeeHashCalculator() noexcept;
-    ResultBlank Update(const score::cpp::span<const std::uint8_t> data) noexcept override;
+    Result<void> Update(const score::cpp::span<const std::uint8_t> data) noexcept override;
     Hash Finalize() noexcept override;
     std::uint_fast32_t GetChecksum() const noexcept override;
 

--- a/score/hash/code/crc/crc32_mock.h
+++ b/score/hash/code/crc/crc32_mock.h
@@ -29,8 +29,8 @@ class Crc32HashCalculatorMock final : public ICrc32HashCalculator
     Crc32HashCalculatorMock() = default;
     ~Crc32HashCalculatorMock() = default;
 
-    MOCK_METHOD(ResultBlank, Update, (const score::cpp::span<const std::uint8_t>), (noexcept, override));
-    MOCK_METHOD(ResultBlank, UpdateFromStream, (std::istream & input), (noexcept, override));
+    MOCK_METHOD(Result<void>, Update, (const score::cpp::span<const std::uint8_t>), (noexcept, override));
+    MOCK_METHOD(Result<void>, UpdateFromStream, (std::istream & input), (noexcept, override));
     MOCK_METHOD(Hash, Finalize, (), (noexcept, override));
     MOCK_METHOD(std::uint_fast32_t, GetChecksum, (), (const, noexcept, override));
 };

--- a/score/hash/code/openssl/openssl_hash_calculator.cpp
+++ b/score/hash/code/openssl/openssl_hash_calculator.cpp
@@ -91,7 +91,7 @@ Result<OpensslHashCalculator> OpensslHashCalculator::Create(const HashAlgorithm 
     return OpensslHashCalculator(algorithm, message_digest_context, openssl);
 }
 
-ResultBlank OpensslHashCalculator::Update(const score::cpp::span<const std::uint8_t> data) noexcept
+Result<void> OpensslHashCalculator::Update(const score::cpp::span<const std::uint8_t> data) noexcept
 {
     if (nullptr == data.data())
     {

--- a/score/hash/code/openssl/openssl_hash_calculator.h
+++ b/score/hash/code/openssl/openssl_hash_calculator.h
@@ -49,7 +49,7 @@ class OpensslHashCalculator final : public IHashCalculator
     static Result<OpensslHashCalculator> Create(const HashAlgorithm algorithm,
                                                 const openssl::IOpensslLib& openssl = GetDefaultOpenSslImpl()) noexcept;
 
-    ResultBlank Update(const score::cpp::span<const std::uint8_t> data) noexcept override;
+    Result<void> Update(const score::cpp::span<const std::uint8_t> data) noexcept override;
 
     Hash Finalize() noexcept override;
 

--- a/score/hash/code/sha256digest/sha256digest.cpp
+++ b/score/hash/code/sha256digest/sha256digest.cpp
@@ -110,7 +110,7 @@ constexpr std::uint32_t Ssig1(const std::uint32_t x)
 
 Sha256Digest::Sha256Digest() noexcept : IHashCalculator(), buffer_{}, hash_(kSha256StartingValues), message_len_{0U} {}
 
-ResultBlank Sha256Digest::Update(const score::cpp::span<const std::uint8_t> data) noexcept
+Result<void> Sha256Digest::Update(const score::cpp::span<const std::uint8_t> data) noexcept
 {
     if (data.empty() || (data.data() == nullptr))
     {

--- a/score/hash/code/sha256digest/sha256digest.h
+++ b/score/hash/code/sha256digest/sha256digest.h
@@ -104,7 +104,7 @@ class Sha256Digest final : public IHashCalculator
   public:
     Sha256Digest() noexcept;
 
-    ResultBlank Update(const score::cpp::span<const std::uint8_t> data) noexcept override;
+    Result<void> Update(const score::cpp::span<const std::uint8_t> data) noexcept override;
     Hash Finalize() noexcept override;
 
   private:

--- a/score/hash/design/ClassDiagram.puml
+++ b/score/hash/design/ClassDiagram.puml
@@ -31,8 +31,8 @@ class SafeHashCalculatorFactory {
 }
 
 interface IHashCalculator {
-  +Update(data: const amp::span<const std::uint8_t>): ResultBlank
-  +UpdateFromStream(input: std::istream&): ResultBlank
+  +Update(data: const amp::span<const std::uint8_t>): Result<void>
+  +UpdateFromStream(input: std::istream&): Result<void>
   +Finalize(): Hash
 }
 


### PR DESCRIPTION
Adopt `Result<void>` in hash to align with the deprecation of `ResultBlank` in the result library.