### PR TITLE
Drop `T: Copy` bound to support nested/movable ABI types

### DIFF
--- a/score/containers_rust/inline/drop_tests.rs
+++ b/score/containers_rust/inline/drop_tests.rs
@@ -1,0 +1,278 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+//! Tests that the inline building blocks correctly support non-`Copy` (movable, droppable) payloads
+//! and arbitrary nesting, without leaking or double-dropping their contents.
+
+use core::mem::{align_of, size_of};
+use std::cell::Cell;
+use std::rc::Rc;
+
+use crate::inline::{InlineOption, InlineQueue, InlineResult, InlineString, InlineVec};
+
+/// A non-`Copy` payload that tracks how many live instances exist and how many times a value has been
+/// dropped, so tests can detect both leaks (live count doesn't return to zero) and double-drops
+/// (drop count exceeds the number of created values).
+struct Tracked {
+    alive: Rc<Cell<i64>>,
+    drops: Rc<Cell<usize>>,
+    value: u32,
+}
+
+impl Tracked {
+    fn new(counters: &Counters, value: u32) -> Self {
+        counters.alive.set(counters.alive.get() + 1);
+        Self {
+            alive: Rc::clone(&counters.alive),
+            drops: Rc::clone(&counters.drops),
+            value,
+        }
+    }
+}
+
+impl Clone for Tracked {
+    fn clone(&self) -> Self {
+        self.alive.set(self.alive.get() + 1);
+        Self {
+            alive: Rc::clone(&self.alive),
+            drops: Rc::clone(&self.drops),
+            value: self.value,
+        }
+    }
+}
+
+impl Drop for Tracked {
+    fn drop(&mut self) {
+        self.alive.set(self.alive.get() - 1);
+        self.drops.set(self.drops.get() + 1);
+    }
+}
+
+#[derive(Clone, Default)]
+struct Counters {
+    alive: Rc<Cell<i64>>,
+    drops: Rc<Cell<usize>>,
+}
+
+impl Counters {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn make(&self, value: u32) -> Tracked {
+        Tracked::new(self, value)
+    }
+}
+
+#[test]
+fn inline_vec_drops_all_elements() {
+    let counters = Counters::new();
+    {
+        let mut vec = InlineVec::<Tracked, 4>::new();
+        for i in 0..4 {
+            vec.push(counters.make(i)).unwrap();
+        }
+        assert_eq!(counters.alive.get(), 4);
+        assert_eq!(counters.drops.get(), 0);
+    }
+    // Dropping the vector must drop every contained element exactly once.
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 4);
+}
+
+#[test]
+fn inline_vec_clear_and_pop_are_drop_safe() {
+    let counters = Counters::new();
+    let mut vec = InlineVec::<Tracked, 4>::new();
+    for i in 0..3 {
+        vec.push(counters.make(i)).unwrap();
+    }
+
+    // `pop` moves the value out; it is dropped only when the returned value goes out of scope.
+    let popped = vec.pop().unwrap();
+    assert_eq!(popped.value, 2);
+    assert_eq!(counters.drops.get(), 0);
+    drop(popped);
+    assert_eq!(counters.drops.get(), 1);
+
+    // `clear` drops the remaining elements exactly once.
+    vec.clear();
+    assert_eq!(counters.drops.get(), 3);
+    assert_eq!(counters.alive.get(), 0);
+
+    // Dropping the now-empty vector must not drop anything again.
+    drop(vec);
+    assert_eq!(counters.drops.get(), 3);
+}
+
+#[test]
+fn inline_queue_drops_all_elements() {
+    let counters = Counters::new();
+    {
+        let mut queue = InlineQueue::<Tracked, 4>::new();
+        queue.push_back(counters.make(0)).unwrap();
+        queue.push_back(counters.make(1)).unwrap();
+        queue.push_front(counters.make(2)).unwrap();
+        assert_eq!(counters.alive.get(), 3);
+    }
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 3);
+}
+
+#[test]
+fn inline_option_is_drop_safe() {
+    let counters = Counters::new();
+
+    // Some drops its payload.
+    {
+        let _some = InlineOption::some(counters.make(1));
+        assert_eq!(counters.alive.get(), 1);
+    }
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 1);
+
+    // None has nothing to drop.
+    let none = InlineOption::<Tracked>::none();
+    drop(none);
+    assert_eq!(counters.drops.get(), 1);
+}
+
+#[test]
+fn inline_option_into_option_does_not_double_drop() {
+    let counters = Counters::new();
+    let some = InlineOption::some(counters.make(7));
+    let recovered = some.into_option();
+    assert_eq!(recovered.as_ref().unwrap().value, 7);
+    // The value has been moved out exactly once, so it is still alive and not double-dropped.
+    assert_eq!(counters.alive.get(), 1);
+    assert_eq!(counters.drops.get(), 0);
+    drop(recovered);
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 1);
+}
+
+#[test]
+fn inline_option_clone_tracks_ownership() {
+    let counters = Counters::new();
+    let original = InlineOption::some(counters.make(3));
+    let cloned = original.clone();
+    assert_eq!(counters.alive.get(), 2);
+    drop(original);
+    drop(cloned);
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 2);
+}
+
+#[test]
+fn inline_result_is_drop_safe() {
+    let counters = Counters::new();
+
+    {
+        let _ok = InlineResult::<Tracked, Tracked>::ok(counters.make(1));
+        let _err = InlineResult::<Tracked, Tracked>::err(counters.make(2));
+        assert_eq!(counters.alive.get(), 2);
+    }
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 2);
+}
+
+#[test]
+fn inline_result_into_result_does_not_double_drop() {
+    let counters = Counters::new();
+
+    let ok = InlineResult::<Tracked, Tracked>::ok(counters.make(5));
+    let recovered = ok.into_result();
+    assert_eq!(recovered.as_ref().ok().unwrap().value, 5);
+    assert_eq!(counters.alive.get(), 1);
+    assert_eq!(counters.drops.get(), 0);
+    drop(recovered);
+    assert_eq!(counters.drops.get(), 1);
+
+    let err = InlineResult::<Tracked, Tracked>::err(counters.make(6));
+    let recovered = err.into_result();
+    assert_eq!(recovered.as_ref().err().unwrap().value, 6);
+    drop(recovered);
+    assert_eq!(counters.drops.get(), 2);
+    assert_eq!(counters.alive.get(), 0);
+}
+
+#[test]
+fn inline_result_clone_tracks_ownership() {
+    let counters = Counters::new();
+    let original = InlineResult::<Tracked, Tracked>::ok(counters.make(9));
+    let cloned = original.clone();
+    assert_eq!(counters.alive.get(), 2);
+    drop(original);
+    drop(cloned);
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 2);
+}
+
+#[test]
+fn nested_vec_of_strings() {
+    let mut vec = InlineVec::<InlineString<8>, 4>::new();
+    for word in ["ab", "cde", "fghi"] {
+        let mut string = InlineString::<8>::new();
+        string.push_str(word).unwrap();
+        vec.push(string).unwrap();
+    }
+
+    assert_eq!(vec.len(), 3);
+    assert_eq!(vec[0].as_str(), "ab");
+    assert_eq!(vec[1].as_str(), "cde");
+    assert_eq!(vec[2].as_str(), "fghi");
+}
+
+#[test]
+fn nested_vec_of_droppable_options_is_drop_safe() {
+    let counters = Counters::new();
+    {
+        let mut vec = InlineVec::<InlineOption<Tracked>, 4>::new();
+        vec.push(InlineOption::some(counters.make(0))).unwrap();
+        vec.push(InlineOption::none()).unwrap();
+        vec.push(InlineOption::some(counters.make(1))).unwrap();
+        assert_eq!(counters.alive.get(), 2);
+    }
+    // Dropping the outer vector must recursively drop the inner options' payloads.
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 2);
+}
+
+#[test]
+fn nested_option_of_vec_is_drop_safe() {
+    let counters = Counters::new();
+    {
+        let mut inner = InlineVec::<Tracked, 4>::new();
+        inner.push(counters.make(0)).unwrap();
+        inner.push(counters.make(1)).unwrap();
+        let _outer = InlineOption::some(inner);
+        assert_eq!(counters.alive.get(), 2);
+    }
+    assert_eq!(counters.alive.get(), 0);
+    assert_eq!(counters.drops.get(), 2);
+}
+
+#[test]
+fn nested_types_have_stable_repr_c_layout() {
+    // `InlineString<8>` is `{ len: u32, [u8; 8] }` => 12 bytes, align 4.
+    assert_eq!(size_of::<InlineString<8>>(), 12);
+    assert_eq!(align_of::<InlineString<8>>(), 4);
+
+    // `InlineVec<InlineString<8>, 4>` is `{ len: u32, [InlineString<8>; 4] }` => 4 + 4*12 = 52 bytes.
+    assert_eq!(size_of::<InlineVec<InlineString<8>, 4>>(), 52);
+    assert_eq!(align_of::<InlineVec<InlineString<8>, 4>>(), 4);
+
+    // `InlineOption<u64>` is `{ MaybeUninit<u64>, bool }` => 8 + 1 padded to 16 bytes, align 8.
+    assert_eq!(size_of::<InlineOption<u64>>(), 16);
+    assert_eq!(align_of::<InlineOption<u64>>(), 8);
+}

