### PR TITLE
Stop using deprecated macro in mw/log

### DIFF
--- a/score/mw/log/detail/log_entry.h
+++ b/score/mw/log/detail/log_entry.h
@@ -82,7 +82,7 @@ Deviation from Rule A0-1-1:
 - A project shall not contain instances of non-volatile variables being given values that are not subsequently used.
 
 Justification:
-- we need to use STRUCT_VISITABLE here and create an instance of LogEntry
+- we need to use SCORE_STRUCT_VISITABLE here and create an instance of LogEntry
 - to get the size of LogEntry for serialization purpose
 */
 // coverity[autosar_cpp14_a18_9_4_violation]
@@ -90,15 +90,15 @@ Justification:
 // coverity[autosar_cpp14_a11_0_2_violation]
 // coverity[autosar_cpp14_a0_1_1_violation]
 // coverity[autosar_cpp14_a2_10_4_violation]
-STRUCT_VISITABLE(LogEntry,
-                     app_id,
-                     ctx_id,
-                     payload,
-                     //  timestamp_steady_nsec,
-                     //  timestamp_system_nsec,
-                     num_of_args,
-                     //  header_buffer,
-                     log_level)
+SCORE_STRUCT_VISITABLE(LogEntry,
+                       app_id,
+                       ctx_id,
+                       payload,
+                       //  timestamp_steady_nsec,
+                       //  timestamp_system_nsec,
+                       num_of_args,
+                       //  header_buffer,
+                       log_level)
 // NOLINTEND(score-struct-usage-compliance) justified by design
 
 }  // namespace detail

--- a/score/mw/log/detail/logging_identifier.h
+++ b/score/mw/log/detail/logging_identifier.h
@@ -68,7 +68,7 @@ class LoggingIdentifier
     // coverity[autosar_cpp14_a0_1_1_violation : FALSE]
     constexpr static std::size_t kMaxLength{4UL};
 
-    // This variable is public because of necessity to pass it to STRUCT_VISITABLE in log_entry.h
+    // This variable is public because of necessity to pass it to SCORE_STRUCT_VISITABLE in log_entry.h
     // coverity[autosar_cpp14_m11_0_1_violation]
     std::array<std::string_view::value_type, kMaxLength> data{};
 };
@@ -81,7 +81,7 @@ class LoggingIdentifier
 // coverity[autosar_cpp14_a7_1_2_violation]
 // coverity[autosar_cpp14_a0_1_1_violation]
 // coverity[autosar_cpp14_a2_10_4_violation]
-STRUCT_VISITABLE(LoggingIdentifier, data)
+SCORE_STRUCT_VISITABLE(LoggingIdentifier, data)
 
 // NOLINTEND(score-struct-usage-compliance) justified by design
 


### PR DESCRIPTION
This is used transitively by a lot of customers and it will trigger compiler warnings to all of them without having any influence.