### PR TITLE
os: make static_destruction_guard target publicly visible

### DIFF
--- a/score/os/BUILD
+++ b/score/os/BUILD
@@ -238,8 +238,8 @@ cc_library(
     deps = [
         ":errno",
         ":object_seam",
-        ":static_destruction_guard",
         "@score_baselibs//score/bitmanipulation:bitmask_operators",
+        "@score_baselibs//score/utils:static_destruction_guard",
     ],
 )
 
@@ -314,8 +314,8 @@ cc_library(
     deps = [
         ":errno",
         ":object_seam",
-        ":static_destruction_guard",
         "@score_baselibs//score/bitmanipulation:bitmask_operators",
+        "@score_baselibs//score/utils:static_destruction_guard",
     ],
 )
 
@@ -645,13 +645,6 @@ cc_library(
 )
 
 cc_library(
-    name = "static_destruction_guard",
-    hdrs = ["static_destruction_guard.h"],
-    features = COMPILER_WARNING_FEATURES,
-    tags = ["FFI"],
-)
-
-cc_library(
     name = "mman",
     srcs = ["mman.cpp"],
     hdrs = ["mman.h"],
@@ -663,8 +656,8 @@ cc_library(
         ":fcntl",
         ":object_seam",
         ":rt",
-        ":static_destruction_guard",
         "@score_baselibs//score/bitmanipulation:bitmask_operators",
+        "@score_baselibs//score/utils:static_destruction_guard",
     ],
 )
 

--- a/score/os/mman.cpp
+++ b/score/os/mman.cpp
@@ -307,7 +307,7 @@ score::os::Mman& score::os::Mman::instance() noexcept
     return select_instance(
         // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
         // coverity[autosar_cpp14_a5_2_4_violation]
-        reinterpret_cast<internal::MmanImpl&>(StaticDestructionGuard<internal::MmanImpl>::GetStorage()));
+        reinterpret_cast<internal::MmanImpl&>(utils::StaticDestructionGuard<internal::MmanImpl>::GetStorage()));
     // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
 }
 

--- a/score/os/mman.h
+++ b/score/os/mman.h
@@ -17,7 +17,7 @@
 #include "score/os/ObjectSeam.h"
 #include "score/os/errno.h"
 #include "score/os/fcntl.h"
-#include "score/os/static_destruction_guard.h"
+#include "score/utils/static_destruction_guard.h"
 
 #include "score/expected.hpp"
 
@@ -175,7 +175,7 @@ class MmanImpl final : public Mman
 // coverity[autosar_cpp14_a3_1_1_violation]
 // coverity[autosar_cpp14_a3_3_2_violation]
 // coverity[autosar_cpp14_a2_10_4_violation]
-static StaticDestructionGuard<MmanImpl> nifty_counter;
+static utils::StaticDestructionGuard<MmanImpl> nifty_counter;
 
 }  // namespace internal
 

--- a/score/os/mqueue.cpp
+++ b/score/os/mqueue.cpp
@@ -254,7 +254,7 @@ score::os::Mqueue& score::os::Mqueue::instance() noexcept
         // type relationship. Despite AUTOSAR A5-2-4 discouraging reinterpret_cast, it is necessary in this specific
         // scenario.
         // coverity[autosar_cpp14_a5_2_4_violation]
-        reinterpret_cast<impl::MqueueImpl&>(StaticDestructionGuard<impl::MqueueImpl>::GetStorage()));
+        reinterpret_cast<impl::MqueueImpl&>(utils::StaticDestructionGuard<impl::MqueueImpl>::GetStorage()));
     // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
 }
 

--- a/score/os/mqueue.h
+++ b/score/os/mqueue.h
@@ -16,7 +16,7 @@
 #include "score/bitmanipulation/bitmask_operators.h"
 #include "score/os/ObjectSeam.h"
 #include "score/os/errno.h"
-#include "score/os/static_destruction_guard.h"
+#include "score/utils/static_destruction_guard.h"
 
 #include "score/expected.hpp"
 #include "score/memory.hpp"
