### PR TITLE
Post-process flatc jsonschema output into rich schema

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1001,7 +1001,7 @@
   "moduleExtensions": {
     "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {
       "general": {
-        "bzlTransitiveDigest": "hMVVcgP4Sj4usdbu8ftPbrhCNPMT5C6BBHhDoKgJQOk=",
+        "bzlTransitiveDigest": "m+1nRJvQO4i2rBVXIiwrvEKX0GAuEm4b36fgpknferw=",
         "usagesDigest": "sj4kz7yaVclWMuWhUhSLq0bVH7+HrkWyMdODMeA7Zhw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1318,7 +1318,7 @@
     },
     "@@aspect_rules_py+//py:extensions.bzl%py_tools": {
       "general": {
-        "bzlTransitiveDigest": "nAxk0u6rhSyQDQguXlpZaBGKvT4TfQQ5QrJLexZzWec=",
+        "bzlTransitiveDigest": "djt7CfplACDm3/SXXCwxDEtkvXV2TzCov+MMdxDmYyw=",
         "usagesDigest": "tVlELaqQFX7HPl1uFzRY9m7nVV7tY9roq1qfK75ApwE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -3544,7 +3544,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ipDzEAtocAfIXfJbcbskFj4cGI7OMiupxpyQcliozJ4=",
+        "bzlTransitiveDigest": "HJP3wKFbPhB1mSYjJS6kbXEiP+OQxvsBdqpvyJN6I3s=",
         "usagesDigest": "qTwqmKKUfWcPdvM0waG+CPWrxsbeAWVeUxavm7tEk9E=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -3759,7 +3759,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "EcMcbtKZvYmd5Mi1Fpg4EeBBztLHEE5tjO5tLDBYDuU=",
+        "bzlTransitiveDigest": "TRGIl0CDmorwyNiblOYyhWuyKzi/kWFHT2uIofq7o9Y=",
         "usagesDigest": "lDbpRfhoWmZCHSaNxwZv/8fF2y0wu2th0G0f/uqX7VM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -10979,7 +10979,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "B6oxR5SAFtgjCf88BJ6mxzjaNRt2oC3WzxFKX/oOkpc=",
+        "bzlTransitiveDigest": "dc5MfL+KgiCba7Ie+8RFXMg+QaVnnCWXSXUymx//0GY=",
         "usagesDigest": "ZyLG/XW0/G9JR1YziwjyZvdWabqFQyDUa+2H4VW1Zi0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1001,7 +1001,7 @@
   "moduleExtensions": {
     "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {
       "general": {
-        "bzlTransitiveDigest": "m+1nRJvQO4i2rBVXIiwrvEKX0GAuEm4b36fgpknferw=",
+        "bzlTransitiveDigest": "hMVVcgP4Sj4usdbu8ftPbrhCNPMT5C6BBHhDoKgJQOk=",
         "usagesDigest": "sj4kz7yaVclWMuWhUhSLq0bVH7+HrkWyMdODMeA7Zhw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1318,7 +1318,7 @@
     },
     "@@aspect_rules_py+//py:extensions.bzl%py_tools": {
       "general": {
-        "bzlTransitiveDigest": "djt7CfplACDm3/SXXCwxDEtkvXV2TzCov+MMdxDmYyw=",
+        "bzlTransitiveDigest": "nAxk0u6rhSyQDQguXlpZaBGKvT4TfQQ5QrJLexZzWec=",
         "usagesDigest": "tVlELaqQFX7HPl1uFzRY9m7nVV7tY9roq1qfK75ApwE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -3544,7 +3544,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "HJP3wKFbPhB1mSYjJS6kbXEiP+OQxvsBdqpvyJN6I3s=",
+        "bzlTransitiveDigest": "ipDzEAtocAfIXfJbcbskFj4cGI7OMiupxpyQcliozJ4=",
         "usagesDigest": "qTwqmKKUfWcPdvM0waG+CPWrxsbeAWVeUxavm7tEk9E=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -3759,7 +3759,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "TRGIl0CDmorwyNiblOYyhWuyKzi/kWFHT2uIofq7o9Y=",
+        "bzlTransitiveDigest": "EcMcbtKZvYmd5Mi1Fpg4EeBBztLHEE5tjO5tLDBYDuU=",
         "usagesDigest": "lDbpRfhoWmZCHSaNxwZv/8fF2y0wu2th0G0f/uqX7VM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -10979,7 +10979,7 @@
     },
     "@@score_bazel_cpp_toolchains+//extensions:gcc.bzl%gcc": {
       "general": {
-        "bzlTransitiveDigest": "dc5MfL+KgiCba7Ie+8RFXMg+QaVnnCWXSXUymx//0GY=",
+        "bzlTransitiveDigest": "B6oxR5SAFtgjCf88BJ6mxzjaNRt2oC3WzxFKX/oOkpc=",
         "usagesDigest": "ZyLG/XW0/G9JR1YziwjyZvdWabqFQyDUa+2H4VW1Zi0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/score/flatbuffers/bazel/BUILD
+++ b/score/flatbuffers/bazel/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_binary(
     name = "inject_buffer_version",
@@ -23,6 +23,17 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+py_library(
+    name = "schema_generator_lib",
+    srcs = ["schema_generator.py"],
+    # Put this package on sys.path so the test can "import schema_generator" directly,
+    # matching how the script is imported when run as a standalone tool.
+    imports = ["."],
+    # "manual" excludes this target from wildcard builds so it is only built for the exec
+    # (host) platform when referenced as a tool via cfg = "exec" in the starlark rules.
+    tags = ["manual"],
+)
+
 py_binary(
     name = "schema_generator",
     srcs = ["schema_generator.py"],
@@ -30,4 +41,11 @@ py_binary(
     # (host) platform when referenced as a tool via cfg = "exec" in the starlark rules.
     tags = ["manual"],
     visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "schema_generator_test",
+    size = "small",
+    srcs = ["schema_generator_test.py"],
+    deps = [":schema_generator_lib"],
 )

--- a/score/flatbuffers/bazel/BUILD
+++ b/score/flatbuffers/bazel/BUILD
@@ -47,5 +47,9 @@ py_test(
     name = "schema_generator_test",
     size = "small",
     srcs = ["schema_generator_test.py"],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
     deps = [":schema_generator_lib"],
 )

--- a/score/flatbuffers/bazel/BUILD
+++ b/score/flatbuffers/bazel/BUILD
@@ -22,3 +22,12 @@ py_binary(
     tags = ["manual"],
     visibility = ["//visibility:public"],
 )
+
+py_binary(
+    name = "schema_generator",
+    srcs = ["schema_generator.py"],
+    # "manual" excludes this target from wildcard builds so it is only built for the exec
+    # (host) platform when referenced as a tool via cfg = "exec" in the starlark rules.
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)

--- a/score/flatbuffers/bazel/schema_generator.py
+++ b/score/flatbuffers/bazel/schema_generator.py
@@ -158,15 +158,10 @@ class _Enricher:
                 if meta["default"] is not None:
                     out["default"] = meta["default"]
             else:
-                # Non-lifted table reference -> inline it. Such fields are authored bare
-                # (metadata lives on the referenced table), so they are never required here;
-                # anything that is set on the field still wins over what the table carries.
-                return (
-                    self._annotate(
-                        self.build_object(self._defs[ref]), meta, desc, node
-                    ),
-                    False,
-                )
+                # Non-lifted table reference -> inline it. Metadata normally lives on the
+                # referenced table, but anything set on the field still wins over what the
+                # table carries -- including a field-level ``@required``.
+                out = self.build_object(self._defs[ref])
             return self._annotate(out, meta, desc, node), meta["required"]
 
         node_type = node.get("type")

--- a/score/flatbuffers/bazel/schema_generator.py
+++ b/score/flatbuffers/bazel/schema_generator.py
@@ -40,6 +40,9 @@ import sys
 
 _TOKEN_RE = re.compile(r"^@(title|default|min|max|required|shared)\b\s*:?\s*(.*)$")
 
+# A JSON number literal: integer, decimal or scientific notation (``0.5``, ``-1e-3``, ...).
+_NUMBER_RE = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?\Z")
+
 _DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
 
 
@@ -47,16 +50,25 @@ class GenerationError(RuntimeError):
     """Raised when schema generation fails."""
 
 
+def _parse_number(raw):
+    """Parse a JSON number literal, returning ``None`` if ``raw`` is not one.
+
+    ``json.loads`` yields an ``int`` for integer literals and a ``float`` otherwise, which is
+    exactly the number type flatc emits for the corresponding scalar field.
+    """
+    if _NUMBER_RE.match(raw) is None:
+        return None
+    return json.loads(raw)
+
+
 def _parse_default(raw):
-    """Parse an ``@default:`` token value into its JSON type (bool / int / string)."""
+    """Parse an ``@default:`` token value into its JSON type (bool / number / string)."""
     if raw == "true":
         return True
     if raw == "false":
         return False
-    try:
-        return int(raw)
-    except ValueError:
-        return raw
+    number = _parse_number(raw)
+    return raw if number is None else number
 
 
 def _parse_description(text):
@@ -83,7 +95,10 @@ def _parse_description(text):
         if key == "required":
             meta["required"] = True
         elif key in ("min", "max"):
-            meta[key] = int(value)
+            number = _parse_number(value)
+            if number is None:
+                raise GenerationError("@%s is not a number: %s" % (key, value))
+            meta[key] = number
         elif key == "default":
             meta["default"] = _parse_default(value)
         elif key == "shared":

--- a/score/flatbuffers/bazel/schema_generator.py
+++ b/score/flatbuffers/bazel/schema_generator.py
@@ -25,7 +25,9 @@ Post-processing steps:
     out of each ``description`` into proper JSON-schema attributes;
   * strip flatc's type-based ``minimum`` / ``maximum``, re-adding only from ``@min`` / ``@max``;
   * inline every ``$ref`` except tables marked ``@shared: <name>`` in the .fbs, which
-    are lifted into ``$defs/<name>`` and referenced (used for tables shared by 2+ parents).
+    are lifted into ``$defs/<name>`` and referenced (used for tables shared by 2+ parents);
+  * additionally lift any table on a reference cycle into ``$defs`` under its flatc name,
+    since inlining a cycle would never terminate.
 
 The result is deterministic (fixed key ordering, ``json.dumps(indent=4)``), so the checked-in
 schema is simply this tool's committed output and a drift test can compare byte-for-byte.
@@ -124,7 +126,7 @@ class _Enricher:
                 if meta["default"] is not None:
                     out["default"] = meta["default"]
                 return out, meta["required"]
-            # Non-shared table reference -> inline it. Such fields are authored bare
+            # Non-lifted table reference -> inline it. Such fields are authored bare
             # (metadata lives on the referenced table), so they are never required here.
             return self.build_object(self._defs[ref]), False
 
@@ -137,6 +139,22 @@ class _Enricher:
             if desc:
                 out["description"] = desc
             out["items"] = self._build_items(node["items"])
+            # Fixed-length FlatBuffer arrays: flatc pins the length via minItems/maxItems.
+            if "minItems" in node:
+                out["minItems"] = node["minItems"]
+            if "maxItems" in node:
+                out["maxItems"] = node["maxItems"]
+            return out, meta["required"]
+        # union type (anyOf) is used for union fields, which are authored bare
+        # metadata lives on the referenced table, so they are never required here.
+        if "anyOf" in node:
+            meta, desc = _parse_description(node.get("description", ""))
+            out = {}
+            if meta["title"] is not None:
+                out["title"] = meta["title"]
+            if desc:
+                out["description"] = desc
+            out["anyOf"] = [self._build_items(alt) for alt in node["anyOf"]]
             return out, meta["required"]
 
         # Scalar / string / bool leaf.
@@ -173,10 +191,11 @@ class _Enricher:
         meta, desc = _parse_description(def_node.get("description", ""))
         properties = {}
         required = []
+        flatc_required = set(def_node.get("required", []))
         for field_name, field_node in def_node.get("properties", {}).items():
             built, is_required = self.build_field(field_node)
             properties[field_name] = built
-            if is_required:
+            if is_required or field_name in flatc_required:
                 required.append(field_name)
         out = {"type": "object"}
         if meta["title"] is not None:
@@ -207,6 +226,66 @@ def _collect_shared_defs(definitions):
     return shared
 
 
+def _iter_ref_names(node):
+    """Yield the name of every definition referenced by a property node."""
+    if "$ref" in node:
+        yield node["$ref"].split("/")[-1]
+    items = node.get("items")
+    if isinstance(items, dict):
+        yield from _iter_ref_names(items)
+    for alt in node.get("anyOf", []):
+        yield from _iter_ref_names(alt)
+
+
+def _collect_cycle_defs(definitions, shared):
+    """Map full def name -> ``$defs`` key for every table that must be lifted to break a cycle.
+
+    Inlining a table reference recurses into the referenced table, so a reference cycle --
+    which FlatBuffers permits, since it stores tables by offset -- would never terminate.
+    Lifting one table per cycle into ``$defs`` breaks it: a lifted table is emitted as a
+    ``$ref`` instead of being inlined. Tables already marked ``@shared`` break cycles for
+    the same reason, so they are skipped here and treated as cuts.
+
+    Iteration follows ``definitions`` order (i.e. .fbs order), so the chosen cut -- and
+    therefore the output -- is deterministic. The full flatc name is used as the ``$defs``
+    key: unlike ``@shared`` names it is not author-chosen, and it is unique by construction.
+    """
+    edges = {
+        name: list(
+            dict.fromkeys(
+                ref
+                for field in node.get("properties", {}).values()
+                for ref in _iter_ref_names(field)
+            )
+        )
+        for name, node in definitions.items()
+    }
+
+    def reaches_itself(start, cuts):
+        """Whether ``start`` is reachable from itself without passing through a cut."""
+        stack, seen = [start], set()
+        while stack:
+            for nxt in edges.get(stack.pop(), ()):
+                if nxt == start:
+                    return True
+                if nxt not in cuts and nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        return False
+
+    cycle = {}
+    for full_name in definitions:
+        if full_name in shared:
+            continue
+        # Every table lifted so far is emitted as a ``$ref``, cutting paths through it.
+        if reaches_itself(full_name, set(shared) | set(cycle)):
+            cycle[full_name] = full_name
+    for name in cycle.values():
+        if name in shared.values():
+            raise GenerationError("@shared name collides with cycle def: %s" % name)
+    return cycle
+
+
 def generate(raw_schema_json):
     """Post-process raw flatc JSON schema into rich draft-2020-12 format.
 
@@ -219,6 +298,9 @@ def generate(raw_schema_json):
     raw = raw_schema_json
     definitions = raw["definitions"]
     shared_defs = _collect_shared_defs(definitions)
+    # Tables on a reference cycle are lifted alongside the ``@shared`` ones: both are
+    # emitted as ``$ref``, which is what stops the inlining from recursing forever.
+    shared_defs.update(_collect_cycle_defs(definitions, shared_defs))
     enricher = _Enricher(definitions, shared_defs)
 
     root_name = raw["$ref"].split("/")[-1]

--- a/score/flatbuffers/bazel/schema_generator.py
+++ b/score/flatbuffers/bazel/schema_generator.py
@@ -108,62 +108,69 @@ class _Enricher:
     def _enum_values(self, def_name):
         return self._defs[def_name]["enum"]
 
+    @staticmethod
+    def _annotate(out, meta, desc, node):
+        """Merge the field's annotations (title / description / deprecated) into ``out``.
+
+        Draft 2020-12 allows these siblings next to a ``$ref``, so they survive even when
+        the field is emitted as a reference to a lifted table. Where ``out`` already carries
+        a title / description -- an inlined table brings its own -- the field-level value
+        wins. Keys are re-emitted in a fixed order so the output stays deterministic.
+        """
+        annotated = {key: out[key] for key in ("$ref", "type") if key in out}
+        title = meta["title"] if meta["title"] is not None else out.get("title")
+        if title is not None:
+            annotated["title"] = title
+        description = desc or out.get("description")
+        if description:
+            annotated["description"] = description
+        annotated.update(
+            (key, value) for key, value in out.items() if key not in annotated
+        )
+        if node.get("deprecated"):
+            annotated["deprecated"] = True
+        return annotated
+
     def build_field(self, node):
         """Build an enriched schema node for a property. Returns (schema_node, required)."""
+        meta, desc = _parse_description(node.get("description", ""))
         if "$ref" in node:
             ref = self._ref_name(node)
             if ref in self._shared_defs:
-                meta, _ = _parse_description(node.get("description", ""))
-                return {"$ref": "#/$defs/%s" % self._shared_defs[ref]}, meta["required"]
-            if self._is_enum(ref):
-                meta, desc = _parse_description(node.get("description", ""))
-                out = {"type": "string"}
-                if meta["title"] is not None:
-                    out["title"] = meta["title"]
-                if desc:
-                    out["description"] = desc
-                out["enum"] = self._enum_values(ref)
+                out = {"$ref": "#/$defs/%s" % self._shared_defs[ref]}
+            elif self._is_enum(ref):
+                out = {"type": "string", "enum": self._enum_values(ref)}
                 if meta["default"] is not None:
                     out["default"] = meta["default"]
-                return out, meta["required"]
-            # Non-lifted table reference -> inline it. Such fields are authored bare
-            # (metadata lives on the referenced table), so they are never required here.
-            return self.build_object(self._defs[ref]), False
+            else:
+                # Non-lifted table reference -> inline it. Such fields are authored bare
+                # (metadata lives on the referenced table), so they are never required here;
+                # anything that is set on the field still wins over what the table carries.
+                return (
+                    self._annotate(
+                        self.build_object(self._defs[ref]), meta, desc, node
+                    ),
+                    False,
+                )
+            return self._annotate(out, meta, desc, node), meta["required"]
 
         node_type = node.get("type")
         if node_type == "array":
-            meta, desc = _parse_description(node.get("description", ""))
-            out = {"type": "array"}
-            if meta["title"] is not None:
-                out["title"] = meta["title"]
-            if desc:
-                out["description"] = desc
-            out["items"] = self._build_items(node["items"])
+            out = {"type": "array", "items": self._build_items(node["items"])}
             # Fixed-length FlatBuffer arrays: flatc pins the length via minItems/maxItems.
             if "minItems" in node:
                 out["minItems"] = node["minItems"]
             if "maxItems" in node:
                 out["maxItems"] = node["maxItems"]
-            return out, meta["required"]
-        # union type (anyOf) is used for union fields, which are authored bare
-        # metadata lives on the referenced table, so they are never required here.
+            return self._annotate(out, meta, desc, node), meta["required"]
+        # union type (anyOf) is used for union fields, which are normally authored bare
+        # (metadata lives on the referenced table).
         if "anyOf" in node:
-            meta, desc = _parse_description(node.get("description", ""))
-            out = {}
-            if meta["title"] is not None:
-                out["title"] = meta["title"]
-            if desc:
-                out["description"] = desc
-            out["anyOf"] = [self._build_items(alt) for alt in node["anyOf"]]
-            return out, meta["required"]
+            out = {"anyOf": [self._build_items(alt) for alt in node["anyOf"]]}
+            return self._annotate(out, meta, desc, node), meta["required"]
 
         # Scalar / string / bool leaf.
-        meta, desc = _parse_description(node.get("description", ""))
         out = {"type": node_type}
-        if meta["title"] is not None:
-            out["title"] = meta["title"]
-        if desc:
-            out["description"] = desc
         if "enum" in node:  # inline enum defined directly on the node (not via $ref)
             out["enum"] = node["enum"]
         if meta["default"] is not None:
@@ -172,9 +179,7 @@ class _Enricher:
             out["minimum"] = meta["min"]
         if meta["max"] is not None:
             out["maximum"] = meta["max"]
-        if node.get("deprecated"):
-            out["deprecated"] = True
-        return out, meta["required"]
+        return self._annotate(out, meta, desc, node), meta["required"]
 
     def _build_items(self, items):
         if "$ref" in items:

--- a/score/flatbuffers/bazel/schema_generator.py
+++ b/score/flatbuffers/bazel/schema_generator.py
@@ -1,0 +1,274 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Post-process flatc --jsonschema output into a rich JSON Schema.
+
+This tool reads the raw JSON schema output from flatc --jsonschema and post-processes it
+into a rich JSON schema in draft-2020-12 format with extracted metadata.
+
+The Bazel rule handles flatc invocation; this script only does post-processing.
+
+Input: Raw JSON schema file from ``flatc --jsonschema`` (draft 2019-09 format with definitions + $ref)
+Output: Rich JSON schema in draft-2020-12 format
+
+Post-processing steps:
+  * split ``@title:`` / ``@default:`` / ``@min:`` / ``@max:`` / ``@required`` token lines
+    out of each ``description`` into proper JSON-schema attributes;
+  * strip flatc's type-based ``minimum`` / ``maximum``, re-adding only from ``@min`` / ``@max``;
+  * inline every ``$ref`` except tables marked ``@shared: <name>`` in the .fbs, which
+    are lifted into ``$defs/<name>`` and referenced (used for tables shared by 2+ parents).
+
+The result is deterministic (fixed key ordering, ``json.dumps(indent=4)``), so the checked-in
+schema is simply this tool's committed output and a drift test can compare byte-for-byte.
+"""
+
+import argparse
+import json
+import re
+import sys
+
+_TOKEN_RE = re.compile(r"^@(title|default|min|max|required|shared)\b\s*:?\s*(.*)$")
+
+_DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema"
+
+
+class GenerationError(RuntimeError):
+    """Raised when schema generation fails."""
+
+
+def _parse_default(raw):
+    """Parse an ``@default:`` token value into its JSON type (bool / int / string)."""
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    try:
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def _parse_description(text):
+    """Split a flatc ``description`` string into (metadata, clean_description).
+
+    ``@token`` lines are extracted into a dict; the remaining lines form the human-readable
+    description (joined with ``\\n``, preserving the original multi-line layout).
+    """
+    meta = {
+        "title": None,
+        "default": None,
+        "min": None,
+        "max": None,
+        "required": False,
+        "shared": None,
+    }
+    desc_lines = []
+    for line in text.split("\n"):
+        match = _TOKEN_RE.match(line)
+        if match is None:
+            desc_lines.append(line)
+            continue
+        key, value = match.group(1), match.group(2).strip()
+        if key == "required":
+            meta["required"] = True
+        elif key in ("min", "max"):
+            meta[key] = int(value)
+        elif key == "default":
+            meta["default"] = _parse_default(value)
+        elif key == "shared":
+            meta["shared"] = value
+        else:  # title
+            meta["title"] = value
+    return meta, "\n".join(desc_lines)
+
+
+class _Enricher:
+    def __init__(self, definitions, shared_defs):
+        self._defs = definitions
+        # Maps a full (namespaced) def name -> the ``$defs`` key it is lifted into.
+        self._shared_defs = shared_defs
+
+    def _ref_name(self, node):
+        return node["$ref"].split("/")[-1]
+
+    def _is_enum(self, def_name):
+        return "enum" in self._defs[def_name]
+
+    def _enum_values(self, def_name):
+        return self._defs[def_name]["enum"]
+
+    def build_field(self, node):
+        """Build an enriched schema node for a property. Returns (schema_node, required)."""
+        if "$ref" in node:
+            ref = self._ref_name(node)
+            if ref in self._shared_defs:
+                meta, _ = _parse_description(node.get("description", ""))
+                return {"$ref": "#/$defs/%s" % self._shared_defs[ref]}, meta["required"]
+            if self._is_enum(ref):
+                meta, desc = _parse_description(node.get("description", ""))
+                out = {"type": "string"}
+                if meta["title"] is not None:
+                    out["title"] = meta["title"]
+                if desc:
+                    out["description"] = desc
+                out["enum"] = self._enum_values(ref)
+                if meta["default"] is not None:
+                    out["default"] = meta["default"]
+                return out, meta["required"]
+            # Non-shared table reference -> inline it. Such fields are authored bare
+            # (metadata lives on the referenced table), so they are never required here.
+            return self.build_object(self._defs[ref]), False
+
+        node_type = node.get("type")
+        if node_type == "array":
+            meta, desc = _parse_description(node.get("description", ""))
+            out = {"type": "array"}
+            if meta["title"] is not None:
+                out["title"] = meta["title"]
+            if desc:
+                out["description"] = desc
+            out["items"] = self._build_items(node["items"])
+            return out, meta["required"]
+
+        # Scalar / string / bool leaf.
+        meta, desc = _parse_description(node.get("description", ""))
+        out = {"type": node_type}
+        if meta["title"] is not None:
+            out["title"] = meta["title"]
+        if desc:
+            out["description"] = desc
+        if "enum" in node:  # inline enum defined directly on the node (not via $ref)
+            out["enum"] = node["enum"]
+        if meta["default"] is not None:
+            out["default"] = meta["default"]
+        if meta["min"] is not None:
+            out["minimum"] = meta["min"]
+        if meta["max"] is not None:
+            out["maximum"] = meta["max"]
+        if node.get("deprecated"):
+            out["deprecated"] = True
+        return out, meta["required"]
+
+    def _build_items(self, items):
+        if "$ref" in items:
+            ref = self._ref_name(items)
+            if ref in self._shared_defs:
+                return {"$ref": "#/$defs/%s" % self._shared_defs[ref]}
+            if self._is_enum(ref):
+                return {"type": "string", "enum": self._enum_values(ref)}
+            return self.build_object(self._defs[ref])
+        # Scalar vector items: drop flatc's type-based min/max (schema has none for these).
+        return {"type": items["type"]}
+
+    def build_object(self, def_node):
+        meta, desc = _parse_description(def_node.get("description", ""))
+        properties = {}
+        required = []
+        for field_name, field_node in def_node.get("properties", {}).items():
+            built, is_required = self.build_field(field_node)
+            properties[field_name] = built
+            if is_required:
+                required.append(field_name)
+        out = {"type": "object"}
+        if meta["title"] is not None:
+            out["title"] = meta["title"]
+        if desc:
+            out["description"] = desc
+        if required:
+            out["required"] = required
+        out["additionalProperties"] = False
+        out["properties"] = properties
+        return out
+
+
+def _collect_shared_defs(definitions):
+    """Map full def name -> ``$defs`` key for every table marked ``@shared: <name>``.
+
+    Iteration follows ``definitions`` order (i.e. .fbs order), keeping ``$defs`` deterministic.
+    """
+    shared = {}
+    for full_name, def_node in definitions.items():
+        meta, _ = _parse_description(def_node.get("description", ""))
+        name = meta["shared"]
+        if name is None:
+            continue
+        if name in shared.values():
+            raise GenerationError("duplicate @shared name: %s" % name)
+        shared[full_name] = name
+    return shared
+
+
+def generate(raw_schema_json):
+    """Post-process raw flatc JSON schema into rich draft-2020-12 format.
+
+    Args:
+        raw_schema_json: Raw JSON schema dict from flatc --jsonschema (draft 2019-09 format)
+
+    Returns:
+        Rich JSON schema as string in draft-2020-12 format
+    """
+    raw = raw_schema_json
+    definitions = raw["definitions"]
+    shared_defs = _collect_shared_defs(definitions)
+    enricher = _Enricher(definitions, shared_defs)
+
+    root_name = raw["$ref"].split("/")[-1]
+    root_obj = enricher.build_object(definitions[root_name])
+
+    schema = {"$schema": _DRAFT_2020_12}
+    if "title" in root_obj:
+        schema["title"] = root_obj["title"]
+    if "description" in root_obj:
+        schema["description"] = root_obj["description"]
+    schema["type"] = "object"
+    if "required" in root_obj:
+        schema["required"] = root_obj["required"]
+    schema["additionalProperties"] = root_obj["additionalProperties"]
+    schema["properties"] = root_obj["properties"]
+    schema["$defs"] = {
+        name: enricher.build_object(definitions[full])
+        for full, name in shared_defs.items()
+    }
+
+    return json.dumps(schema, indent=4, ensure_ascii=False) + "\n"
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--raw-schema",
+        required=True,
+        help="Path to the raw JSON schema file from flatc --jsonschema.",
+    )
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Where to write the schema, or '-' for stdout (default: stdout).",
+    )
+    args = parser.parse_args(argv)
+
+    # Read the raw schema from flatc
+    with open(args.raw_schema, "r", encoding="utf-8") as handle:
+        raw_schema_json = json.load(handle)
+
+    schema = generate(raw_schema_json)
+    if args.output == "-":
+        sys.stdout.write(schema)
+    else:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(schema)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/score/flatbuffers/bazel/schema_generator_test.py
+++ b/score/flatbuffers/bazel/schema_generator_test.py
@@ -257,12 +257,12 @@ class BuildFieldTest(unittest.TestCase):
             },
         )
 
-    def test_ref_to_plain_table_is_inlined_and_never_required(self):
+    def test_ref_to_plain_table_is_inlined_and_honours_required(self):
         enricher = self._enricher(
             {"NS.Thing": _table("@title: Thing", {"a": {"type": "integer"}})}
         )
         out, required = enricher.build_field(_ref("NS.Thing", "@required"))
-        self.assertFalse(required)
+        self.assertTrue(required)
         self.assertEqual(
             out,
             {

--- a/score/flatbuffers/bazel/schema_generator_test.py
+++ b/score/flatbuffers/bazel/schema_generator_test.py
@@ -49,11 +49,19 @@ class ParseDefaultTest(unittest.TestCase):
         self.assertEqual(sg._parse_default("42"), 42)
         self.assertEqual(sg._parse_default("-7"), -7)
 
-    def test_non_integer_stays_string(self):
-        # Floats are not special-cased; they fall through to the string branch.
-        self.assertEqual(sg._parse_default("1.5"), "1.5")
+    def test_floats(self):
+        self.assertEqual(sg._parse_default("1.5"), 1.5)
+        self.assertEqual(sg._parse_default("-0.25"), -0.25)
+        self.assertEqual(sg._parse_default("1e-3"), 0.001)
+        self.assertIsInstance(sg._parse_default("1.5"), float)
+
+    def test_non_number_stays_string(self):
         self.assertEqual(sg._parse_default("hello world"), "hello world")
         self.assertEqual(sg._parse_default(""), "")
+        # Not JSON number literals, so they stay verbatim.
+        self.assertEqual(sg._parse_default("1.5f"), "1.5f")
+        self.assertEqual(sg._parse_default("nan"), "nan")
+        self.assertEqual(sg._parse_default("0x10"), "0x10")
 
     def test_capitalized_booleans_are_strings(self):
         self.assertEqual(sg._parse_default("True"), "True")
@@ -107,6 +115,16 @@ class ParseDescriptionTest(unittest.TestCase):
         meta, _ = sg._parse_description("@min: -3\n@max: -1")
         self.assertEqual(meta["min"], -3)
         self.assertEqual(meta["max"], -1)
+
+    def test_fractional_min_max(self):
+        meta, _ = sg._parse_description("@min: 0.5\n@max: 1e3")
+        self.assertEqual(meta["min"], 0.5)
+        self.assertEqual(meta["max"], 1000.0)
+
+    def test_non_numeric_min_is_an_error(self):
+        with self.assertRaises(sg.GenerationError) as ctx:
+            sg._parse_description("@min: lots")
+        self.assertIn("@min", str(ctx.exception))
 
     def test_unknown_token_is_plain_description(self):
         meta, desc = sg._parse_description("@unknown: x")

--- a/score/flatbuffers/bazel/schema_generator_test.py
+++ b/score/flatbuffers/bazel/schema_generator_test.py
@@ -158,7 +158,10 @@ class BuildFieldTest(unittest.TestCase):
 
     def test_scalar_key_order_is_deterministic(self):
         out, _ = self._enricher().build_field(
-            {"type": "integer", "description": "@title: T\n@max: 9\n@min: 1\n@default: 2\nd"}
+            {
+                "type": "integer",
+                "description": "@title: T\n@max: 9\n@min: 1\n@default: 2\nd",
+            }
         )
         self.assertEqual(
             list(out), ["type", "title", "description", "default", "minimum", "maximum"]
@@ -215,12 +218,26 @@ class BuildFieldTest(unittest.TestCase):
         )
 
     def test_ref_to_shared_def(self):
-        enricher = self._enricher(
-            {"NS.Thing": _table()}, shared={"NS.Thing": "Thing"}
-        )
+        enricher = self._enricher({"NS.Thing": _table()}, shared={"NS.Thing": "Thing"})
         out, required = enricher.build_field(_ref("NS.Thing", "@required"))
         self.assertEqual(out, {"$ref": "#/$defs/Thing"})
         self.assertTrue(required)
+
+    def test_ref_to_shared_def_keeps_field_annotations(self):
+        # Draft 2020-12 allows annotation siblings next to a ``$ref``.
+        enricher = self._enricher({"NS.Thing": _table()}, shared={"NS.Thing": "Thing"})
+        node = _ref("NS.Thing", "@title: The Thing\nwhat it does")
+        node["deprecated"] = True
+        out, _ = enricher.build_field(node)
+        self.assertEqual(
+            out,
+            {
+                "$ref": "#/$defs/Thing",
+                "title": "The Thing",
+                "description": "what it does",
+                "deprecated": True,
+            },
+        )
 
     def test_ref_to_plain_table_is_inlined_and_never_required(self):
         enricher = self._enricher(
@@ -237,6 +254,61 @@ class BuildFieldTest(unittest.TestCase):
                 "properties": {"a": {"type": "integer"}},
             },
         )
+
+    def test_inlined_table_field_annotations_win_over_the_table(self):
+        enricher = self._enricher(
+            {"NS.Thing": _table("@title: Thing\ntable doc", {"a": {"type": "integer"}})}
+        )
+        node = _ref("NS.Thing", "@title: Field\nfield doc")
+        node["deprecated"] = True
+        out, _ = enricher.build_field(node)
+        self.assertEqual(
+            out,
+            {
+                "type": "object",
+                "title": "Field",
+                "description": "field doc",
+                "additionalProperties": False,
+                "properties": {"a": {"type": "integer"}},
+                "deprecated": True,
+            },
+        )
+
+    def test_inlined_table_keeps_its_own_annotations_when_field_is_bare(self):
+        enricher = self._enricher({"NS.Thing": _table("@title: Thing\ntable doc")})
+        out, _ = enricher.build_field(_ref("NS.Thing"))
+        self.assertEqual(out["title"], "Thing")
+        self.assertEqual(out["description"], "table doc")
+
+    def test_deprecated_ref_to_enum(self):
+        enricher = self._enricher({"NS.Color": {"enum": ["RED"]}})
+        node = _ref("NS.Color", "@title: Color")
+        node["deprecated"] = True
+        out, _ = enricher.build_field(node)
+        self.assertEqual(
+            out,
+            {
+                "type": "string",
+                "title": "Color",
+                "enum": ["RED"],
+                "deprecated": True,
+            },
+        )
+
+    def test_deprecated_array(self):
+        out, _ = self._enricher().build_field(
+            {"type": "array", "items": {"type": "integer"}, "deprecated": True}
+        )
+        self.assertEqual(
+            out, {"type": "array", "items": {"type": "integer"}, "deprecated": True}
+        )
+
+    def test_deprecated_union(self):
+        enricher = self._enricher({"NS.A": _table()})
+        out, _ = enricher.build_field(
+            {"anyOf": [_ref("NS.A")], "description": "@title: U", "deprecated": True}
+        )
+        self.assertEqual(list(out), ["title", "anyOf", "deprecated"])
 
     def test_array_of_scalars_drops_item_bounds(self):
         out, required = self._enricher().build_field(
@@ -271,9 +343,7 @@ class BuildFieldTest(unittest.TestCase):
 
     def test_array_of_enum_refs(self):
         enricher = self._enricher({"NS.Color": {"enum": ["RED"]}})
-        out, _ = enricher.build_field(
-            {"type": "array", "items": _ref("NS.Color")}
-        )
+        out, _ = enricher.build_field({"type": "array", "items": _ref("NS.Color")})
         self.assertEqual(out["items"], {"type": "string", "enum": ["RED"]})
 
     def test_array_of_shared_refs(self):
@@ -395,7 +465,8 @@ class IterRefNamesTest(unittest.TestCase):
 
     def test_scalar_items_yield_nothing(self):
         self.assertEqual(
-            list(sg._iter_ref_names({"type": "array", "items": {"type": "integer"}})), []
+            list(sg._iter_ref_names({"type": "array", "items": {"type": "integer"}})),
+            [],
         )
 
     def test_plain_scalar(self):
@@ -512,7 +583,8 @@ class GenerateTest(unittest.TestCase):
             "$ref": "#/definitions/NS.Root",
             "definitions": {
                 "NS.Root": _table(
-                    "@title: Root\ndoc", {"a": {"type": "string", "description": "@required"}}
+                    "@title: Root\ndoc",
+                    {"a": {"type": "string", "description": "@required"}},
                 )
             },
         }

--- a/score/flatbuffers/bazel/schema_generator_test.py
+++ b/score/flatbuffers/bazel/schema_generator_test.py
@@ -1,0 +1,636 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Unit tests for schema_generator.py."""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+import schema_generator as sg
+
+
+def _table(description=None, properties=None, required=None):
+    """Build a flatc-style table definition node."""
+    node = {"type": "object", "additionalProperties": False}
+    if description is not None:
+        node["description"] = description
+    if required is not None:
+        node["required"] = required
+    node["properties"] = properties or {}
+    return node
+
+
+def _ref(name, description=None):
+    node = {"$ref": "#/definitions/%s" % name}
+    if description is not None:
+        node["description"] = description
+    return node
+
+
+class ParseDefaultTest(unittest.TestCase):
+    def test_booleans(self):
+        self.assertIs(sg._parse_default("true"), True)
+        self.assertIs(sg._parse_default("false"), False)
+
+    def test_integers(self):
+        self.assertEqual(sg._parse_default("42"), 42)
+        self.assertEqual(sg._parse_default("-7"), -7)
+
+    def test_non_integer_stays_string(self):
+        # Floats are not special-cased; they fall through to the string branch.
+        self.assertEqual(sg._parse_default("1.5"), "1.5")
+        self.assertEqual(sg._parse_default("hello world"), "hello world")
+        self.assertEqual(sg._parse_default(""), "")
+
+    def test_capitalized_booleans_are_strings(self):
+        self.assertEqual(sg._parse_default("True"), "True")
+
+
+class ParseDescriptionTest(unittest.TestCase):
+    def test_empty(self):
+        meta, desc = sg._parse_description("")
+        self.assertEqual(desc, "")
+        self.assertEqual(
+            meta,
+            {
+                "title": None,
+                "default": None,
+                "min": None,
+                "max": None,
+                "required": False,
+                "shared": None,
+            },
+        )
+
+    def test_all_tokens(self):
+        meta, desc = sg._parse_description(
+            "@title: My Title\n"
+            "@default: 3\n"
+            "@min: 1\n"
+            "@max: 10\n"
+            "@required\n"
+            "@shared: MyShared\n"
+            "human text"
+        )
+        self.assertEqual(meta["title"], "My Title")
+        self.assertEqual(meta["default"], 3)
+        self.assertEqual(meta["min"], 1)
+        self.assertEqual(meta["max"], 10)
+        self.assertTrue(meta["required"])
+        self.assertEqual(meta["shared"], "MyShared")
+        self.assertEqual(desc, "human text")
+
+    def test_multi_line_description_layout_is_preserved(self):
+        meta, desc = sg._parse_description("first\n@title: T\nsecond\n\nthird")
+        self.assertEqual(meta["title"], "T")
+        self.assertEqual(desc, "first\nsecond\n\nthird")
+
+    def test_tokens_accept_missing_colon_and_extra_space(self):
+        meta, _ = sg._parse_description("@title   Spaced\n@min   5")
+        self.assertEqual(meta["title"], "Spaced")
+        self.assertEqual(meta["min"], 5)
+
+    def test_negative_min_max(self):
+        meta, _ = sg._parse_description("@min: -3\n@max: -1")
+        self.assertEqual(meta["min"], -3)
+        self.assertEqual(meta["max"], -1)
+
+    def test_unknown_token_is_plain_description(self):
+        meta, desc = sg._parse_description("@unknown: x")
+        self.assertIsNone(meta["title"])
+        self.assertEqual(desc, "@unknown: x")
+
+    def test_token_must_start_the_line(self):
+        _, desc = sg._parse_description("see @title: not a token")
+        self.assertEqual(desc, "see @title: not a token")
+
+    def test_last_token_wins(self):
+        meta, _ = sg._parse_description("@title: one\n@title: two")
+        self.assertEqual(meta["title"], "two")
+
+
+class BuildFieldTest(unittest.TestCase):
+    def _enricher(self, definitions=None, shared=None):
+        return sg._Enricher(definitions or {}, shared or {})
+
+    def test_scalar_leaf_full_metadata(self):
+        enricher = self._enricher()
+        out, required = enricher.build_field(
+            {
+                "type": "integer",
+                "minimum": -128,  # flatc's type-based bound: must be dropped
+                "maximum": 127,
+                "description": "@title: Count\n@default: 3\n@min: 1\n@max: 10\n@required\nhow many",
+            }
+        )
+        self.assertTrue(required)
+        self.assertEqual(
+            out,
+            {
+                "type": "integer",
+                "title": "Count",
+                "description": "how many",
+                "default": 3,
+                "minimum": 1,
+                "maximum": 10,
+            },
+        )
+
+    def test_scalar_leaf_drops_flatc_bounds_when_no_tokens(self):
+        out, required = self._enricher().build_field(
+            {"type": "integer", "minimum": 0, "maximum": 255}
+        )
+        self.assertEqual(out, {"type": "integer"})
+        self.assertFalse(required)
+
+    def test_scalar_key_order_is_deterministic(self):
+        out, _ = self._enricher().build_field(
+            {"type": "integer", "description": "@title: T\n@max: 9\n@min: 1\n@default: 2\nd"}
+        )
+        self.assertEqual(
+            list(out), ["type", "title", "description", "default", "minimum", "maximum"]
+        )
+
+    def test_inline_enum_on_node(self):
+        out, _ = self._enricher().build_field(
+            {"type": "string", "enum": ["a", "b"], "description": "@default: a"}
+        )
+        self.assertEqual(out, {"type": "string", "enum": ["a", "b"], "default": "a"})
+
+    def test_deprecated_flag(self):
+        out, _ = self._enricher().build_field({"type": "boolean", "deprecated": True})
+        self.assertEqual(out, {"type": "boolean", "deprecated": True})
+
+    def test_deprecated_false_is_omitted(self):
+        out, _ = self._enricher().build_field({"type": "boolean", "deprecated": False})
+        self.assertEqual(out, {"type": "boolean"})
+
+    def test_default_false_is_emitted(self):
+        # ``False`` is not ``None``, so an explicit ``@default: false`` survives.
+        out, _ = self._enricher().build_field(
+            {"type": "boolean", "description": "@default: false"}
+        )
+        self.assertEqual(out, {"type": "boolean", "default": False})
+
+    def test_default_zero_is_emitted(self):
+        out, _ = self._enricher().build_field(
+            {"type": "integer", "description": "@default: 0"}
+        )
+        self.assertEqual(out, {"type": "integer", "default": 0})
+
+    def test_min_zero_is_emitted(self):
+        out, _ = self._enricher().build_field(
+            {"type": "integer", "description": "@min: 0\n@max: 0"}
+        )
+        self.assertEqual(out, {"type": "integer", "minimum": 0, "maximum": 0})
+
+    def test_ref_to_enum(self):
+        enricher = self._enricher({"NS.Color": {"enum": ["RED", "GREEN"]}})
+        out, required = enricher.build_field(
+            _ref("NS.Color", "@title: Color\n@default: RED\n@required\npick one")
+        )
+        self.assertTrue(required)
+        self.assertEqual(
+            out,
+            {
+                "type": "string",
+                "title": "Color",
+                "description": "pick one",
+                "enum": ["RED", "GREEN"],
+                "default": "RED",
+            },
+        )
+
+    def test_ref_to_shared_def(self):
+        enricher = self._enricher(
+            {"NS.Thing": _table()}, shared={"NS.Thing": "Thing"}
+        )
+        out, required = enricher.build_field(_ref("NS.Thing", "@required"))
+        self.assertEqual(out, {"$ref": "#/$defs/Thing"})
+        self.assertTrue(required)
+
+    def test_ref_to_plain_table_is_inlined_and_never_required(self):
+        enricher = self._enricher(
+            {"NS.Thing": _table("@title: Thing", {"a": {"type": "integer"}})}
+        )
+        out, required = enricher.build_field(_ref("NS.Thing", "@required"))
+        self.assertFalse(required)
+        self.assertEqual(
+            out,
+            {
+                "type": "object",
+                "title": "Thing",
+                "additionalProperties": False,
+                "properties": {"a": {"type": "integer"}},
+            },
+        )
+
+    def test_array_of_scalars_drops_item_bounds(self):
+        out, required = self._enricher().build_field(
+            {
+                "type": "array",
+                "description": "@title: List\n@required\nitems here",
+                "items": {"type": "integer", "minimum": 0, "maximum": 255},
+            }
+        )
+        self.assertTrue(required)
+        self.assertEqual(
+            out,
+            {
+                "type": "array",
+                "title": "List",
+                "description": "items here",
+                "items": {"type": "integer"},
+            },
+        )
+
+    def test_fixed_length_array_keeps_min_max_items(self):
+        out, _ = self._enricher().build_field(
+            {
+                "type": "array",
+                "items": {"type": "integer"},
+                "minItems": 4,
+                "maxItems": 4,
+            }
+        )
+        self.assertEqual(out["minItems"], 4)
+        self.assertEqual(out["maxItems"], 4)
+
+    def test_array_of_enum_refs(self):
+        enricher = self._enricher({"NS.Color": {"enum": ["RED"]}})
+        out, _ = enricher.build_field(
+            {"type": "array", "items": _ref("NS.Color")}
+        )
+        self.assertEqual(out["items"], {"type": "string", "enum": ["RED"]})
+
+    def test_array_of_shared_refs(self):
+        enricher = self._enricher({"NS.Thing": _table()}, shared={"NS.Thing": "Thing"})
+        out, _ = enricher.build_field({"type": "array", "items": _ref("NS.Thing")})
+        self.assertEqual(out["items"], {"$ref": "#/$defs/Thing"})
+
+    def test_array_of_inlined_tables(self):
+        enricher = self._enricher(
+            {"NS.Thing": _table(properties={"a": {"type": "string"}})}
+        )
+        out, _ = enricher.build_field({"type": "array", "items": _ref("NS.Thing")})
+        self.assertEqual(
+            out["items"],
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {"a": {"type": "string"}},
+            },
+        )
+
+    def test_union_any_of(self):
+        enricher = self._enricher(
+            {
+                "NS.A": _table(properties={"a": {"type": "string"}}),
+                "NS.B": _table(),
+            },
+            shared={"NS.B": "B"},
+        )
+        out, required = enricher.build_field(
+            {
+                "anyOf": [_ref("NS.A"), _ref("NS.B")],
+                "description": "@title: Either\none of two",
+            }
+        )
+        self.assertFalse(required)
+        self.assertEqual(out["title"], "Either")
+        self.assertEqual(out["description"], "one of two")
+        self.assertEqual(out["anyOf"][1], {"$ref": "#/$defs/B"})
+        self.assertEqual(out["anyOf"][0]["type"], "object")
+
+
+class BuildObjectTest(unittest.TestCase):
+    def test_required_from_tokens_and_flatc(self):
+        enricher = sg._Enricher({}, {})
+        out = enricher.build_object(
+            _table(
+                description="@title: Root\nroot doc",
+                properties={
+                    "a": {"type": "string", "description": "@required"},
+                    "b": {"type": "string"},
+                    "c": {"type": "string"},
+                },
+                required=["c"],
+            )
+        )
+        self.assertEqual(out["title"], "Root")
+        self.assertEqual(out["description"], "root doc")
+        self.assertEqual(out["required"], ["a", "c"])
+        self.assertFalse(out["additionalProperties"])
+        self.assertEqual(list(out["properties"]), ["a", "b", "c"])
+
+    def test_no_required_key_when_nothing_required(self):
+        out = sg._Enricher({}, {}).build_object(
+            _table(properties={"a": {"type": "string"}})
+        )
+        self.assertNotIn("required", out)
+        self.assertEqual(list(out), ["type", "additionalProperties", "properties"])
+
+    def test_empty_table(self):
+        self.assertEqual(
+            sg._Enricher({}, {}).build_object({"type": "object"}),
+            {"type": "object", "additionalProperties": False, "properties": {}},
+        )
+
+    def test_shared_token_is_stripped_from_description(self):
+        out = sg._Enricher({}, {}).build_object(_table(description="@shared: X\ndoc"))
+        self.assertEqual(out["description"], "doc")
+
+
+class CollectSharedDefsTest(unittest.TestCase):
+    def test_collects_in_definition_order(self):
+        definitions = {
+            "NS.A": _table("@shared: Alpha"),
+            "NS.B": _table("plain"),
+            "NS.C": _table("@shared: Gamma"),
+        }
+        self.assertEqual(
+            sg._collect_shared_defs(definitions), {"NS.A": "Alpha", "NS.C": "Gamma"}
+        )
+
+    def test_none_shared(self):
+        self.assertEqual(sg._collect_shared_defs({"NS.A": _table()}), {})
+
+    def test_duplicate_shared_name_raises(self):
+        definitions = {
+            "NS.A": _table("@shared: Dup"),
+            "NS.B": _table("@shared: Dup"),
+        }
+        with self.assertRaises(sg.GenerationError) as ctx:
+            sg._collect_shared_defs(definitions)
+        self.assertIn("Dup", str(ctx.exception))
+
+
+class IterRefNamesTest(unittest.TestCase):
+    def test_direct_ref(self):
+        self.assertEqual(list(sg._iter_ref_names(_ref("NS.A"))), ["NS.A"])
+
+    def test_array_items(self):
+        self.assertEqual(
+            list(sg._iter_ref_names({"type": "array", "items": _ref("NS.A")})), ["NS.A"]
+        )
+
+    def test_any_of(self):
+        self.assertEqual(
+            list(sg._iter_ref_names({"anyOf": [_ref("NS.A"), _ref("NS.B")]})),
+            ["NS.A", "NS.B"],
+        )
+
+    def test_scalar_items_yield_nothing(self):
+        self.assertEqual(
+            list(sg._iter_ref_names({"type": "array", "items": {"type": "integer"}})), []
+        )
+
+    def test_plain_scalar(self):
+        self.assertEqual(list(sg._iter_ref_names({"type": "string"})), [])
+
+
+class CollectCycleDefsTest(unittest.TestCase):
+    def test_no_cycle(self):
+        definitions = {
+            "NS.Root": _table(properties={"a": _ref("NS.A")}),
+            "NS.A": _table(),
+        }
+        self.assertEqual(sg._collect_cycle_defs(definitions, {}), {})
+
+    def test_self_reference(self):
+        definitions = {"NS.A": _table(properties={"me": _ref("NS.A")})}
+        self.assertEqual(sg._collect_cycle_defs(definitions, {}), {"NS.A": "NS.A"})
+
+    def test_mutual_cycle_cuts_only_the_first_table(self):
+        definitions = {
+            "NS.A": _table(properties={"b": _ref("NS.B")}),
+            "NS.B": _table(properties={"a": _ref("NS.A")}),
+        }
+        self.assertEqual(sg._collect_cycle_defs(definitions, {}), {"NS.A": "NS.A"})
+
+    def test_cut_choice_follows_definition_order(self):
+        definitions = {
+            "NS.B": _table(properties={"a": _ref("NS.A")}),
+            "NS.A": _table(properties={"b": _ref("NS.B")}),
+        }
+        self.assertEqual(sg._collect_cycle_defs(definitions, {}), {"NS.B": "NS.B"})
+
+    def test_cycle_through_array_and_union(self):
+        definitions = {
+            "NS.A": _table(properties={"bs": {"type": "array", "items": _ref("NS.B")}}),
+            "NS.B": _table(properties={"a": {"anyOf": [_ref("NS.A")]}}),
+        }
+        self.assertEqual(sg._collect_cycle_defs(definitions, {}), {"NS.A": "NS.A"})
+
+    def test_shared_table_already_breaks_the_cycle(self):
+        definitions = {
+            "NS.A": _table("@shared: Alpha", {"b": _ref("NS.B")}),
+            "NS.B": _table(properties={"a": _ref("NS.A")}),
+        }
+        self.assertEqual(sg._collect_cycle_defs(definitions, {"NS.A": "Alpha"}), {})
+
+    def test_two_independent_cycles_are_both_cut(self):
+        definitions = {
+            "NS.A": _table(properties={"me": _ref("NS.A")}),
+            "NS.B": _table(properties={"me": _ref("NS.B")}),
+        }
+        self.assertEqual(
+            sg._collect_cycle_defs(definitions, {}), {"NS.A": "NS.A", "NS.B": "NS.B"}
+        )
+
+    def test_shared_name_colliding_with_cycle_def_raises(self):
+        definitions = {
+            "Foo": _table("@shared: Bar"),
+            "Bar": _table(properties={"me": _ref("Bar")}),
+        }
+        with self.assertRaises(sg.GenerationError) as ctx:
+            sg._collect_cycle_defs(definitions, {"Foo": "Bar"})
+        self.assertIn("Bar", str(ctx.exception))
+
+
+class GenerateTest(unittest.TestCase):
+    def test_full_schema(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {
+                "NS.Color": {"type": "string", "enum": ["RED", "GREEN"]},
+                "NS.Shared": _table(
+                    "@shared: Shared\n@title: Shared Thing\nreused",
+                    {"n": {"type": "integer", "description": "@min: 1"}},
+                ),
+                "NS.Inline": _table(properties={"s": {"type": "string"}}),
+                "NS.Root": _table(
+                    "@title: Root\nthe root",
+                    {
+                        "color": _ref("NS.Color", "@required"),
+                        "shared": _ref("NS.Shared"),
+                        "inline": _ref("NS.Inline"),
+                        "names": {"type": "array", "items": {"type": "string"}},
+                    },
+                ),
+            },
+        }
+        schema = json.loads(sg.generate(raw))
+        self.assertEqual(schema["$schema"], sg._DRAFT_2020_12)
+        self.assertEqual(schema["title"], "Root")
+        self.assertEqual(schema["description"], "the root")
+        self.assertEqual(schema["type"], "object")
+        self.assertEqual(schema["required"], ["color"])
+        self.assertFalse(schema["additionalProperties"])
+        self.assertEqual(
+            schema["properties"]["color"],
+            {"type": "string", "enum": ["RED", "GREEN"]},
+        )
+        self.assertEqual(schema["properties"]["shared"], {"$ref": "#/$defs/Shared"})
+        self.assertEqual(schema["properties"]["inline"]["type"], "object")
+        self.assertEqual(
+            schema["$defs"]["Shared"],
+            {
+                "type": "object",
+                "title": "Shared Thing",
+                "description": "reused",
+                "additionalProperties": False,
+                "properties": {"n": {"type": "integer", "minimum": 1}},
+            },
+        )
+
+    def test_top_level_key_order(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {
+                "NS.Root": _table(
+                    "@title: Root\ndoc", {"a": {"type": "string", "description": "@required"}}
+                )
+            },
+        }
+        self.assertEqual(
+            list(json.loads(sg.generate(raw))),
+            [
+                "$schema",
+                "title",
+                "description",
+                "type",
+                "required",
+                "additionalProperties",
+                "properties",
+                "$defs",
+            ],
+        )
+
+    def test_root_without_title_description_or_required(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {"NS.Root": _table(properties={"a": {"type": "string"}})},
+        }
+        schema = json.loads(sg.generate(raw))
+        self.assertNotIn("title", schema)
+        self.assertNotIn("description", schema)
+        self.assertNotIn("required", schema)
+        self.assertEqual(schema["$defs"], {})
+
+    def test_cycle_is_lifted_into_defs(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {
+                "NS.Node": _table(
+                    properties={
+                        "child": _ref("NS.Node"),
+                        "name": {"type": "string"},
+                    }
+                ),
+                "NS.Root": _table(properties={"node": _ref("NS.Node")}),
+            },
+        }
+        schema = json.loads(sg.generate(raw))
+        self.assertEqual(schema["properties"]["node"], {"$ref": "#/$defs/NS.Node"})
+        self.assertEqual(
+            schema["$defs"]["NS.Node"]["properties"]["child"],
+            {"$ref": "#/$defs/NS.Node"},
+        )
+
+    def test_output_is_deterministic_and_ends_with_newline(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {"NS.Root": _table(properties={"a": {"type": "string"}})},
+        }
+        first = sg.generate(raw)
+        self.assertEqual(first, sg.generate(raw))
+        self.assertTrue(first.endswith("\n"))
+        self.assertIn('\n    "type": "object"', first)  # indent=4
+
+    def test_non_ascii_is_not_escaped(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {"NS.Root": _table("@title: Grüße")},
+        }
+        self.assertIn("Grüße", sg.generate(raw))
+
+    def test_duplicate_shared_name_propagates(self):
+        raw = {
+            "$ref": "#/definitions/NS.Root",
+            "definitions": {
+                "NS.A": _table("@shared: Dup"),
+                "NS.B": _table("@shared: Dup"),
+                "NS.Root": _table(),
+            },
+        }
+        with self.assertRaises(sg.GenerationError):
+            sg.generate(raw)
+
+
+class MainTest(unittest.TestCase):
+    RAW = {
+        "$ref": "#/definitions/NS.Root",
+        "definitions": {"NS.Root": _table("@title: Root", {"a": {"type": "string"}})},
+    }
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.raw_path = os.path.join(self._tmp.name, "raw.json")
+        with open(self.raw_path, "w", encoding="utf-8") as handle:
+            json.dump(self.RAW, handle)
+
+    def test_writes_to_stdout_by_default(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            exit_code = sg.main(["--raw-schema", self.raw_path])
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(buffer.getvalue(), sg.generate(self.RAW))
+
+    def test_writes_to_output_file(self):
+        out_path = os.path.join(self._tmp.name, "out.json")
+        self.assertEqual(
+            sg.main(["--raw-schema", self.raw_path, "--output", out_path]), 0
+        )
+        with open(out_path, "r", encoding="utf-8") as handle:
+            self.assertEqual(handle.read(), sg.generate(self.RAW))
+
+    def test_explicit_dash_output_is_stdout(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            sg.main(["--raw-schema", self.raw_path, "--output", "-"])
+        self.assertEqual(buffer.getvalue(), sg.generate(self.RAW))
+
+    def test_missing_required_argument_exits(self):
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(io.StringIO()):
+                sg.main([])
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/score/flatbuffers/bazel/tools.bzl
+++ b/score/flatbuffers/bazel/tools.bzl
@@ -457,7 +457,11 @@ def serialize_multiple_versioned_buffers(
     )
 
 def _generate_json_schema_impl(ctx):
-    """Implementation of the generate_json_schema rule."""
+    """Implementation of the generate_json_schema rule.
+
+    Runs flatc --jsonschema to generate a raw JSON schema, then post-processes it
+    with schema_generator.py to convert to draft-2020-12 format and extract metadata.
+    """
 
     # Input files
     schema_file = ctx.file.schema
@@ -465,15 +469,17 @@ def _generate_json_schema_impl(ctx):
     # Get the flatc compiler using absolute path from flatbuffers repository
     flatc = ctx.executable._flatc
 
+    # Get the schema generator script
+    schema_generator = ctx.executable._schema_generator
+
     # Collect include directories from included .fbs files
     include_files = ctx.files.includes + [ctx.file._buffer_version_fbs]
     include_dirs = {f.dirname: True for f in include_files}
 
-    # When generating JSON schema, flatc generates a file named after the schema file
+    # Step 1: Run flatc --jsonschema to generate raw schema
     default_name = schema_file.basename.replace(".fbs", ".schema.json")
     temp_subdir = "tmp_{}".format(ctx.label.name)
-    generated_file = ctx.actions.declare_file("{}/{}".format(temp_subdir, default_name))
-    out_schema = ctx.actions.declare_file(ctx.attr.output)
+    raw_schema_file = ctx.actions.declare_file("{}/{}".format(temp_subdir, default_name))
 
     # Options for flatc --jsonschema: Generate a JSON Schema from a FlatBuffer schema.
     # Options that apply only to other modes are not listed.
@@ -495,20 +501,34 @@ def _generate_json_schema_impl(ctx):
     args.add("--jsonschema")
     for inc_dir in include_dirs:
         args.add("-I", inc_dir)
-    args.add("-o", generated_file.dirname)
+    args.add("-o", raw_schema_file.dirname)
     args.add(schema_file.path)
 
     ctx.actions.run(
         inputs = [schema_file] + include_files,
-        outputs = [generated_file],
+        outputs = [raw_schema_file],
         executable = flatc,
         arguments = [args],
         mnemonic = "FlatbuffersJsonSchema",
-        progress_message = "Generating JSON schema from %s" % schema_file.short_path,
+        progress_message = "Generating raw JSON schema from %s" % schema_file.short_path,
     )
 
-    # Symlink to the requested output name
-    ctx.actions.symlink(output = out_schema, target_file = generated_file)
+    # Step 2: Post-process the raw schema with schema_generator.py
+    # Converts to draft-2020-12 format and extracts metadata
+    out_schema = ctx.actions.declare_file(ctx.attr.output)
+
+    generator_args = ctx.actions.args()
+    generator_args.add("--raw-schema", raw_schema_file.path)
+    generator_args.add("--output", out_schema.path)
+
+    ctx.actions.run(
+        inputs = [raw_schema_file],
+        outputs = [out_schema],
+        executable = schema_generator,
+        arguments = [generator_args],
+        mnemonic = "FlatbuffersRichJsonSchema",
+        progress_message = "Post-processing JSON schema from %s" % schema_file.short_path,
+    )
 
     return [DefaultInfo(files = depset([out_schema]))]
 
@@ -535,13 +555,22 @@ generate_json_schema = rule(
             cfg = "exec",
             doc = "The flatc compiler (absolute path from flatbuffers repository)",
         ),
+        "_schema_generator": attr.label(
+            default = "//score/flatbuffers/bazel:schema_generator",
+            executable = True,
+            cfg = "exec",
+            doc = "The schema_generator script for post-processing JSON schema output",
+        ),
         "_buffer_version_fbs": attr.label(
             default = "@score_baselibs//score/flatbuffers/common:buffer_version.fbs",
             allow_single_file = [".fbs"],
             doc = "Automatically included buffer_version.fbs for common buffer version support.",
         ),
     },
-    doc = """Generates a JSON schema from a FlatBuffer schema.
+    doc = """Generates a rich JSON schema from a FlatBuffer schema.
+
+    This rule runs flatc --jsonschema and post-processes the output to convert it to
+    draft-2020-12 format with extracted metadata (@title, @default, @min, @max, etc.).
 
     @score_baselibs//score/flatbuffers/common:buffer_version.fbs is always included
     automatically. The schema must include buffer_version.fbs manually if it uses

--- a/score/flatbuffers/test/generate_json_schema/BUILD
+++ b/score/flatbuffers/test/generate_json_schema/BUILD
@@ -59,7 +59,8 @@ generate_json_schema(
 )
 
 # Regenerate the golden after an intentional change with:
-#   bazel build //score/flatbuffers/test/generate_json_schema:gen_rich_json_schema && \
+#   bazel build --config=bl-x86_64-linux \
+#     //score/flatbuffers/test/generate_json_schema:gen_rich_json_schema && \
 #     cp -f bazel-bin/score/flatbuffers/test/generate_json_schema/test_rich_schema.schema.json \
 #       score/flatbuffers/test/generate_json_schema/test_rich_schema.golden.schema.json
 diff_test(

--- a/score/flatbuffers/test/generate_json_schema/BUILD
+++ b/score/flatbuffers/test/generate_json_schema/BUILD
@@ -12,6 +12,7 @@
 # *******************************************************************************
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("//score/flatbuffers/bazel:tools.bzl", "generate_json_schema")
 
 generate_json_schema(
@@ -43,6 +44,32 @@ build_test(
         ":gen_json_schema_default_name",
         ":gen_json_schema_in_subdir",
     ],
+)
+
+# End-to-end check of the whole flatc --jsonschema -> schema_generator.py pipeline against a
+# real .fbs fixture that uses every supported comment token (@title, @default, @min, @max,
+# @required, @shared) plus (required) fields, a deprecated field, an enum, a union, vectors,
+# a fixed-size array and a reference cycle. Unlike the unit tests -- which feed hand-written
+# raw dictionaries to the Python -- this fails if flatc changes the shape it emits for
+# descriptions, $refs, required lists or array bounds.
+generate_json_schema(
+    name = "gen_rich_json_schema",
+    output = "test_rich_schema.schema.json",
+    schema = "//score/flatbuffers/test/testdata:test_rich_schema.fbs",
+)
+
+# Regenerate the golden after an intentional change with:
+#   bazel build //score/flatbuffers/test/generate_json_schema:gen_rich_json_schema && \
+#     cp -f bazel-bin/score/flatbuffers/test/generate_json_schema/test_rich_schema.schema.json \
+#       score/flatbuffers/test/generate_json_schema/test_rich_schema.golden.schema.json
+diff_test(
+    name = "gen_rich_json_schema_diff_test",
+    file1 = "test_rich_schema.golden.schema.json",
+    file2 = ":gen_rich_json_schema",
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],  # flatc is only built for the exec platform
 )
 
 # ===================================================

--- a/score/flatbuffers/test/generate_json_schema/test_rich_schema.golden.schema.json
+++ b/score/flatbuffers/test/generate_json_schema/test_rich_schema.golden.schema.json
@@ -1,0 +1,181 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Rich Demo Configuration",
+    "description": "Root configuration of the rich schema fixture.",
+    "type": "object",
+    "required": [
+        "component_name",
+        "schema_version"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "component_name": {
+            "type": "string",
+            "title": "Component Name",
+            "description": "Human readable component name."
+        },
+        "schema_version": {
+            "type": "string",
+            "description": "Marked required in the .fbs instead of via @required."
+        },
+        "thread_pool_size": {
+            "type": "integer",
+            "title": "Thread Pool Size",
+            "default": 4,
+            "minimum": 1,
+            "maximum": 32
+        },
+        "tracing_enabled": {
+            "type": "boolean",
+            "default": true
+        },
+        "log_path": {
+            "type": "string",
+            "default": "/tmp/demo"
+        },
+        "mode": {
+            "type": "string",
+            "enum": [
+                "EVENT_DRIVEN",
+                "POLLING",
+                "PERIODIC"
+            ],
+            "default": "POLLING"
+        },
+        "legacy_id": {
+            "type": "integer",
+            "description": "Superseded by component_name.",
+            "deprecated": true
+        },
+        "retry_policy": {
+            "type": "object",
+            "description": "Inlined (not @shared, not on a cycle) table reference.",
+            "additionalProperties": false,
+            "properties": {
+                "attempts": {
+                    "type": "integer",
+                    "default": 3,
+                    "maximum": 10
+                }
+            }
+        },
+        "limits": {
+            "$ref": "#/$defs/limits",
+            "description": "Reference to a @shared table, so it is emitted as a $ref into $defs."
+        },
+        "endpoints": {
+            "type": "array",
+            "description": "Vector of tables.",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "limits": {
+                        "$ref": "#/$defs/limits",
+                        "title": "Endpoint Limits",
+                        "description": "Field-level annotations win over the ones the @shared table carries."
+                    }
+                }
+            }
+        },
+        "priorities": {
+            "type": "array",
+            "description": "Vector of scalars.",
+            "items": {
+                "type": "integer"
+            }
+        },
+        "data_type": {
+            "type": "string",
+            "enum": [
+                "NONE",
+                "StringData",
+                "BinaryData"
+            ]
+        },
+        "data": {
+            "description": "Union field.",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "value": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "root_node": {
+            "$ref": "#/$defs/demo_rich_Node",
+            "description": "Self-recursive table: lifted into $defs to break the reference cycle."
+        },
+        "accent_color": {
+            "type": "object",
+            "description": "Struct with a fixed-size array.",
+            "additionalProperties": false,
+            "properties": {
+                "channels": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "minItems": 3,
+                    "maxItems": 3
+                }
+            }
+        }
+    },
+    "$defs": {
+        "limits": {
+            "type": "object",
+            "title": "Resource Limits",
+            "description": "Resource limits, referenced from two parents.",
+            "additionalProperties": false,
+            "properties": {
+                "max_memory_mb": {
+                    "type": "integer",
+                    "title": "Maximum Memory",
+                    "default": 64,
+                    "minimum": 0,
+                    "maximum": 4096
+                }
+            }
+        },
+        "demo_rich_Node": {
+            "type": "object",
+            "description": "Recursive tree node: reaches itself through children.",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/demo_rich_Node"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/score/flatbuffers/test/testdata/BUILD
+++ b/score/flatbuffers/test/testdata/BUILD
@@ -18,6 +18,7 @@ load("//score/flatbuffers/bazel:tools.bzl", "serialize_multiple_versioned_buffer
 exports_files(
     [
         "test.fbs",
+        "test_rich_schema.fbs",
         "test_versioned.fbs",
         "test_versioned_min.fbs",
         "test_versioned_max.fbs",

--- a/score/flatbuffers/test/testdata/test_rich_schema.fbs
+++ b/score/flatbuffers/test/testdata/test_rich_schema.fbs
@@ -2,7 +2,7 @@
 ///
 /// Kept separate from test.fbs so the end-to-end generate_json_schema test can pin the
 /// exact shape flatc emits for descriptions, $refs, required lists and fixed-size arrays.
-/// The generated schema is checked in as test_rich_schema.schema.json and compared
+/// The generated schema is checked in as test_rich_schema.golden.schema.json and compared
 /// byte-for-byte by //score/flatbuffers/test/generate_json_schema:gen_rich_json_schema_diff_test.
 namespace demo.rich;
 

--- a/score/flatbuffers/test/testdata/test_rich_schema.fbs
+++ b/score/flatbuffers/test/testdata/test_rich_schema.fbs
@@ -1,0 +1,121 @@
+/// Fixture exercising every comment token understood by schema_generator.py.
+///
+/// Kept separate from test.fbs so the end-to-end generate_json_schema test can pin the
+/// exact shape flatc emits for descriptions, $refs, required lists and fixed-size arrays.
+/// The generated schema is checked in as test_rich_schema.schema.json and compared
+/// byte-for-byte by //score/flatbuffers/test/generate_json_schema:gen_rich_json_schema_diff_test.
+namespace demo.rich;
+
+/// Operational mode of the component.
+enum OperationMode:uint8 {
+    EVENT_DRIVEN = 0,
+    POLLING = 1,
+    PERIODIC = 2,
+}
+
+/// Union of the supported payload shapes.
+union DataPayloadUnion {
+    StringData,
+    BinaryData
+}
+
+/// A struct, so it can hold a fixed-size array (flatc pins minItems/maxItems).
+struct Rgb {
+    channels:[uint8:3];
+}
+
+/// Root configuration of the rich schema fixture.
+/// @title: Rich Demo Configuration
+table RichConfig {
+    /// Human readable component name.
+    /// @title: Component Name
+    /// @required
+    component_name:string;
+
+    /// Marked required in the .fbs instead of via @required.
+    schema_version:string (required);
+
+    /// @title: Thread Pool Size
+    /// @default: 4
+    /// @min: 1
+    /// @max: 32
+    thread_pool_size:uint8 = 4;
+
+    /// @default: true
+    tracing_enabled:bool = true;
+
+    /// @default: /tmp/demo
+    log_path:string;
+
+    /// @default: POLLING
+    mode:OperationMode;
+
+    /// Superseded by component_name.
+    legacy_id:uint32 (deprecated);
+
+    /// Inlined (not @shared, not on a cycle) table reference.
+    retry_policy:RetryPolicy;
+
+    /// Reference to a @shared table, so it is emitted as a $ref into $defs.
+    limits:Limits;
+
+    /// Vector of tables.
+    endpoints:[Endpoint];
+
+    /// Vector of scalars.
+    priorities:[uint8];
+
+    /// Union field.
+    data:DataPayloadUnion;
+
+    /// Self-recursive table: lifted into $defs to break the reference cycle.
+    root_node:Node;
+
+    /// Struct with a fixed-size array.
+    accent_color:Rgb;
+}
+
+/// Resource limits, referenced from two parents.
+/// @title: Resource Limits
+/// @shared: limits
+table Limits {
+    /// @title: Maximum Memory
+    /// @default: 64
+    /// @min: 0
+    /// @max: 4096
+    max_memory_mb:uint16 = 64;
+}
+
+/// Only referenced once, so it stays inlined.
+table RetryPolicy {
+    /// @default: 3
+    /// @max: 10
+    attempts:uint8 = 3;
+}
+
+table Endpoint {
+    /// @required
+    name:string;
+
+    /// Field-level annotations win over the ones the @shared table carries.
+    /// @title: Endpoint Limits
+    limits:Limits;
+}
+
+/// Recursive tree node: reaches itself through children.
+table Node {
+    name:string;
+    children:[Node];
+}
+
+table StringData {
+    value:string;
+}
+
+table BinaryData {
+    value:[uint8];
+}
+
+root_type RichConfig;
+
+file_identifier "RICH";


### PR DESCRIPTION
+ Script to generate the JSON schema from Flatbuffers Schema.
+ Rich JSON schema attributes are rebuilt using specific tokens in fbs comment (e.g. @title)
+ Generated JSON schema attributes are to be ordered to be consistent with each schema generation (easing comparison)
+ Unit test & End to End test fixture