### PR TITLE
Add AGENTS.md and C++ style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,168 @@
+# AGENTS.md
+
+## Repository Overview
+
+**score_baselibs** is a collection of foundational C++ and Rust libraries for the S-CORE (Eclipse) automotive platform, targeting ISO 26262 ASIL-B compliance with MISRA C++:2023. The C++ standard is **C++17**. Rust edition is **2021**. C++ exceptions are **not used** (they cause `abort` on target platforms). Supported platforms: **Linux** and **QNX 8.0 SDP**. Architectures: **x86_64** and **AArch64**. Build system: **Bazel 8 (bzlmod)**. The Bazel module name is `score_baselibs`.
+
+## Repository Layout
+
+```
+score/          # C++ AND Rust libraries side by side (concurrency, containers, containers_rust, filesystem,
+                # json, memory, network, os, result, allocator, pal, sync, thread, testing_macros, log_rust, etc.)
+src/            # Deprecated Bazel alias stubs. No real sources here.
+examples/       # Integration and usage examples (C++ and Rust)
+third_party/    # External dependency BUILD files (acl, openssl, libcap2, etc.)
+docs/           # Sphinx documentation sources
+.github/        # CI workflows, CODEOWNERS, tools
+```
+
+**Key root files:** `MODULE.bazel` (Bazel module definition and deps), `.bazelrc` (all build configs), `Cargo.toml` (Rust workspace).
+
+## Core Libraries and Preferred Alternatives
+
+A few `score/` libraries exist specifically to replace a standard C++ feature that is banned, unavailable, or unsafe in this repository. Prefer these over the standard feature they replace:
+
+- **`score/result`** — `score::Result<T>` is the repository's error-return type. Use it instead of C++ exceptions, which this repository does not use (see Repository Overview).
+- **`score/filesystem`** — a C++ wrapper around POSIX filesystem operations, modeled on `std::filesystem` but with mockable/fake implementations for tests. Use it instead of the standard `<filesystem>` header, which might be not safety-certified on some platforms.
+- **`score/language/futurecpp`** (namespace `score::cpp`) — backports of newer (C++20-and-later) standard library facilities to C++17, e.g. `score::cpp::jthread`, `score::cpp::span`, `score::cpp::expected`, `score::cpp::latch`, `score::cpp::stop_token`. Use these instead of the equivalent `std::` C++20+ types, since this repository is C++17 only. It also provides `score::cpp::pmr`, the repository's counterpart to the C++17 `std::pmr` polymorphic memory resource facilities (e.g. `score::cpp::pmr::polymorphic_allocator`, `score::cpp::pmr::memory_resource`, and the `score::cpp::pmr` container aliases like `vector`, `string`, `map`). Prefer `score::cpp::pmr` over `std::pmr`.
+- **`score/os`** — the OS Abstraction Layer (OSAL): an adapter library giving an OS-independent interface to POSIX-like operating systems (Linux, QNX). Use it instead of calling raw OS/POSIX APIs directly (e.g. `SigAction` wraps `sigaction()`).
+- **`libm`** (system library) — the C math library, for real-valued math functions. Use it instead of the C++ `<complex>`/`<complex.h>` headers, which might be not safety-certified on some platforms.
+
+## Building and Testing
+
+Always use `--config=bl-x86_64-linux` for Linux x86_64 builds. This flag is **required** — bare `bazel build //...` will fail due to missing platform/toolchain configuration.
+
+### Build
+
+```bash
+bazel build --config=bl-x86_64-linux //score/...   # All C++ and Rust libraries
+```
+
+### Test
+
+```bash
+bazel test --config=bl-x86_64-linux //score/...    # All C++ and Rust tests
+```
+
+To test a single target, replace `//score/...` with the specific Bazel label, e.g., `//score/containers_rust:containers_test`.
+
+### Other Configs (reference only — prefer bl-x86_64-linux)
+
+- `--config=bl-aarch64-linux` — AArch64 Linux (cross-compile, needs `qemu-user`)
+- `--config=bl-x86_64-qnx` / `--config=bl-aarch64-qnx` — QNX (needs SDP credentials). If a user requests a QNX build, first confirm they have QNX SDP credentials configured. If not, direct them to obtain credentials before proceeding and do not generate QNX build commands.
+
+## Formatting
+
+### Auto-fix all formatting (C++, Python, Rust, Starlark/BUILD, YAML)
+
+```bash
+bazel run //:format.fix
+```
+
+This formats C++ (clang-format), Python (ruff), Rust (rustfmt), Starlark/BUILD (buildifier), and YAML (yamlfmt).
+
+To format only specific files instead of the whole project, list them after `--`:
+
+```bash
+bazel run //:format.fix -- score/result/error.cpp score/result/error.h
+```
+
+### Check formatting (without modifying files)
+
+```bash
+bazel test //:format.check
+```
+
+This runs all format checks (C++, Python, Rust, Starlark, YAML) as test targets.
+
+### Copyright headers
+
+Copyright headers are enforced in this repository; CI will fail if they are missing or incorrect. If unsure how the header should look for a given file type, don't guess: run `copyright.fix` and let it generate the header for you.
+
+```bash
+bazel run //:copyright.check    # Verify
+bazel run //:copyright.fix      # Auto-fix missing headers
+```
+
+**Every new file must have a copyright header.** The year must be the year in which the file is being created. If the current year is unknown, use `<YEAR>` as a placeholder.
+
+C++ files (`.h`, `.cpp`):
+```cpp
+/********************************************************************************
+ * Copyright (c) <YEAR> Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+```
+
+Rust (`.rs`), Python (`.py`), Starlark (`.bzl`), BUILD files — use `#` comment prefix. Bazel files use the same text with `#` line comments.
+
+## Linting
+
+### clang-tidy (C++)
+
+```bash
+bazel build --config=clang_tidy -- //score/...
+```
+
+Config: `.clang-tidy-minimal` at repo root.
+
+### Rust clippy
+
+```bash
+bazel build --config=lint -- //score/...
+```
+
+### C++ Sanitizers
+
+```bash
+bazel test --config=bl-x86_64-linux --config=asan_ubsan_lsan --build_tests_only -- //score/...
+```
+
+## C++ Coding Conventions
+
+### Style (naming, files, formatting, comments)
+
+**Before writing, modifying, or reviewing any C++, you MUST read [cpp-style-guide.md](./docs/cpp-style-guide.md)** and apply it on the first pass. It is the source of truth for naming, file/API structure, and comments. Do not rely on neighboring files as a style reference — some predate the guide and violate it. Mechanical formatting is applied by `.clang-format`.
+
+C++ standard: C++17. No exceptions. No RTTI unless explicitly needed. Tests use Google Test (`cc_gtest_unit_test` macro from `bazel/unit_tests.bzl`), named `*_test.cpp` and colocated with source.
+
+### Build Rules
+
+- **Visibility:** Use `visibility = ["//visibility:public"]` only for libraries with a public API consumed by users of `score_baselibs`. Be conservative: do not expose internal or helper libraries. Internal targets should use package-level or narrower visibility.
+- **Compiler warnings:** Use `features = COMPILER_WARNING_FEATURES` from `score/language/safecpp:toolchain_features.bzl`.
+
+### Safety Tags
+
+- **ASIL tags:** Use `tags = ["FFI"]` only for libraries targeting ASIL-B safety integrity level. QM-level libraries must not have this tag.
+
+## Rust Conventions
+
+- Do **not** run `rustfmt` directly. Use commands from Formatting section.
+- Cargo workspace is defined in root `Cargo.toml`. Rust crates live under `score/`, alongside the C++ libraries.
+- Cargo build requires Rust **1.90.0** (from `rust-toolchain.toml`). Bazel uses Ferrocene toolchain.
+- Rust code should follow the Safety-Critical Rust Consortium coding guidelines: https://github.com/Safety-Critical-Rust-Consortium/safety-critical-rust-coding-guidelines/tree/main/src/coding-guidelines.
+- Allowed Rust crates are listed in https://github.com/eclipse-score/score-crates/blob/main/MODULE.bazel. Adding new crate dependencies should be a last resort. If a required crate is missing and there is no meaningful alternative to implement a feature, consult the user before proceeding.
+
+## Integration Test
+
+The `examples/integration/` directory contains a module-level integration test. CI runs:
+
+```bash
+cd examples/integration && bazel build //...
+```
+
+## Documentation
+
+Documentation lives in `docs/` and uses Sphinx with the sphinx-needs extension, integrated with Bazel. The project follows the S-CORE process defined at https://github.com/eclipse-score/process_description. The metamodels for Sphinx-needs directives and Bazel integration are maintained at https://github.com/eclipse-score/docs-as-code.
+
+```bash
+bazel run //:docs    # Build docs, output at _build/index.html
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,3 +18,7 @@ extensions = [
     "sphinxcontrib.plantuml",
     "score_sphinx_bundle",
 ]
+
+# Not part of the Sphinx doc tree; it's a plain-Markdown style guide referenced
+# directly (e.g. from AGENTS.md), not meant to be rendered as a docs page.
+exclude_patterns = ["cpp-style-guide.md"]

--- a/docs/cpp-style-guide.md
+++ b/docs/cpp-style-guide.md
@@ -1,0 +1,58 @@
+# C++ Style Conventions
+
+Apply these when writing or reviewing C++. This document covers **style**: naming, file and API structure, and comments, i.e. how the code reads.
+
+Mechanical formatting (indentation, spacing, brace placement, line wrapping, pointer alignment, the 120-column limit, namespace-close comments, preprocessor-directive indentation) is applied automatically by the repository's `.clang-format`. These conventions deliberately omit those rules so they stay focused on what clang-format cannot do: naming, structure, and semantics. Do not spend effort hand-formatting; run clang-format.
+
+When you touch existing code, fix style within the lines you add or change; leave untouched surrounding lines alone rather than reformatting the whole file.
+
+## Worked examples
+The highest-frequency style fixes; the same reasoning generalizes to the rules below.
+
+**Member naming:**
+Before: `int m_count;`
+After: `int count_;`
+
+**Global constant:**
+Before: `const int DAYS_IN_WEEK = 7;`
+After: `constexpr int kDaysInAWeek{7};`
+
+**Uniform initialization:**
+Before: `std::string name = "abc";`
+After: `std::string name{"abc"};`
+
+## Naming
+- Files and variables are `snake_case`. Namespaces are `snake_case` and follow the `score::...` hierarchy.
+- Types (classes, structs, enums, aliases) are `PascalCase` with no underscores; even well-known acronyms are not all-caps (`XmlStreamReader`, not `XMLStreamReader`).
+- Functions and methods are `PascalCase` (`MaxConcurrencyLevel()`).
+- Class data members carry a trailing underscore (`memory_resource_`); struct members do not. Exception: `static constexpr`/`static const` class constants use the `k`-prefix constant rule below (`kMask`, not `mask_`).
+- `k`-prefix every `const`/`constexpr` with static storage duration and a fixed value: namespace-scope constants and `static constexpr`/`static const` class members (`kDaysInAWeek`, `static constexpr std::uint8_t kMask{...};`). Optional for local `constexpr` variables. Enumerators also take the `k` prefix; prefer scoped enums (`enum class`), and only an enumerator in the global namespace embeds the type name (`kUrlTableErrors_Ok`). Mutable global variables are not used (MISRA 6.7.2 forbids them).
+- Macros are a last resort (MISRA 19.0.2 bans function-like macros); when unavoidable, name them `UPPER_CASE_WITH_UNDERSCORES`.
+- Be descriptive. Avoid abbreviations except ones that are well known outside the project (`url`, `dns`), and never abbreviate by dropping letters (`error_count`, not `error_cnt`). Types and variables are nouns; functions read as imperative verbs.
+- Function parameter order is inputs, then inputs/outputs, then outputs.
+- Non-type template parameters follow the variable convention; type template parameters are `PascalCase`, commonly suffixed `...Type`.
+
+## Files and headers
+- One class per translation unit: `class_name.h` / `class_name.cpp`, tests in `class_name_test.cpp`, mocks in `class_name_mock.h` / `class_name_mock.cpp`. Library folder names are `snake_case`.
+- A file opens with the copyright header, then the include guard. `#pragma once` is not allowed.
+- Include-guard name: the file path uppercased, `/` and `.` replaced by `_`, so `score/result/error.h` becomes `SCORE_RESULT_ERROR_H`.
+- Use `"..."` for project headers and `<...>` for system and external headers, and include the file's own header first. clang-format sorts includes within each block.
+- Definitions of inline functions belong in a header.
+
+## Classes
+- Declaration order: `public`, then `protected`, then `private`. Within each section: aliases/enums, constructors, destructor, methods, data members. `friend` declarations go in the `private` section. The `.cpp` defines members in the same order.
+- List constructor initializers in member-declaration order, so run order matches the source and there is no `-Wreorder` warning.
+- Interfaces do not use an `I` prefix: the interface keeps the plain name (`Executor`), the implementation takes an `Impl` suffix (`ExecutorImpl`), and the mock a `Mock` suffix (`ExecutorMock`). A pure interface declares a non-pure `virtual` destructor so deletion through the interface pointer is well defined.
+
+## Idioms
+Semantic and declaration rules that `.clang-format` cannot apply, so apply them yourself:
+- Brace-initialize uniformly (`int x{3};`), not `int x = 3;`; clang-format will not convert `=` to braces.
+- Declare only one pointer variable per line (`char* a;` then `char* b;`, never `char* a, *b;`).
+- Do not wrap a `return` value in unnecessary parentheses.
+- Prefer named constants over bare literals, `nullptr`, or `true`/`false` passed as arguments, so the call site explains itself.
+
+## Comments
+- `//` for ordinary comments, `///` for Doxygen; prefix Doxygen tags with `@` (`@brief`, `@param`, `@return`). Write in English, in complete sentences.
+- On a public declaration, `@brief` is mandatory; add `@param`/`@return` when non-trivial. Document ownership transfer, whether arguments may be `nullptr`, the lifetime of retained references, thread-safety assumptions, and performance implications. A comment at the definition explains *how* the code works rather than repeating the declaration.
+- Class data members get a short Doxygen comment describing their purpose and any sentinel values.
+- Use `@todo` with the associated GitHub issue for non-trivial TODOs. Mark deprecated APIs with the C++ `[[deprecated("use NewApi instead")]]` attribute.


### PR DESCRIPTION
Adds an AGENTS.md file at the repo root to give AI coding agents the context needed to work effectively in `score_baselibs`.

Also adds `cpp-style-guide.md`, the C++ style reference that AGENTS.md points to and that contributors should follow when writing or reviewing C++ code.