### PR TITLE
ci(docs): split documentation build and publish workflows

### DIFF
--- a/.github/workflows/daily_maintenance.yml
+++ b/.github/workflows/daily_maintenance.yml
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Daily Maintenance
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+jobs:
+  docs-cleanup:
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-cleanup.yml@33842dcb0a19ca700d159101a34a7f078bada023
+    permissions:
+      contents: write
+      pages: write
+      id-token: write

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -10,37 +10,33 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-name: Tests, Verify and Build Docs
+name: Documentation CI
 permissions:
-  contents: write
-  pages: write
-  pull-requests: write
-  id-token: write
+  contents: read
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize] # Allows forks to trigger the docs build
+  pull_request:
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - main
+    tags:
+      - "v*"
+  release:
+    types: [published]
   merge_group:
     types: [checks_requested]
 jobs:
   docs-verify:
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@af347722c7ae3ed85518895c11268d96ac728f62
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-verify.yml@33842dcb0a19ca700d159101a34a7f078bada023
     permissions:
-      pull-requests: write
       contents: read
     with:
       bazel-docs-verify-target: "//:docs_check"
-  # TODO skipping tests as we don't integrate test results in docs anyways
   docs-build:
     needs: [docs-verify]
-    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@af347722c7ae3ed85518895c11268d96ac728f62
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs.yml@33842dcb0a19ca700d159101a34a7f078bada023
     permissions:
-      contents: write
-      pages: write
-      pull-requests: write
-      id-token: write
+      contents: read
     with:
-      bazel-target: "//:docs -- --github_user=${{ github.repository_owner }} --github_repo=${{ github.event.repository.name }}"
+      bazel-target: "//:docs"
       retention-days: 3

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -1,0 +1,33 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Publish Documentation
+on:
+  workflow_run:
+    workflows: ["Documentation CI"]
+    types: [completed]
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  pages: write
+  pull-requests: write
+jobs:
+  docs-deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: eclipse-score/cicd-workflows/.github/workflows/docs-publish.yml@33842dcb0a19ca700d159101a34a7f078bada023
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      pages: write
+      pull-requests: write

--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -23,7 +23,12 @@ permissions:
   pull-requests: write
 jobs:
   docs-deploy:
-    if: github.event.workflow_run.conclusion == 'success'
+    # Only publish for events that produce a real, addressable doc version.
+    # merge_group runs are ephemeral (merge-queue checks) and would otherwise
+    # cause unintended Pages publishes / preview-folder churn.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      contains(fromJSON('["pull_request", "push", "release"]'), github.event.workflow_run.event)
     uses: eclipse-score/cicd-workflows/.github/workflows/docs-publish.yml@33842dcb0a19ca700d159101a34a7f078bada023
     permissions:
       actions: read


### PR DESCRIPTION
## Why

eclipse-score/cicd-workflows split the documentation workflow into a build-only `docs.yml` and a new `docs-publish.yml`, so that the untrusted build stage no longer needs write permissions and can run under plain `pull_request` instead of `pull_request_target`. Only the separate publish stage (triggered via `workflow_run` after a successful build) gets the `pages`/`id-token`/`contents: write` permissions it needs. This PR migrates baselibs to that new approach.

## Changes

- Renamed `test_and_docs.yml` to `docs_ci.yml` (workflow renamed to *Documentation CI*): trigger switched from `pull_request_target` to `pull_request`, added `push: tags` and `release: published` triggers for versioned docs, permissions shrunk to `contents: read`, both `uses:` refs bumped to the current cicd-workflows commit, and the now-inert `--github_user`/`--github_repo` `bazel-target` flags were dropped (`score_docs_as_code` now derives these from the `GITHUB_REPOSITORY` env var, not from CLI flags).
- Added `docs_publish.yml`: deploys to GitHub Pages via the new `docs-publish.yml` reusable workflow, triggered by `workflow_run` after *Documentation CI* completes.
- Added `daily_maintenance.yml`: runs `docs-cleanup.yml` on a daily schedule (plus manual dispatch) to prune stale `gh-pages` preview folders. Intentionally does not use the bundled `daily.yml` workflow, since that also marks/closes stale PRs, which is out of scope here.

## Follow-up

If branch protection has required status checks referencing the old "Tests, Verify and Build Docs" workflow name, they will need to be updated to "Documentation CI".
