### PR TITLE
Prepare migration of score/memory/shared to score_communication

### DIFF
--- a/.github/workflows/build_qnx.yml
+++ b/.github/workflows/build_qnx.yml
@@ -33,8 +33,6 @@ jobs:
               -//score/language/futurecpp/tests:memory_resource_test
               -//score/language/futurecpp/tests:zip_iterator_test
               -//score/language/safecpp/aborts_upon_exception:abortsuponexception_toolchain_test
-              -//score/memory/shared:shared_memory_factory_test
-              -//score/memory/shared:shared_memory_resource_open_test
               -//score/os/test:asil_qm_test
               -//score/os/test:grp_test
           - bazel-config: bl-aarch64-qnx
@@ -42,8 +40,6 @@ jobs:
               //score/...
               -//score/language/futurecpp/tests:memory_resource_test
               -//score/language/safecpp/aborts_upon_exception:abortsuponexception_toolchain_test
-              -//score/memory/shared:shared_memory_factory_test
-              -//score/memory/shared:shared_memory_resource_open_test
               -//score/os/utils/inotify:unit_test
             extra-bazel-test-flags: "--test_timeout=120,600,1800,7200" # Increase test timeout due to QEMU emulation
     uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@af347722c7ae3ed85518895c11268d96ac728f62

--- a/score/memory/shared/BUILD
+++ b/score/memory/shared/BUILD
@@ -609,6 +609,7 @@ cc_gtest_unit_test(
         "shared_memory_factory_test.cpp",
     ],
     features = COMPILER_WARNING_FEATURES,
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = [
         "@score_baselibs//score/memory:__pkg__",
     ],
@@ -889,6 +890,7 @@ cc_gtest_unit_test(
         "shared_memory_resource_open_test.cpp",
     ],
     features = COMPILER_WARNING_FEATURES,
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = [
         "@score_baselibs//score/memory:__pkg__",
     ],


### PR DESCRIPTION
Drop targets from QNX workflow.
Since the workflow is triggered by pull_request_target, modifying it in the same PR that removes the targets leads still to a red gate.

Thus, we first remove them in a separate PR.