### PR TITLE
Add AI instructions for commenting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,16 @@ bazel build --config=lint -- //score/...
 bazel test --config=bl-x86_64-linux --config=asan_ubsan_lsan --build_tests_only -- //score/...
 ```
 
+## General coding commenting guidelines
+
+- Write in English in complete sentences. Be concise.
+- Avoid filler, pleasantries and hedging.
+- Write one sentence per line.
+- Do not decorate sections (e.g. with long ---------- comments).
+- Wrap only when unavoidable, first try to rephrase the comment to fit. Respect formatter column limit.
+- Do not wrap Markdown - rephrase or keep as is.
+- Double spaces between sentences are unnecessary.
+
 ## C++ Coding Conventions
 
 ### Style (naming, files, formatting, comments)

--- a/docs/cpp-style-guide.md
+++ b/docs/cpp-style-guide.md
@@ -52,7 +52,7 @@ Semantic and declaration rules that `.clang-format` cannot apply, so apply them 
 - Prefer named constants over bare literals, `nullptr`, or `true`/`false` passed as arguments, so the call site explains itself.
 
 ## Comments
-- `//` for ordinary comments, `///` for Doxygen; prefix Doxygen tags with `@` (`@brief`, `@param`, `@return`). Write in English, in complete sentences.
+- `//` for ordinary comments, `///` for Doxygen; prefix Doxygen tags with `@` (`@brief`, `@param`, `@return`).
 - On a public declaration, `@brief` is mandatory; add `@param`/`@return` when non-trivial. Document ownership transfer, whether arguments may be `nullptr`, the lifetime of retained references, thread-safety assumptions, and performance implications. A comment at the definition explains *how* the code works rather than repeating the declaration.
 - Class data members get a short Doxygen comment describing their purpose and any sentinel values.
 - Use `@todo` with the associated GitHub issue for non-trivial TODOs. Mark deprecated APIs with the C++ `[[deprecated("use NewApi instead")]]` attribute.


### PR DESCRIPTION
Updates coding guidelines, specifically for commenting.

This was requested by reviewers, as generated code was emitting too verbose and unobjective descriptions.