--- a/score/containers_rust/inline/mod.rs
+++ b/score/containers_rust/inline/mod.rs
@@ -19,6 +19,9 @@ mod result;
 mod string;
 mod vec;
 
+#[cfg(test)]
+mod drop_tests;
+
 pub use self::option::InlineOption;
 pub use self::queue::InlineQueue;
 pub use self::result::InlineResult;

--- a/score/containers_rust/inline/option.rs
+++ b/score/containers_rust/inline/option.rs
@@ -13,6 +13,7 @@
 
 use core::cmp;
 use core::fmt;
+use core::mem::ManuallyDrop;
 use core::mem::MaybeUninit;
 use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 
@@ -27,15 +28,17 @@ use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 /// **Note:** When encoding an instance of this type in other programming languages,
 /// the `is_some` field must only be assigned the binary values `0x00` and `0x01`;
 /// everything else results in *Undefined Behavior*.
-#[derive(Clone, Copy)]
+///
+/// Unlike the standard [`Option`], this type is **not** `Copy` (even when `T: Copy`), because it runs
+/// drop glue for the contained value; it implements [`Clone`] when `T: Clone`.
 #[repr(C)]
-pub struct InlineOption<T: Copy> {
+pub struct InlineOption<T> {
     /// This is valid/initialized if and only if `is_some` is true.
     value: MaybeUninit<T>,
     is_some: bool,
 }
 
-impl<T: Copy> InlineOption<T> {
+impl<T> InlineOption<T> {
     /// Creates a new instance populated by `value`.
     pub const fn some(value: T) -> Self {
         Self {
@@ -62,10 +65,13 @@ impl<T: Copy> InlineOption<T> {
     }
 
     /// Converts this instance into a standard [`Option`].
-    pub const fn into_option(self) -> Option<T> {
-        if self.is_some {
+    pub fn into_option(self) -> Option<T> {
+        let this = ManuallyDrop::new(self);
+        if this.is_some {
             // SAFETY: `is_some` is true, so `value` must be valid as per its invariant.
-            Some(unsafe { self.value.assume_init() })
+            // `self` is wrapped in `ManuallyDrop`, so its `Drop` impl won't run and the value is
+            // moved out exactly once.
+            Some(unsafe { this.value.assume_init_read() })
         } else {
             None
         }
@@ -92,7 +98,25 @@ impl<T: Copy> InlineOption<T> {
     }
 }
 
-impl<T: Copy> Default for InlineOption<T> {
+impl<T> Drop for InlineOption<T> {
+    fn drop(&mut self) {
+        if self.is_some {
+            // SAFETY: `is_some` is true, so `value` must be valid as per its invariant.
+            unsafe { self.value.assume_init_drop() };
+        }
+    }
+}
+
+impl<T: Clone> Clone for InlineOption<T> {
+    fn clone(&self) -> Self {
+        match self.as_ref() {
+            Some(value) => Self::some(value.clone()),
+            None => Self::none(),
+        }
+    }
+}
+
+impl<T> Default for InlineOption<T> {
     fn default() -> Self {
         Self {
             value: MaybeUninit::uninit(),
@@ -101,7 +125,7 @@ impl<T: Copy> Default for InlineOption<T> {
     }
 }
 
-impl<T: Copy> From<T> for InlineOption<T> {
+impl<T> From<T> for InlineOption<T> {
     fn from(value: T) -> Self {
         Self {
             value: MaybeUninit::new(value),
@@ -110,19 +134,19 @@ impl<T: Copy> From<T> for InlineOption<T> {
     }
 }
 
-impl<T: Copy> From<Option<T>> for InlineOption<T> {
+impl<T> From<Option<T>> for InlineOption<T> {
     fn from(option: Option<T>) -> Self {
         Self::from_option(option)
     }
 }
 
-impl<T: Copy> From<InlineOption<T>> for Option<T> {
+impl<T> From<InlineOption<T>> for Option<T> {
     fn from(option: InlineOption<T>) -> Self {
         option.into_option()
     }
 }
 
-impl<T: PartialEq + Copy> PartialEq for InlineOption<T> {
+impl<T: PartialEq> PartialEq for InlineOption<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self.as_ref(), other.as_ref()) {
             (Some(a), Some(b)) => a.eq(b),
@@ -133,9 +157,9 @@ impl<T: PartialEq + Copy> PartialEq for InlineOption<T> {
     }
 }
 
-impl<T: Eq + Copy> Eq for InlineOption<T> {}
+impl<T: Eq> Eq for InlineOption<T> {}
 
-impl<T: PartialOrd + Copy> PartialOrd for InlineOption<T> {
+impl<T: PartialOrd> PartialOrd for InlineOption<T> {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         match (self.as_ref(), other.as_ref()) {
             (Some(a), Some(b)) => a.partial_cmp(b),
@@ -146,7 +170,7 @@ impl<T: PartialOrd + Copy> PartialOrd for InlineOption<T> {
     }
 }
 
-impl<T: Ord + Copy> Ord for InlineOption<T> {
+impl<T: Ord> Ord for InlineOption<T> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         match (self.as_ref(), other.as_ref()) {
             (Some(a), Some(b)) => a.cmp(b),
@@ -157,7 +181,7 @@ impl<T: Ord + Copy> Ord for InlineOption<T> {
     }
 }
 
-impl<T: Copy> fmt::Display for InlineOption<T>
+impl<T> fmt::Display for InlineOption<T>
 where
     for<'a> Option<&'a T>: fmt::Display,
 {
@@ -166,7 +190,7 @@ where
     }
 }
 
-impl<T: Copy> fmt::Debug for InlineOption<T>
+impl<T> fmt::Debug for InlineOption<T>
 where
     for<'a> Option<&'a T>: fmt::Debug,
 {
@@ -175,7 +199,7 @@ where
     }
 }
 
-impl<T: Copy> ScoreDebug for InlineOption<T>
+impl<T> ScoreDebug for InlineOption<T>
 where
     for<'a> Option<&'a T>: ScoreDebug,
 {
@@ -233,12 +257,10 @@ mod tests {
             assert_eq!(lhs.ne(rhs), lhs.as_ref().ne(&rhs.as_ref()));
         }
 
-        let some_5 = InlineOption::some(5);
-        let some_6 = InlineOption::some(6);
-        let none = InlineOption::none();
+        let options = [InlineOption::some(5), InlineOption::some(6), InlineOption::none()];
         // Check all combinations
-        for lhs in &[some_5, some_6, none] {
-            for rhs in &[some_5, some_6, none] {
+        for lhs in &options {
+            for rhs in &options {
                 check(lhs, rhs);
             }
         }
@@ -256,12 +278,10 @@ mod tests {
             assert_eq!(lhs >= rhs, lhs.as_ref() >= rhs.as_ref());
         }
 
-        let some_5 = InlineOption::some(5);
-        let some_6 = InlineOption::some(6);
-        let none = InlineOption::none();
+        let options = [InlineOption::some(5), InlineOption::some(6), InlineOption::none()];
         // Check all combinations
-        for lhs in &[some_5, some_6, none] {
-            for rhs in &[some_5, some_6, none] {
+        for lhs in &options {
+            for rhs in &options {
                 check(lhs, rhs);
             }
         }
@@ -277,12 +297,10 @@ mod tests {
             assert_eq!(lhs.min(rhs).as_ref(), lhs.as_ref().min(rhs.as_ref()));
         }
 
-        let some_5 = InlineOption::some(5);
-        let some_6 = InlineOption::some(6);
-        let none = InlineOption::none();
+        let options = [InlineOption::some(5), InlineOption::some(6), InlineOption::none()];
         // Check all combinations
-        for lhs in &[some_5, some_6, none] {
-            for rhs in &[some_5, some_6, none] {
+        for lhs in &options {
+            for rhs in &options {
                 check(lhs, rhs);
             }
         }

--- a/score/containers_rust/inline/queue.rs
+++ b/score/containers_rust/inline/queue.rs
@@ -37,11 +37,11 @@ use crate::storage::Inline;
 /// }
 /// ```
 #[repr(transparent)]
-pub struct InlineQueue<T: Copy, const CAPACITY: usize> {
+pub struct InlineQueue<T, const CAPACITY: usize> {
     inner: GenericQueue<T, Inline<T, CAPACITY>>,
 }
 
-impl<T: Copy, const CAPACITY: usize> InlineQueue<T, CAPACITY> {
+impl<T, const CAPACITY: usize> InlineQueue<T, CAPACITY> {
     const CHECK_CAPACITY: () = assert!(0 < CAPACITY && CAPACITY <= u32::MAX as usize);
 
     /// Creates an empty queue.
@@ -55,13 +55,19 @@ impl<T: Copy, const CAPACITY: usize> InlineQueue<T, CAPACITY> {
     }
 }
 
-impl<T: Copy, const CAPACITY: usize> Default for InlineQueue<T, CAPACITY> {
+impl<T, const CAPACITY: usize> Drop for InlineQueue<T, CAPACITY> {
+    fn drop(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<T, const CAPACITY: usize> Default for InlineQueue<T, CAPACITY> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: Copy, const CAPACITY: usize> ops::Deref for InlineQueue<T, CAPACITY> {
+impl<T, const CAPACITY: usize> ops::Deref for InlineQueue<T, CAPACITY> {
     type Target = GenericQueue<T, Inline<T, CAPACITY>>;
 
     fn deref(&self) -> &Self::Target {
@@ -69,19 +75,19 @@ impl<T: Copy, const CAPACITY: usize> ops::Deref for InlineQueue<T, CAPACITY> {
     }
 }
 
-impl<T: Copy, const CAPACITY: usize> ops::DerefMut for InlineQueue<T, CAPACITY> {
+impl<T, const CAPACITY: usize> ops::DerefMut for InlineQueue<T, CAPACITY> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<T: Copy + fmt::Debug, const CAPACITY: usize> fmt::Debug for InlineQueue<T, CAPACITY> {
+impl<T: fmt::Debug, const CAPACITY: usize> fmt::Debug for InlineQueue<T, CAPACITY> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.inner, f)
     }
 }
 
-impl<T: Copy + ScoreDebug, const CAPACITY: usize> ScoreDebug for InlineQueue<T, CAPACITY> {
+impl<T: ScoreDebug, const CAPACITY: usize> ScoreDebug for InlineQueue<T, CAPACITY> {
     fn fmt(&self, f: Writer, spec: &FormatSpec) -> ScoreLogResult {
         ScoreDebug::fmt(&self.inner, f, spec)
     }

--- a/score/containers_rust/inline/result.rs
+++ b/score/containers_rust/inline/result.rs
@@ -14,6 +14,7 @@
 use core::cmp;
 use core::fmt;
 use core::mem::ManuallyDrop;
+use core::ptr;
 use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 
 /// An result value for error handling, similar to [`Result`] in the Rust standard library.
@@ -24,22 +25,24 @@ use score_log::fmt::{FormatSpec, Result as ScoreLogResult, ScoreDebug, Writer};
 /// **Note:** When encoding an instance of this type in other programming languages,
 /// the `is_ok` field must only be assigned the binary values `0x00` and `0x01`;
 /// everything else results in *Undefined Behavior*.
-#[derive(Clone, Copy)]
+///
+/// Unlike the standard [`Result`], this type is **not** `Copy` (even when `T: Copy` and `E: Copy`),
+/// because it runs drop glue for the contained value; it implements [`Clone`] when `T: Clone` and
+/// `E: Clone`.
 #[repr(C)]
-pub struct InlineResult<T: Copy, E: Copy> {
+pub struct InlineResult<T, E> {
     /// When `is_ok` is true, then `value.ok` is valid, otherwise `value.err`.
     value: ResultUnion<T, E>,
     is_ok: bool,
 }
 
-#[derive(Clone, Copy)]
 #[repr(C)]
-union ResultUnion<T: Copy, E: Copy> {
+union ResultUnion<T, E> {
     ok: ManuallyDrop<T>,
     err: ManuallyDrop<E>,
 }
 
-impl<T: Copy, E: Copy> InlineResult<T, E> {
+impl<T, E> InlineResult<T, E> {
     /// Creates a new instance representing success with `value` as payload.
     pub const fn ok(value: T) -> Self {
         Self {
@@ -69,13 +72,16 @@ impl<T: Copy, E: Copy> InlineResult<T, E> {
     }
 
     /// Converts this instance into a standard [`Result`].
-    pub const fn into_result(self) -> Result<T, E> {
-        if self.is_ok {
+    pub fn into_result(self) -> Result<T, E> {
+        let this = ManuallyDrop::new(self);
+        if this.is_ok {
             // SAFETY: `is_ok` is true, so `value.ok` must be valid as per its invariant.
-            Ok(ManuallyDrop::into_inner(unsafe { self.value.ok }))
+            // `self` is wrapped in `ManuallyDrop`, so its `Drop` impl won't run and the payload is
+            // moved out exactly once.
+            Ok(ManuallyDrop::into_inner(unsafe { ptr::read(&this.value.ok) }))
         } else {
             // SAFETY: `is_ok` is false, so `value.err` must be valid as per its invariant.
-            Err(ManuallyDrop::into_inner(unsafe { self.value.err }))
+            Err(ManuallyDrop::into_inner(unsafe { ptr::read(&this.value.err) }))
         }
     }
 
@@ -102,7 +108,28 @@ impl<T: Copy, E: Copy> InlineResult<T, E> {
     }
 }
 
-impl<T: Default + Copy, E: Copy> Default for InlineResult<T, E> {
+impl<T, E> Drop for InlineResult<T, E> {
+    fn drop(&mut self) {
+        if self.is_ok {
+            // SAFETY: `is_ok` is true, so `value.ok` must be valid as per its invariant.
+            unsafe { ManuallyDrop::drop(&mut self.value.ok) };
+        } else {
+            // SAFETY: `is_ok` is false, so `value.err` must be valid as per its invariant.
+            unsafe { ManuallyDrop::drop(&mut self.value.err) };
+        }
+    }
+}
+
+impl<T: Clone, E: Clone> Clone for InlineResult<T, E> {
+    fn clone(&self) -> Self {
+        match self.as_ref() {
+            Ok(value) => Self::ok(value.clone()),
+            Err(error) => Self::err(error.clone()),
+        }
+    }
+}
+
+impl<T: Default, E> Default for InlineResult<T, E> {
     fn default() -> Self {
         Self {
             value: ResultUnion {
@@ -113,7 +140,7 @@ impl<T: Default + Copy, E: Copy> Default for InlineResult<T, E> {
     }
 }
 
-impl<T: Copy, E: Copy> From<T> for InlineResult<T, E> {
+impl<T, E> From<T> for InlineResult<T, E> {
     fn from(value: T) -> Self {
         Self {
             value: ResultUnion {
@@ -124,19 +151,19 @@ impl<T: Copy, E: Copy> From<T> for InlineResult<T, E> {
     }
 }
 
-impl<T: Copy, E: Copy> From<Result<T, E>> for InlineResult<T, E> {
+impl<T, E> From<Result<T, E>> for InlineResult<T, E> {
     fn from(result: Result<T, E>) -> Self {
         Self::from_result(result)
     }
 }
 
-impl<T: Copy, E: Copy> From<InlineResult<T, E>> for Result<T, E> {
+impl<T, E> From<InlineResult<T, E>> for Result<T, E> {
     fn from(result: InlineResult<T, E>) -> Self {
         result.into_result()
     }
 }
 
-impl<T: PartialEq + Copy, E: PartialEq + Copy> PartialEq for InlineResult<T, E> {
+impl<T: PartialEq, E: PartialEq> PartialEq for InlineResult<T, E> {
     fn eq(&self, other: &Self) -> bool {
         match (self.as_ref(), other.as_ref()) {
             (Ok(a), Ok(b)) => a.eq(b),
@@ -147,9 +174,9 @@ impl<T: PartialEq + Copy, E: PartialEq + Copy> PartialEq for InlineResult<T, E> 
     }
 }
 
-impl<T: Eq + Copy, E: Eq + Copy> Eq for InlineResult<T, E> {}
+impl<T: Eq, E: Eq> Eq for InlineResult<T, E> {}
 
-impl<T: PartialOrd + Copy, E: PartialOrd + Copy> PartialOrd for InlineResult<T, E> {
+impl<T: PartialOrd, E: PartialOrd> PartialOrd for InlineResult<T, E> {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         match (self.as_ref(), other.as_ref()) {
             (Ok(a), Ok(b)) => a.partial_cmp(b),
@@ -160,7 +187,7 @@ impl<T: PartialOrd + Copy, E: PartialOrd + Copy> PartialOrd for InlineResult<T, 
     }
 }
 
-impl<T: Ord + Copy, E: Ord + Copy> Ord for InlineResult<T, E> {
+impl<T: Ord, E: Ord> Ord for InlineResult<T, E> {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         match (self.as_ref(), other.as_ref()) {
             (Ok(a), Ok(b)) => a.cmp(b),
@@ -171,7 +198,7 @@ impl<T: Ord + Copy, E: Ord + Copy> Ord for InlineResult<T, E> {
     }
 }
 
-impl<T: Copy, E: Copy> fmt::Display for InlineResult<T, E>
+impl<T, E> fmt::Display for InlineResult<T, E>
 where
     for<'a> Result<&'a T, &'a E>: fmt::Display,
 {
@@ -180,7 +207,7 @@ where
     }
 }
 
-impl<T: Copy, E: Copy> fmt::Debug for InlineResult<T, E>
+impl<T, E> fmt::Debug for InlineResult<T, E>
 where
     for<'a> Result<&'a T, &'a E>: fmt::Debug,
 {
@@ -189,7 +216,7 @@ where
     }
 }
 
-impl<T: Copy, E: Copy> ScoreDebug for InlineResult<T, E>
+impl<T, E> ScoreDebug for InlineResult<T, E>
 where
     for<'a> Result<&'a T, &'a E>: ScoreDebug,
 {
@@ -247,13 +274,15 @@ mod tests {
             assert_eq!(lhs.ne(rhs), lhs.as_ref().ne(&rhs.as_ref()));
         }
 
-        let ok_5 = InlineResult::ok(5);
-        let ok_6 = InlineResult::ok(6);
-        let err_5 = InlineResult::err(5);
-        let err_6 = InlineResult::err(6);
+        let results = [
+            InlineResult::ok(5),
+            InlineResult::ok(6),
+            InlineResult::err(5),
+            InlineResult::err(6),
+        ];
         // Check all combinations
-        for lhs in &[ok_5, ok_6, err_5, err_6] {
-            for rhs in &[ok_5, ok_6, err_5, err_6] {
+        for lhs in &results {
+            for rhs in &results {
                 check(lhs, rhs);
             }
         }
@@ -271,13 +300,15 @@ mod tests {
             assert_eq!(lhs >= rhs, lhs.as_ref() >= rhs.as_ref());
         }
 
-        let ok_5 = InlineResult::ok(5);
-        let ok_6 = InlineResult::ok(6);
-        let err_5 = InlineResult::err(5);
-        let err_6 = InlineResult::err(6);
+        let results = [
+            InlineResult::ok(5),
+            InlineResult::ok(6),
+            InlineResult::err(5),
+            InlineResult::err(6),
+        ];
         // Check all combinations
-        for lhs in &[ok_5, ok_6, err_5, err_6] {
-            for rhs in &[ok_5, ok_6, err_5, err_6] {
+        for lhs in &results {
+            for rhs in &results {
                 check(lhs, rhs);
             }
         }
@@ -293,13 +324,15 @@ mod tests {
             assert_eq!(lhs.min(rhs).as_ref(), lhs.as_ref().min(rhs.as_ref()));
         }
 
-        let ok_5 = InlineResult::ok(5);
-        let ok_6 = InlineResult::ok(6);
-        let err_5 = InlineResult::err(5);
-        let err_6 = InlineResult::err(6);
+        let results = [
+            InlineResult::ok(5),
+            InlineResult::ok(6),
+            InlineResult::err(5),
+            InlineResult::err(6),
+        ];
         // Check all combinations
-        for lhs in &[ok_5, ok_6, err_5, err_6] {
-            for rhs in &[ok_5, ok_6, err_5, err_6] {
+        for lhs in &results {
+            for rhs in &results {
                 check(lhs, rhs);
             }
         }

--- a/score/containers_rust/inline/vec.rs
+++ b/score/containers_rust/inline/vec.rs
@@ -36,11 +36,11 @@ use crate::storage::Inline;
 /// }
 /// ```
 #[repr(transparent)]
-pub struct InlineVec<T: Copy, const CAPACITY: usize> {
+pub struct InlineVec<T, const CAPACITY: usize> {
     inner: GenericVec<T, Inline<T, CAPACITY>>,
 }
 
-impl<T: Copy, const CAPACITY: usize> InlineVec<T, CAPACITY> {
+impl<T, const CAPACITY: usize> InlineVec<T, CAPACITY> {
     const CHECK_CAPACITY: () = assert!(0 < CAPACITY && CAPACITY <= u32::MAX as usize);
 
     /// Creates an empty vector.
@@ -54,13 +54,19 @@ impl<T: Copy, const CAPACITY: usize> InlineVec<T, CAPACITY> {
     }
 }
 
-impl<T: Copy, const CAPACITY: usize> Default for InlineVec<T, CAPACITY> {
+impl<T, const CAPACITY: usize> Drop for InlineVec<T, CAPACITY> {
+    fn drop(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl<T, const CAPACITY: usize> Default for InlineVec<T, CAPACITY> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: Copy, const CAPACITY: usize> ops::Deref for InlineVec<T, CAPACITY> {
+impl<T, const CAPACITY: usize> ops::Deref for InlineVec<T, CAPACITY> {
     type Target = GenericVec<T, Inline<T, CAPACITY>>;
 
     fn deref(&self) -> &Self::Target {
@@ -68,19 +74,19 @@ impl<T: Copy, const CAPACITY: usize> ops::Deref for InlineVec<T, CAPACITY> {
     }
 }
 
-impl<T: Copy, const CAPACITY: usize> ops::DerefMut for InlineVec<T, CAPACITY> {
+impl<T, const CAPACITY: usize> ops::DerefMut for InlineVec<T, CAPACITY> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<T: Copy + fmt::Debug, const CAPACITY: usize> fmt::Debug for InlineVec<T, CAPACITY> {
+impl<T: fmt::Debug, const CAPACITY: usize> fmt::Debug for InlineVec<T, CAPACITY> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.as_slice(), f)
     }
 }
 
-impl<T: Copy + ScoreDebug, const CAPACITY: usize> ScoreDebug for InlineVec<T, CAPACITY> {
+impl<T: ScoreDebug, const CAPACITY: usize> ScoreDebug for InlineVec<T, CAPACITY> {
     fn fmt(&self, f: Writer, spec: &FormatSpec) -> ScoreLogResult {
         ScoreDebug::fmt(self.as_slice(), f, spec)
     }


### PR DESCRIPTION
This enables nestable/movable of the Rust inline data types, so nesting such as `InlineVec<InlineString<..>>` becomes possible.

- InlineVec/InlineQueue: remove the `T: Copy` bound and add a `Drop` impl that calls `inner.clear()` (mirrors the FixedCapacity* pattern; the generic layer is already drop-safe internally).
- InlineOption/InlineResult: remove `#[derive(Clone, Copy)]` and the `T/E: Copy` bounds, add manual `Drop` glue, and make into_option/ into_result double-drop safe via ManuallyDrop. Because Rust forbids `Copy + Drop`, these types are no longer `Copy`; they now implement `Clone` when the payload is `Clone`.

Relocation stays trivial (Rust moves are memcpy) and all `#[repr(C)]`/`#[repr(transparent)]` layouts are unchanged. Adds drop-safety, nesting, and size_of/align_of layout tests, and updates existing comparison tests that relied on `Copy` (reuse-after-move).