### PR TITLE
baselibs/utils: hide reinterpret_cast inside StaticDestructionGuard::GetStorage()

### DIFF
--- a/score/os/mman.cpp
+++ b/score/os/mman.cpp
@@ -301,16 +301,7 @@ score::cpp::pmr::unique_ptr<score::os::Mman> score::os::Mman::Default(
 
 score::os::Mman& score::os::Mman::instance() noexcept
 {
-    // Suppress “AUTOSAR_Cpp14_A5_2_4” rule finding: “Reinterpret_cast shall not be used.”
-    // Reinterpret_cast is used here to ensure proper type handling of the underlying storage
-    // (StaticDestructionGuard<impl::MmanImpl>::GetStorage()), allowing correct object destruction. This usage is
-    // considered safe in this context, as it involves casting an object from static storage with a well-defined type
-    // relationship. Despite AUTOSAR A5-2-4 discouraging reinterpret_cast, it is necessary in this specific scenario.
-    return select_instance(
-        // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
-        // coverity[autosar_cpp14_a5_2_4_violation]
-        reinterpret_cast<internal::MmanImpl&>(utils::StaticDestructionGuard<internal::MmanImpl>::GetStorage()));
-    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
+    return select_instance(utils::StaticDestructionGuard<internal::MmanImpl>::GetStorage());
 }
 
 /* KW_SUPPRESS_END:MISRA.VAR.HIDDEN: Wrapper function is identifiable through namespace usage */

--- a/score/os/mqueue.cpp
+++ b/score/os/mqueue.cpp
@@ -245,18 +245,7 @@ mode_t MqueueImpl::modeflag_to_nativeflag(const ModeFlag flags) const noexcept
 
 score::os::Mqueue& score::os::Mqueue::instance() noexcept
 {
-    return select_instance(
-
-        // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
-        // Suppress “AUTOSAR_Cpp14_A5_2_4” rule finding: “Reinterpret_cast shall not be used.”
-        // Rationale: Reinterpret_cast is used here to ensure proper type handling of the underlying storage
-        // (StaticDestructionGuard<impl::MqueueImpl>::GetStorage()), allowing correct object destruction. This usage is
-        // considered safe in this context, as it involves casting an object from static storage with a well-defined
-        // type relationship. Despite AUTOSAR A5-2-4 discouraging reinterpret_cast, it is necessary in this specific
-        // scenario.
-        // coverity[autosar_cpp14_a5_2_4_violation]
-        reinterpret_cast<impl::MqueueImpl&>(utils::StaticDestructionGuard<impl::MqueueImpl>::GetStorage()));
-    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
+    return select_instance(utils::StaticDestructionGuard<impl::MqueueImpl>::GetStorage());
 }
 
 /* KW_SUPPRESS_START:MISRA.PPARAM.NEEDS.CONST,MISRA.VAR.NEEDS.CONST: */

--- a/score/os/unistd.cpp
+++ b/score/os/unistd.cpp
@@ -391,14 +391,7 @@ score::cpp::expected_blank<score::os::Error> score::os::internal::UnistdImpl::ge
 
 score::os::Unistd& score::os::Unistd::instance() noexcept
 {
-    return select_instance(
-        // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast) see rationale below
-        // Suppress “AUTOSAR_Cpp14_A5_2_4” rule finding: “Reinterpret_cast shall not be used.”
-        // Rationale: Have to use reinterpret_cast here because of the use of GetStorage
-        // coverity[autosar_cpp14_a5_2_4_violation]
-        reinterpret_cast<internal::UnistdImpl&>(utils::StaticDestructionGuard<internal::UnistdImpl>::GetStorage())
-        // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
-    );
+    return select_instance(utils::StaticDestructionGuard<internal::UnistdImpl>::GetStorage());
 }
 
 std::unique_ptr<score::os::Unistd> score::os::Unistd::Default() noexcept

--- a/score/utils/BUILD
+++ b/score/utils/BUILD
@@ -12,7 +12,7 @@
 # *******************************************************************************
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
-load("@score_baselibs//:bazel/unit_tests.bzl", "cc_unit_test_suites_for_host_and_qnx")
+load("@score_baselibs//:bazel/unit_tests.bzl", "cc_gtest_unit_test", "cc_unit_test_suites_for_host_and_qnx")
 load("@score_baselibs//score/quality/clang_tidy:extra_checks.bzl", "clang_tidy_extra_checks")
 
 cc_library(
@@ -25,6 +25,20 @@ cc_library(
     ],
     tags = ["FFI"],
     visibility = ["//visibility:public"],
+)
+
+cc_gtest_unit_test(
+    name = "static_destruction_guard_test",
+    srcs = ["static_destruction_guard_test.cpp"],
+    features = [
+        "treat_warnings_as_errors",
+        "strict_warnings",
+        "additional_warnings",
+    ],
+    visibility = ["@score_baselibs//score/utils:__pkg__"],
+    deps = [
+        ":static_destruction_guard",
+    ],
 )
 
 cc_library(
@@ -63,6 +77,7 @@ cc_unit_test_suites_for_host_and_qnx(
     name = "unit_test_suite",
     cc_unit_tests = [
         ":base64_unit_test",
+        ":static_destruction_guard_test",
     ],
     test_suites_from_sub_packages = [
         "@score_baselibs//score/utils/meyer_singleton:unit_test_suite",

--- a/score/utils/static_destruction_guard.h
+++ b/score/utils/static_destruction_guard.h
@@ -14,6 +14,7 @@
 #define SCORE_LIB_UTILS_STATIC_DESTRUCTION_GUARD_H
 
 #include <cstdint>
+#include <new>
 #include <type_traits>
 
 namespace score
@@ -39,12 +40,22 @@ class StaticDestructionGuard
   public:
     using StorageType = std::aligned_storage_t<sizeof(T), alignof(T)>;
 
-    /// \brief Enables access to underlying local storage
-    /// \return StorageType&, be aware that the storage is only filled correctly once the constructor was invoked.
-    static StorageType& GetStorage()
+    /// \brief Enables access to the guarded T instance.
+    /// \return A reference to T that is valid only while at least one StaticDestructionGuard instance is alive
+    ///        (e.g. a namespace-scope `static` variable in the header declaring this specialization).
+    static T& GetStorage() noexcept
     {
-        static StorageType storage;
-        return storage;
+        // std::launder is required here per C++17 object-lifetime rules: T was placement-new'd into
+        // StorageType-typed storage, so a pointer merely reinterpreted from that storage's address is not guaranteed
+        // by the standard to refer to the T object; std::launder makes that guarantee explicit. This is only valid to
+        // call once T has actually been constructed (see GetRawStorage(), used for that construction).
+        // Suppress “AUTOSAR_Cpp14_A5_2_4” rule finding: “Reinterpret_cast shall not be used.”
+        // Rationale: Reinterpret_cast is used to safely treat StorageType as type T. This usage is considered safe in
+        // this context.
+        // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reinterpret_cast
+        // coverity[autosar_cpp14_a5_2_4_violation]
+        return *std::launder(reinterpret_cast<T*>(&GetRawStorage()));
+        // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reinterpret_cast
     }
 
     /// \brief Constructs T in local storage upon first usage
@@ -63,12 +74,12 @@ class StaticDestructionGuard
             {
                 // NOLINTBEGIN(score-no-dynamic-raw-memory): safe usage of new
                 // Suppress "AUTOSAR C++14 A18-5-10" rule finding: "Placement new shall be used only with properly
-                // aligned pointers to sufficient storage capacity." Rationale: 'new' ensures proper object construction
-                // by dynamically allocating memory within GetStorage(). This allows us to manage initialization,
-                // required for handlingr static storage. Although this approach goes against AUTOSAR rule A18-5-10, it
-                // is essential to ensure proper object construction.
+                // aligned pointers to sufficient storage capacity." Rationale: 'new' does not allocate memory here;
+                // it constructs T in-place within the already-allocated, correctly-aligned raw storage returned by
+                // GetRawStorage(). This is required to manage construction of static storage. Although this approach
+                // goes against AUTOSAR rule A18-5-10, it is essential to ensure proper object construction.
                 // coverity[autosar_cpp14_a18_5_10_violation]
-                new (&GetStorage()) T();
+                new (&GetRawStorage()) T();
                 // NOLINTEND(score-no-dynamic-raw-memory): safe usage of new
             }
         }
@@ -87,13 +98,7 @@ class StaticDestructionGuard
             --counter_value;
             if (counter_value == 0)
             {
-                // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
-                // Suppress “AUTOSAR_Cpp14_A5_2_4” rule finding: “Reinterpret_cast shall not be used.”
-                // Rationale: Reinterpret_cast is used to safely treat StorageType as type T, allowing proper
-                // destruction. This usage is considered safe in this context, despite AUTOSAR A5-2-4 prohibition.
-                // coverity[autosar_cpp14_a5_2_4_violation]
-                reinterpret_cast<T&>(GetStorage()).~T();
-                // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast): safe usage of reintrpret_cast
+                GetStorage().~T();
             }
         }
     };
@@ -104,6 +109,14 @@ class StaticDestructionGuard
     StaticDestructionGuard& operator=(StaticDestructionGuard&&) noexcept = default;
 
   private:
+    /// \brief Raw, not-yet-typed storage. Only intended to obtain an address for placement-new (before T exists);
+    ///        must not be accessed as T without first going through GetStorage()'s std::launder.
+    static StorageType& GetRawStorage()
+    {
+        static StorageType storage;
+        return storage;
+    }
+
     static std::int32_t& GetCounter()
     {
         static std::int32_t counter;

--- a/score/utils/static_destruction_guard_test.cpp
+++ b/score/utils/static_destruction_guard_test.cpp
@@ -1,0 +1,164 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/utils/static_destruction_guard.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+
+namespace score
+{
+namespace utils
+{
+namespace
+{
+
+/// \brief A type with an observable lifecycle (construction/destruction counters, a mutable value) used to verify
+/// both the nifty-counter idiom's lifetime guarantees and that StaticDestructionGuard::GetStorage() consistently
+/// refers to one and the same live object across calls (i.e. exercises the std::launder'ed access path).
+struct LifecycleTracker
+{
+    static constexpr std::int32_t kInitialValue{42};
+
+    LifecycleTracker() noexcept
+    {
+        ++construction_count;
+        value = kInitialValue;
+    }
+
+    ~LifecycleTracker() noexcept
+    {
+        ++destruction_count;
+    }
+
+    LifecycleTracker(const LifecycleTracker&) = delete;
+    LifecycleTracker& operator=(const LifecycleTracker&) = delete;
+    LifecycleTracker(LifecycleTracker&&) = delete;
+    LifecycleTracker& operator=(LifecycleTracker&&) = delete;
+
+    static void Reset() noexcept
+    {
+        construction_count = 0;
+        destruction_count = 0;
+    }
+
+    std::int32_t value{};
+
+    static std::uint8_t construction_count;
+    static std::uint8_t destruction_count;
+};
+
+std::uint8_t LifecycleTracker::construction_count{0U};
+std::uint8_t LifecycleTracker::destruction_count{0U};
+
+using Guard = StaticDestructionGuard<LifecycleTracker>;
+
+// The counter and storage guarded by Guard have static storage duration for the whole test binary (that is the
+// point of the nifty-counter idiom), so every test must leave it fully destroyed (all guards out of scope) by the
+// time it ends, and reset the observation counters in SetUp(), to keep tests independent of each other and of order.
+class StaticDestructionGuardTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        LifecycleTracker::Reset();
+    }
+};
+
+TEST_F(StaticDestructionGuardTest, FirstGuardConstructsGuardedInstanceExactlyOnce)
+{
+    // Given a first guard has just been constructed
+    Guard guard_1{};
+    EXPECT_EQ(LifecycleTracker::construction_count, 1U);
+
+    // When a second guard is constructed while the first is still alive
+    Guard guard_2{};
+
+    // Then the guarded instance must not have been constructed a second time
+    EXPECT_EQ(LifecycleTracker::construction_count, 1U);
+}
+
+TEST_F(StaticDestructionGuardTest, GuardedInstanceIsDestroyedOnceAllGuardsAreGone)
+{
+    // Given two nested guards are alive
+    {
+        Guard guard_1{};
+        {
+            Guard guard_2{};
+
+            // Then the guarded instance must still be alive
+            EXPECT_EQ(LifecycleTracker::destruction_count, 0U);
+        }
+        // When the inner guard goes out of scope while the outer one is still alive
+
+        // Then the guarded instance must still not have been destroyed
+        EXPECT_EQ(LifecycleTracker::destruction_count, 0U);
+    }
+    // When the last remaining guard also goes out of scope
+
+    // Then the guarded instance must have been destroyed exactly once
+    EXPECT_EQ(LifecycleTracker::destruction_count, 1U);
+}
+
+TEST_F(StaticDestructionGuardTest, GuardedInstanceOutlivesEveryGuardExceptTheLast)
+{
+    // Given two independently-owned guards are alive
+    auto guard_1 = std::make_unique<Guard>();
+    auto guard_2 = std::make_unique<Guard>();
+    EXPECT_EQ(LifecycleTracker::construction_count, 1U);
+
+    // When the first guard is destroyed while the second is still alive
+    guard_1.reset();
+
+    // Then the guarded instance must not have been destroyed yet
+    EXPECT_EQ(LifecycleTracker::destruction_count, 0U);
+
+    // When the last remaining guard is also destroyed
+    guard_2.reset();
+
+    // Then the guarded instance must have been destroyed exactly once
+    EXPECT_EQ(LifecycleTracker::destruction_count, 1U);
+}
+
+TEST_F(StaticDestructionGuardTest, GetStorageReturnsFreshlyConstructedValue)
+{
+    // Given a guard has just been constructed
+    Guard guard{};
+
+    // When/Then the guarded instance is accessed via GetStorage(), it must hold its freshly constructed value
+    EXPECT_EQ(Guard::GetStorage().value, LifecycleTracker::kInitialValue);
+}
+
+TEST_F(StaticDestructionGuardTest, GetStorageAlwaysRefersToTheSameLiveObject)
+{
+    // Given a guard has just been constructed
+    Guard guard{};
+
+    // GetStorage() used to reinterpret_cast the raw StorageType bytes to T& directly, without std::launder.
+    // Per C++17 object-lifetime rules ([basic.life]), a reference obtained that way is not guaranteed
+    // by the standard to refer to the T that was placement-new'd into that storage, even though it has the same
+    // address - which is exactly what std::launder is required to fix.
+
+    // When the guarded instance is mutated through one call to GetStorage()
+    Guard::GetStorage().value = 1337;
+
+    // Then that mutation must be visible through a later call, and both calls must yield the same address, proving
+    // every access refers to the one live object
+    EXPECT_EQ(Guard::GetStorage().value, 1337);
+    EXPECT_EQ(&Guard::GetStorage(), &Guard::GetStorage());
+}
+
+}  // namespace
+}  // namespace utils
+}  // namespace score


### PR DESCRIPTION
GetStorage() previously returned the raw StorageType& (aligned storage), forcing every caller to reinterpret_cast it to T& themselves. Move that cast into GetStorage() so it returns T& directly, and update the constructor/destructor to use it without a redundant second cast.

Update the three existing consumers (Mman, Mqueue, Unistd instance()) accordingly, removing their now-unneeded reinterpret_cast.