### PR TITLE
concurrency: fix placement new over the live value_ member

### DIFF
--- a/score/concurrency/future/interruptible_state.cpp
+++ b/score/concurrency/future/interruptible_state.cpp
@@ -34,8 +34,8 @@ bool score::concurrency::InterruptibleState<void>::SetError(score::result::Error
     }
 
     // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
-    // The existing object is destroyed first: reusing the storage of a live object without ending its
-    // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+    // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+    // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
     std::destroy_at(&value_);
     // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
     static_cast<void>(::new (&value_) score::Result<void>{MakeUnexpected<void>(error)});

--- a/score/concurrency/future/interruptible_state.cpp
+++ b/score/concurrency/future/interruptible_state.cpp
@@ -12,6 +12,8 @@
  ********************************************************************************/
 #include "score/concurrency/future/interruptible_state.h"
 
+#include <memory>
+
 bool score::concurrency::InterruptibleState<void>::SetValue()
 {
     if ((this->TestAndMarkValueAsSet()) == true)
@@ -32,8 +34,11 @@ bool score::concurrency::InterruptibleState<void>::SetError(score::result::Error
     }
 
     // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
+    // The existing object is destroyed first: reusing the storage of a live object without ending its
+    // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+    std::destroy_at(&value_);
     // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-    new (&value_) score::Result<void>{MakeUnexpected<void>(error)};
+    static_cast<void>(::new (&value_) score::Result<void>{MakeUnexpected<void>(error)});
 
     MakeReady();
     TriggerContinuations();

--- a/score/concurrency/future/interruptible_state.h
+++ b/score/concurrency/future/interruptible_state.h
@@ -80,8 +80,8 @@ class InterruptibleState final : public score::concurrency::detail::TypedBaseInt
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
-        // The existing object is destroyed first: reusing the storage of a live object without ending its
-        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+        // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
         std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
         static_cast<void>(::new (&value_) score::Result<Value>{std::move(value)});
@@ -103,8 +103,8 @@ class InterruptibleState final : public score::concurrency::detail::TypedBaseInt
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
-        // The existing object is destroyed first: reusing the storage of a live object without ending its
-        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+        // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
         std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
         static_cast<void>(::new (&value_) score::Result<Value>{value});
@@ -122,8 +122,8 @@ class InterruptibleState final : public score::concurrency::detail::TypedBaseInt
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
-        // The existing object is destroyed first: reusing the storage of a live object without ending its
-        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+        // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
         std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
         static_cast<void>(::new (&value_) score::Result<Value>{MakeUnexpected<Value>(error)});
@@ -213,8 +213,8 @@ class InterruptibleState<Value&> final : public score::concurrency::detail::Type
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
-        // The existing object is destroyed first: reusing the storage of a live object without ending its
-        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+        // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
         std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
         static_cast<void>(::new (&value_) score::Result<std::reference_wrapper<Value>>{std::ref(value)});
@@ -232,8 +232,8 @@ class InterruptibleState<Value&> final : public score::concurrency::detail::Type
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
-        // The existing object is destroyed first: reusing the storage of a live object without ending its
-        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+        // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
         std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
         static_cast<void>(::new (&value_) score::Result<std::reference_wrapper<Value>>{

--- a/score/concurrency/future/interruptible_state.h
+++ b/score/concurrency/future/interruptible_state.h
@@ -25,6 +25,7 @@
 #include "score/expected.hpp"
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -79,8 +80,11 @@ class InterruptibleState final : public score::concurrency::detail::TypedBaseInt
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
+        // The existing object is destroyed first: reusing the storage of a live object without ending its
+        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-        new (&value_) score::Result<Value>{std::move(value)};
+        static_cast<void>(::new (&value_) score::Result<Value>{std::move(value)});
 
         MakeReady();
         TriggerContinuations();
@@ -99,8 +103,11 @@ class InterruptibleState final : public score::concurrency::detail::TypedBaseInt
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
+        // The existing object is destroyed first: reusing the storage of a live object without ending its
+        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-        new (&value_) score::Result<Value>{value};
+        static_cast<void>(::new (&value_) score::Result<Value>{value});
 
         MakeReady();
         TriggerContinuations();
@@ -115,8 +122,11 @@ class InterruptibleState final : public score::concurrency::detail::TypedBaseInt
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
+        // The existing object is destroyed first: reusing the storage of a live object without ending its
+        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-        new (&value_) score::Result<Value>{MakeUnexpected<Value>(error)};
+        static_cast<void>(::new (&value_) score::Result<Value>{MakeUnexpected<Value>(error)});
 
         MakeReady();
         TriggerContinuations();
@@ -203,8 +213,11 @@ class InterruptibleState<Value&> final : public score::concurrency::detail::Type
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
+        // The existing object is destroyed first: reusing the storage of a live object without ending its
+        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-        new (&value_) score::Result<std::reference_wrapper<Value>>{std::ref(value)};
+        static_cast<void>(::new (&value_) score::Result<std::reference_wrapper<Value>>{std::ref(value)});
 
         MakeReady();
         TriggerContinuations();
@@ -219,9 +232,12 @@ class InterruptibleState<Value&> final : public score::concurrency::detail::Type
         }
 
         // Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
+        // The existing object is destroyed first: reusing the storage of a live object without ending its
+        // lifetime is undefined behaviour as soon as score::Result is not trivially destructible.
+        std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-        new (&value_)
-            score::Result<std::reference_wrapper<Value>>{MakeUnexpected<std::reference_wrapper<Value>>(error)};
+        static_cast<void>(::new (&value_) score::Result<std::reference_wrapper<Value>>{
+            MakeUnexpected<std::reference_wrapper<Value>>(error)});
 
         MakeReady();
         TriggerContinuations();


### PR DESCRIPTION
Fixes #301.

## What

`InterruptibleState` overwrites its live `value_` member with placement `new`. Placement `new` ends the previous object's lifetime by reusing its storage ([basic.life]/1.5), but it never runs that object's destructor, so anything a non-trivially destructible `score::Result` holds is silently never released. The result of the placement `new` is also discarded. This fixes both, at all six occurrences.

```diff
+        // Placement-new ends the old object's lifetime by reusing its storage, but never runs its
+        // destructor; destroy explicitly so a non-trivially destructible score::Result releases what it holds.
+        std::destroy_at(&value_);
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Non-assignable types workaround
-        new (&value_) score::Result<Value>{std::move(value)};
+        static_cast<void>(::new (&value_) score::Result<Value>{std::move(value)});
```

## Why this shape of fix

The issue proposes `value_ = score::Result<Value>{...}` as preferred. That would change which types the class supports, so it is not used here. The comment above each call already records the reason:

```cpp
// Use the constructor instead of assignment operator to circumvent issue with types that are not assignable
```

Verified against `main`:

```cpp
static_assert(!std::is_move_assignable<score::Result<NonAssignable>>::value, "");
static_assert(std::is_move_constructible<score::Result<NonAssignable>>::value, "");
```

Both hold, so `InterruptibleState<NonAssignable>` compiles today and would stop compiling under the assignment form. Keeping construction and destroying the previous object explicitly fixes the defect without narrowing support.

Both idioms used here already exist in this repository: `std::destroy_at` in `score/language/futurecpp/include/score/circular_buffer.hpp:102`, and `static_cast<void>(::new ...)` for the deliberately discarded result in `score/language/futurecpp/include/score/expected.hpp`.

## Scope: six occurrences, not three

The issue lists three and invites checking for others. A sweep of `score/` found three more:

| location | specialization |
|---|---|
| `interruptible_state.h:83, 103, 119` | `InterruptibleState<Value>` (listed in the issue) |
| `interruptible_state.h:207, 223` | `InterruptibleState<Value&>` |
| `interruptible_state.cpp:36` | `InterruptibleState<void>` |

All six overwrite a live `value_` member (declared at `:176`, `:277`, `:308`).

The other 49 placement-new uses in `score/` are on raw storage with matching destruction and are **not** touched: `variant.hpp`, `expected.hpp`, `inplace_vector.hpp`, `circular_buffer.hpp`, `memory_resource.cpp`, `move_only_function.hpp`, `chunk_list.hpp`, `free_list.hpp`, `construct_at.hpp`, and `score/os/static_destruction_guard.h:71` (refcount-guarded with a matching destructor).

## Severity

Stated plainly so this is prioritised correctly: `TestAndMarkValueAsSet()` means these run once, and at that point `value_` always holds the error alternative rather than a `Value`. `score::result::Error` is currently trivially destructible, so **there is no leak today** — as the issue itself notes. This is a latent defect rather than a live leak: the code silently depends on `score::result::Error` staying trivially destructible, and a destructor that has to run is skipped the moment that stops being true. Note that skipping it is not automatically undefined behaviour — [basic.life]/4 makes it undefined only for a program that depends on the destructor's side effects.

## Verification

I could not run the full Bazel suite locally: the `ape` and `rules_diff` dependencies are hosted on `gitlab.arm.com`, which does not resolve from my machine, so `bazel test --config=bl-x86_64-linux //score/concurrency/...` aborts during fetch. I am relying on CI for the real build and flagging that rather than implying I ran it.

What I did verify locally, with `g++ -std=c++17 -fsyntax-only` against the repository include paths:

- `interruptible_state.cpp` compiles clean, no warnings.
- Explicit instantiation of `InterruptibleState<std::string>` (non-trivially-destructible `Value`), `InterruptibleState<NonAssignable>` (non-assignable `Value`) and `InterruptibleState<int&>` (the `reference_wrapper` specialization), so every changed line is instantiated.
- The two `static_assert`s above.

## AI disclosure

AI-assisted (Claude Code). The tool was used to sweep the repository for the pattern, apply the change across the six sites, and draft this description. The results were checked before opening: the three additional sites were confirmed by reading the declarations of `value_` in each specialization, the 49 other placement-new uses were reviewed and excluded individually, and the compilation checks above were run. I have reviewed and understood the change and take responsibility for it.

