### PR TITLE
DataTypeSizeInfo: Assert overaligned type

### DIFF
--- a/score/memory/data_type_size_info.h
+++ b/score/memory/data_type_size_info.h
@@ -23,14 +23,22 @@ namespace score::memory
 class DataTypeSizeInfo
 {
   public:
+    /// \brief Constructs size and alignment information.
+    /// \param size Size in bytes, which must be a multiple of `alignment`.
+    /// \param alignment Nonzero power-of-two alignment not exceeding `alignof(std::max_align_t)`.
     constexpr DataTypeSizeInfo(const std::size_t size, const std::size_t alignment) : size_{size}, alignment_{alignment}
     {
         const bool is_alignment_power_of_two = ((alignment != 0) && ((alignment & (alignment - 1)) == 0));
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(is_alignment_power_of_two, "The standard requires that alignment is a power of 2!");
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(is_alignment_power_of_two,
+                                                    "The standard requires that alignment is a power of 2!");
 
         const bool is_size_multiple_of_alignment = (size % alignment == 0);
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(is_size_multiple_of_alignment,
-                               "The standard requires that size is a multiple of alignment!");
+                                                    "The standard requires that size is a multiple of alignment!");
+
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            alignment <= alignof(std::max_align_t),
+            "alignment exceeds maximum supported alignment (alignof(std::max_align_t)).");
     }
 
     constexpr std::size_t Size() const

--- a/score/memory/data_type_size_info_test.cpp
+++ b/score/memory/data_type_size_info_test.cpp
@@ -24,7 +24,8 @@ namespace
 {
 
 constexpr std::size_t kValidSize{32U};
-constexpr std::size_t kValidAlignment{16U};
+constexpr std::size_t kValidAlignment{alignof(std::max_align_t) / 2};
+constexpr std::size_t kOverAlignment{alignof(std::max_align_t) * 2U};
 
 TEST(DataTypeSizeInfoTest, ConstructingWithAlignmentOfZeroTerminates)
 {
@@ -45,6 +46,13 @@ TEST(DataTypeSizeInfoTest, ConstructingWithSizeNotMultipleOfAlignmentTerminates)
     // When constructing a DataTypeSizeInfo with invalid alignment
     // Then the program terminates
     SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(DataTypeSizeInfo(kValidAlignment + 1U, kValidAlignment));
+}
+
+TEST(DataTypeSizeInfoTest, ConstructingWithOveralignedTypeTerminates)
+{
+    // When constructing a DataTypeSizeInfo with invalid alignment
+    // Then the program terminates
+    SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(DataTypeSizeInfo(kOverAlignment, kOverAlignment));
 }
 
 TEST(DataTypeSizeInfoEqualityTest, ObjectsWithSameSizeAndAlignmentCompareTrue)


### PR DESCRIPTION
Alignments gt alignof(std::max_align_t) will
be asserted now!