@@ -167,7 +167,7 @@ class MqueueImpl final : public Mqueue
 // coverity[autosar_cpp14_a3_1_1_violation]
 // coverity[autosar_cpp14_a3_3_2_violation]
 // coverity[autosar_cpp14_a2_10_4_violation]
-static StaticDestructionGuard<MqueueImpl> nifty_counter_mqueue;
+static utils::StaticDestructionGuard<MqueueImpl> nifty_counter_mqueue;
 
 }  // namespace impl
 }  // namespace os

--- a/score/os/unistd.cpp
+++ b/score/os/unistd.cpp
@@ -381,7 +381,7 @@ score::os::Unistd& score::os::Unistd::instance() noexcept
         // Suppress “AUTOSAR_Cpp14_A5_2_4” rule finding: “Reinterpret_cast shall not be used.”
         // Rationale: Have to use reinterpret_cast here because of the use of GetStorage
         // coverity[autosar_cpp14_a5_2_4_violation]
-        reinterpret_cast<internal::UnistdImpl&>(StaticDestructionGuard<internal::UnistdImpl>::GetStorage())
+        reinterpret_cast<internal::UnistdImpl&>(utils::StaticDestructionGuard<internal::UnistdImpl>::GetStorage())
         // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
     );
 }

--- a/score/os/unistd.h
+++ b/score/os/unistd.h
@@ -16,7 +16,7 @@
 #include "score/bitmanipulation/bitmask_operators.h"
 #include "score/os/ObjectSeam.h"
 #include "score/os/errno.h"
-#include "score/os/static_destruction_guard.h"
+#include "score/utils/static_destruction_guard.h"
 
 #include "score/expected.hpp"
 #include "score/memory.hpp"
@@ -239,7 +239,7 @@ class UnistdImpl final : public Unistd
 // nifty_counter is unique and not reused elsewhere in score::os
 // coverity[autosar_cpp14_a3_1_1_violation]
 // coverity[autosar_cpp14_a2_10_4_violation]
-static StaticDestructionGuard<internal::UnistdImpl> nifty_counter;
+static utils::StaticDestructionGuard<internal::UnistdImpl> nifty_counter;
 
 }  // namespace os
 }  // namespace score

--- a/score/utils/BUILD
+++ b/score/utils/BUILD
@@ -16,6 +16,18 @@ load("@score_baselibs//:bazel/unit_tests.bzl", "cc_unit_test_suites_for_host_and
 load("@score_baselibs//score/quality/clang_tidy:extra_checks.bzl", "clang_tidy_extra_checks")
 
 cc_library(
+    name = "static_destruction_guard",
+    hdrs = ["static_destruction_guard.h"],
+    features = [
+        "treat_warnings_as_errors",
+        "strict_warnings",
+        "additional_warnings",
+    ],
+    tags = ["FFI"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "base64",
     srcs = ["base64.cpp"],
     hdrs = ["base64.h"],

--- a/score/utils/static_destruction_guard.h
+++ b/score/utils/static_destruction_guard.h
@@ -10,15 +10,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-#ifndef SCORE_LIB_OS_STATIC_DESTRUCTION_GUARD_H
-#define SCORE_LIB_OS_STATIC_DESTRUCTION_GUARD_H
+#ifndef SCORE_LIB_UTILS_STATIC_DESTRUCTION_GUARD_H
+#define SCORE_LIB_UTILS_STATIC_DESTRUCTION_GUARD_H
 
 #include <cstdint>
 #include <type_traits>
 
 namespace score
 {
-namespace os
+namespace utils
 {
 
 /// \brief An abstraction of the Nifty Counter Idiom which ensures that variables with static storage duration are only
@@ -111,7 +111,7 @@ class StaticDestructionGuard
     }
 };
 
-}  // namespace os
+}  // namespace utils
 }  // namespace score
 
-#endif  // SCORE_LIB_OS_STATIC_DESTRUCTION_GUARD_H
+#endif  // SCORE_LIB_UTILS_STATIC_DESTRUCTION_GUARD_H


### PR DESCRIPTION
Needed for other repos (e.g. communication) can reuse the nifty-counter idiom for their own static-storage singletons without vendoring a local copy.