### PR TITLE
Add more component labels to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,18 +14,33 @@
 comp-abi-types:
   - changed-files:
       - any-glob-to-any-file: 'score/containers_rust/**'
+comp-allocator:
+  - changed-files:
+      - any-glob-to-any-file: 'score/allocator/**'
+comp-bitmanipulation:
+  - changed-files:
+      - any-glob-to-any-file: 'score/bitmanipulation/**'
 comp-concurrency:
   - changed-files:
-      - any-glob-to-any-file: 'score/concurrency/**'
+      - any-glob-to-any-file:
+          - 'score/concurrency/**'
+          - 'score/sync/**'
+          - 'score/thread/**'
 comp-cpp-containers:
   - changed-files:
       - any-glob-to-any-file: 'score/containers/**'
 comp-datetime:
   - changed-files:
       - any-glob-to-any-file: 'score/datetime_converter/**'
+comp-filesystem:
+  - changed-files:
+      - any-glob-to-any-file: 'score/filesystem/**'
 comp-flatbuffers:
   - changed-files:
       - any-glob-to-any-file: 'score/flatbuffers/**'
+comp-futurecpp:
+  - changed-files:
+      - any-glob-to-any-file: 'score/language/futurecpp/**'
 comp-hash:
   - changed-files:
       - any-glob-to-any-file: 'score/hash/**'
@@ -37,18 +52,36 @@ comp-logging:
       - any-glob-to-any-file:
           - 'score/mw/log/**'
           - 'score/log_rust/**'
+comp-memory:
+  - changed-files:
+      - any-glob-to-any-file: 'score/memory/**'
+comp-network:
+  - changed-files:
+      - any-glob-to-any-file: 'score/network/**'
 comp-osal:
   - changed-files:
       - any-glob-to-any-file: 'score/os/**'
+comp-pal:
+  - changed-files:
+      - any-glob-to-any-file: 'score/pal/**'
 comp-result:
   - changed-files:
       - any-glob-to-any-file: 'score/result/**'
 comp-safecpp:
   - changed-files:
       - any-glob-to-any-file: 'score/language/safecpp/**'
+comp-scope_exit:
+  - changed-files:
+      - any-glob-to-any-file: 'score/scope_exit/**'
 comp-static_reflection_with_serialization:
   - changed-files:
       - any-glob-to-any-file: 'score/static_reflection_with_serialization/**'
+comp-string_manipulation:
+  - changed-files:
+      - any-glob-to-any-file: 'score/string_manipulation/**'
+comp-testing_macros:
+  - changed-files:
+      - any-glob-to-any-file: 'score/testing_macros/**'
 comp-tracing:
   - changed-files:
       - any-glob-to-any-file: 'score/analysis/tracing/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -104,3 +104,12 @@ c++:
 rust:
   - changed-files:
       - any-glob-to-any-file: '**/*.rs'
+bazel:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.bzl'
+          - '**/*.bazel'
+          - '**/BUILD'
+          - '**/WORKSPACE'
+          - '**/.bazelrc'
+          - '**/.bazelversion'


### PR DESCRIPTION
Extends `.github/labeler.yml` to cover previously unlabeled `score/` components.

New component labels (already created in the repo):
- `comp-filesystem` -> `score/filesystem`
- `comp-memory` -> `score/memory`
- `comp-allocator` -> `score/allocator`
- `comp-bitmanipulation` -> `score/bitmanipulation`
- `comp-futurecpp` -> `score/language/futurecpp`
- `comp-network` -> `score/network`
- `comp-pal` -> `score/pal`
- `comp-scope_exit` -> `score/scope_exit`
- `comp-string_manipulation` -> `score/string_manipulation`
- `comp-testing_macros` -> `score/testing_macros`

Also groups `score/sync` and `score/thread` under the existing `comp-concurrency` label.

Additionally, `bazel` label is used if any bazel related files are modified.