### PR TITLE
Making inotify bazel target public

### DIFF
--- a/score/os/BUILD
+++ b/score/os/BUILD
@@ -133,9 +133,7 @@ cc_library(
     ],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
-    visibility = [
-        "@score_baselibs//score/os:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":errno",
         ":object_seam",


### PR DESCRIPTION
Making the `inotify` bazel target public, (I think it was made non-public by mistake as the mock is public).