### PR TITLE
`LockedPtr::transform` implemented

### DIFF
--- a/score/concurrency/BUILD
+++ b/score/concurrency/BUILD
@@ -161,6 +161,7 @@ cc_library(
     ],
     deps = [
         ":unlock_guard",
+        "@score_baselibs//score/language/futurecpp",
     ],
 )
 

--- a/score/concurrency/locked_ptr.h
+++ b/score/concurrency/locked_ptr.h
@@ -216,7 +216,8 @@ class LockedPtr
     template <typename Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, LockedPtr&>>,
               typename FuncResult = std::invoke_result_t<Func, LockedPtr&>,
-              typename = std::enable_if_t<!std::is_void_v<FuncResult>>>
+              typename = std::enable_if_t<std::conjunction_v<std::negation<std::is_void<FuncResult>>,
+                                                             std::negation<std::is_reference<FuncResult>>>>>
     [[nodiscard]] auto transform(Func&& f) & -> score::cpp::optional<FuncResult>
     {
         if (ptr_ == nullptr)
@@ -237,7 +238,8 @@ class LockedPtr
     template <typename Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, const LockedPtr&>>,
               typename FuncResult = std::invoke_result_t<Func, const LockedPtr&>,
-              typename = std::enable_if_t<!std::is_void_v<FuncResult>>>
+              typename = std::enable_if_t<std::conjunction_v<std::negation<std::is_void<FuncResult>>,
+                                                             std::negation<std::is_reference<FuncResult>>>>>
     [[nodiscard]] auto transform(Func&& f) const& -> score::cpp::optional<FuncResult>
     {
         if (ptr_ == nullptr)
@@ -249,16 +251,17 @@ class LockedPtr
 
     /**
      * @brief Applies a callable to this LockedPtr if the pointer is non-null.
-     *        The LockedPtr is moved into the callable by value, transferring lock ownership.
+     *        The LockedPtr is moved into the callable by value allowing the `Func` to take ownership of the LockedPtr.
      *        Returns score::cpp::optional containing the result.
-     * @tparam Func Callable type that accepts LockedPtr by value and returns a non-void type.
+     * @tparam Func Callable type that accepts a LockedPtr by value and returns a non-void type.
      * @param f The callable to apply. Must not return void.
      * @return score::cpp::optional containing the result if non-null, score::cpp::nullopt otherwise.
      */
     template <typename Func,
               typename = std::enable_if_t<std::is_invocable_v<Func, LockedPtr>>,
               typename FuncResult = std::invoke_result_t<Func, LockedPtr>,
-              typename = std::enable_if_t<!std::is_void_v<FuncResult>>>
+              typename = std::enable_if_t<std::conjunction_v<std::negation<std::is_void<FuncResult>>,
+                                                             std::negation<std::is_reference<FuncResult>>>>>
     [[nodiscard]] auto transform(Func&& f) && -> score::cpp::optional<FuncResult>
     {
         if (ptr_ == nullptr)

--- a/score/concurrency/locked_ptr.h
+++ b/score/concurrency/locked_ptr.h
@@ -16,6 +16,9 @@
 #include "score/concurrency/type_traits.h"
 #include "score/concurrency/unlock_guard.h"
 
+#include <score/optional.hpp>
+
+#include <functional>
 #include <utility>
 
 namespace score
@@ -200,6 +203,69 @@ class LockedPtr
     [[nodiscard]] explicit operator bool() const noexcept
     {
         return ptr_ != nullptr;
+    }
+
+    /**
+     * @brief Applies a callable to this LockedPtr if the pointer is non-null.
+     *        The callable receives a non-const lvalue reference to this LockedPtr.
+     *        Returns score::cpp::optional containing the result.
+     * @tparam Func Callable type that accepts LockedPtr& and returns a non-void type.
+     * @param f The callable to apply. Must not return void.
+     * @return score::cpp::optional containing the result if non-null, score::cpp::nullopt otherwise.
+     */
+    template <typename Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, LockedPtr&>>,
+              typename FuncResult = std::invoke_result_t<Func, LockedPtr&>,
+              typename = std::enable_if_t<!std::is_void_v<FuncResult>>>
+    [[nodiscard]] auto transform(Func&& f) & -> score::cpp::optional<FuncResult>
+    {
+        if (ptr_ == nullptr)
+        {
+            return score::cpp::nullopt;
+        }
+        return std::invoke(std::forward<Func>(f), *this);
+    }
+
+    /**
+     * @brief Applies a callable to this LockedPtr if the pointer is non-null.
+     *        The callable receives a const lvalue reference to this LockedPtr.
+     *        Returns score::cpp::optional containing the result.
+     * @tparam Func Callable type that accepts const LockedPtr& and returns a non-void type.
+     * @param f The callable to apply. Must not return void.
+     * @return score::cpp::optional containing the result if non-null, score::cpp::nullopt otherwise.
+     */
+    template <typename Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, const LockedPtr&>>,
+              typename FuncResult = std::invoke_result_t<Func, const LockedPtr&>,
+              typename = std::enable_if_t<!std::is_void_v<FuncResult>>>
+    [[nodiscard]] auto transform(Func&& f) const& -> score::cpp::optional<FuncResult>
+    {
+        if (ptr_ == nullptr)
+        {
+            return score::cpp::nullopt;
+        }
+        return std::invoke(std::forward<Func>(f), *this);
+    }
+
+    /**
+     * @brief Applies a callable to this LockedPtr if the pointer is non-null.
+     *        The LockedPtr is moved into the callable by value, transferring lock ownership.
+     *        Returns score::cpp::optional containing the result.
+     * @tparam Func Callable type that accepts LockedPtr by value and returns a non-void type.
+     * @param f The callable to apply. Must not return void.
+     * @return score::cpp::optional containing the result if non-null, score::cpp::nullopt otherwise.
+     */
+    template <typename Func,
+              typename = std::enable_if_t<std::is_invocable_v<Func, LockedPtr>>,
+              typename FuncResult = std::invoke_result_t<Func, LockedPtr>,
+              typename = std::enable_if_t<!std::is_void_v<FuncResult>>>
+    [[nodiscard]] auto transform(Func&& f) && -> score::cpp::optional<FuncResult>
+    {
+        if (ptr_ == nullptr)
+        {
+            return score::cpp::nullopt;
+        }
+        return std::invoke(std::forward<Func>(f), std::move(*this));
     }
 
     /**

--- a/score/concurrency/locked_ptr_test.cpp
+++ b/score/concurrency/locked_ptr_test.cpp
@@ -44,20 +44,25 @@ struct IntWrapper
 
 using LPtr2IntW = LockedPtr<IntWrapper, std::unique_lock<MockMutex>>;
 
-auto value_by_10 = [](LPtr2IntW& lp) {
+double ValueBy10(LPtr2IntW& lp)
+{
     return lp->value / 10.0;
-};
-auto cvalue_by_10 = [](const LPtr2IntW& lp) {
-    return lp->value / 10.0;
-};
+}
 
-auto move_ptr = [](LPtr2IntW&& ptr) {
+double CValueBy10(const LPtr2IntW& lp)
+{
+    return lp->value / 10.0;
+}
+
+LPtr2IntW MovePtr(LPtr2IntW&& ptr)
+{
     return std::move(ptr);
-};
+}
 
-auto get_obj = [](const LPtr2IntW& ptr) {
+const IntWrapper* GetObj(const LPtr2IntW& ptr)
+{
     return ptr.get();
-};
+}
 }  // namespace
 
 TEST(LockedPtrTest, ConstructionWithTypes)
@@ -478,15 +483,15 @@ TEST(LockedPtrTest, TransformLvalueRefNotNull)
     LockedPtr lockedptr(&obj, std::unique_lock{mut});
 
     // Invocables accepting lvalue ref
-    EXPECT_EQ(lockedptr.transform(value_by_10), score::cpp::optional{4.2});
+    EXPECT_EQ(lockedptr.transform(ValueBy10), score::cpp::optional{4.2});
 
     // Invocables accepting const lvalue ref
-    EXPECT_EQ(lockedptr.transform(cvalue_by_10), score::cpp::optional{4.2});
+    EXPECT_EQ(lockedptr.transform(CValueBy10), score::cpp::optional{4.2});
 
     // Invocables accepting const lvalue ref transforming const LockedPtr
-    EXPECT_EQ(std::as_const(lockedptr).transform(cvalue_by_10), score::cpp::optional{4.2});
+    EXPECT_EQ(std::as_const(lockedptr).transform(CValueBy10), score::cpp::optional{4.2});
 
-    auto result = lockedptr.transform(value_by_10);
+    auto result = lockedptr.transform(ValueBy10);
     ASSERT_TRUE((std::is_same_v<decltype(result), score::cpp::optional<double>>))
         << "transform should return score::cpp::optional<double>";
 }
@@ -497,8 +502,8 @@ TEST(LockedPtrTest, TransformLvalueRefNull)
     MockMutex mut;
     auto lp = LockedPtr(nullp, std::unique_lock{mut});
 
-    EXPECT_EQ(lp.transform(cvalue_by_10), score::cpp::optional<double>{});
-    EXPECT_EQ(lp.transform(cvalue_by_10), score::cpp::nullopt);
+    EXPECT_EQ(lp.transform(CValueBy10), score::cpp::optional<double>{});
+    EXPECT_EQ(lp.transform(CValueBy10), score::cpp::nullopt);
 }
 
 TEST(LockedPtrTest, TransformRvalueRefNotNull)
@@ -507,7 +512,7 @@ TEST(LockedPtrTest, TransformRvalueRefNotNull)
     MockMutex mut;
     auto lp = LockedPtr(&obj, std::unique_lock{mut});
 
-    EXPECT_EQ(std::move(lp).transform(move_ptr).value().get(), &obj);
+    EXPECT_EQ(std::move(lp).transform(MovePtr).value().get(), &obj);
 }
 
 TEST(LockedPtrTest, TransformRvalueRefNull)
@@ -515,8 +520,8 @@ TEST(LockedPtrTest, TransformRvalueRefNull)
     IntWrapper* nullp = nullptr;
     MockMutex mut;
 
-    EXPECT_EQ(LockedPtr(nullp, std::unique_lock{mut}).transform(get_obj), score::cpp::optional<const IntWrapper*>{});
-    EXPECT_EQ(LockedPtr(nullp, std::unique_lock{mut}).transform(cvalue_by_10), score::cpp::nullopt);
+    EXPECT_EQ(LockedPtr(nullp, std::unique_lock{mut}).transform(GetObj), score::cpp::optional<const IntWrapper*>{});
+    EXPECT_EQ(LockedPtr(nullp, std::unique_lock{mut}).transform(CValueBy10), score::cpp::nullopt);
 }
 
 }  // namespace test

--- a/score/concurrency/locked_ptr_test.cpp
+++ b/score/concurrency/locked_ptr_test.cpp
@@ -18,6 +18,8 @@
 #include "score/concurrency/test_types.h"
 #include "score/concurrency/unlock_guard.h"
 
+#include <score/optional.hpp>
+
 #include <functional>
 #include <mutex>
 #include <shared_mutex>
@@ -41,6 +43,21 @@ struct IntWrapper
 };
 
 using LPtr2IntW = LockedPtr<IntWrapper, std::unique_lock<MockMutex>>;
+
+auto value_by_10 = [](LPtr2IntW& lp) {
+    return lp->value / 10.0;
+};
+auto cvalue_by_10 = [](const LPtr2IntW& lp) {
+    return lp->value / 10.0;
+};
+
+auto move_ptr = [](LPtr2IntW&& ptr) {
+    return std::move(ptr);
+};
+
+auto get_obj = [](const LPtr2IntW& ptr) {
+    return ptr.get();
+};
 }  // namespace
 
 TEST(LockedPtrTest, ConstructionWithTypes)
@@ -452,6 +469,54 @@ TEST(LockedPtrTest, UnlockGuard)
     }
 
     EXPECT_TRUE(mut.is_locked());
+}
+
+TEST(LockedPtrTest, TransformLvalueRefNotNull)
+{
+    IntWrapper obj{42};
+    MockMutex mut;
+    LockedPtr lockedptr(&obj, std::unique_lock{mut});
+
+    // Invocables accepting lvalue ref
+    EXPECT_EQ(lockedptr.transform(value_by_10), score::cpp::optional{4.2});
+
+    // Invocables accepting const lvalue ref
+    EXPECT_EQ(lockedptr.transform(cvalue_by_10), score::cpp::optional{4.2});
+
+    // Invocables accepting const lvalue ref transforming const LockedPtr
+    EXPECT_EQ(std::as_const(lockedptr).transform(cvalue_by_10), score::cpp::optional{4.2});
+
+    auto result = lockedptr.transform(value_by_10);
+    ASSERT_TRUE((std::is_same_v<decltype(result), score::cpp::optional<double>>))
+        << "transform should return score::cpp::optional<double>";
+}
+
+TEST(LockedPtrTest, TransformLvalueRefNull)
+{
+    IntWrapper* nullp = nullptr;
+    MockMutex mut;
+    auto lp = LockedPtr(nullp, std::unique_lock{mut});
+
+    EXPECT_EQ(lp.transform(cvalue_by_10), score::cpp::optional<double>{});
+    EXPECT_EQ(lp.transform(cvalue_by_10), score::cpp::nullopt);
+}
+
+TEST(LockedPtrTest, TransformRvalueRefNotNull)
+{
+    IntWrapper obj{42};
+    MockMutex mut;
+    auto lp = LockedPtr(&obj, std::unique_lock{mut});
+
+    EXPECT_EQ(std::move(lp).transform(move_ptr).value().get(), &obj);
+}
+
+TEST(LockedPtrTest, TransformRvalueRefNull)
+{
+    IntWrapper* nullp = nullptr;
+    MockMutex mut;
+
+    EXPECT_EQ(LockedPtr(nullp, std::unique_lock{mut}).transform(get_obj), score::cpp::optional<const IntWrapper*>{});
+    EXPECT_EQ(LockedPtr(nullp, std::unique_lock{mut}).transform(cvalue_by_10), score::cpp::nullopt);
 }
 
 }  // namespace test


### PR DESCRIPTION
Monadic interfaces help write functional code by supporting [`transform`](https://en.cppreference.com/cpp/utility/optional/transform), [`and_then`](https://en.cppreference.com/cpp/utility/optional/and_then) and [`or_else`](https://en.cppreference.com/cpp/utility/optional/or_else). This PR is to support `transform`. 

This makes the following possible.
```c++
Synchronized<int> synced_int{42};
auto to_str = [](const LockedPtr<int>& lp) { return std::to_string(*lp); };

auto str = synced_int.lock()
                     .transform(to_str);
EXPECT_EQ(str, "42");
```