### PR TITLE
Deprecate datetime_converter

### DIFF
--- a/score/datetime_converter/BUILD
+++ b/score/datetime_converter/BUILD
@@ -19,6 +19,7 @@ cc_library(
     name = "datetime_converter",
     srcs = ["datetime_converter.cpp"],
     hdrs = ["datetime_converter.h"],
+    deprecation = "This target is deprecated due to known bugs and error prone implementation. It will be removed in the future. If you need it please comment in https://github.com/eclipse-score/baselibs/pull/471",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
The implementation is error prone, it had already several bugs in the past and at least I could find another one that basically it does not work proper with leap seconds.
This is not yet widely used, before we get more people depending on it and get unexpected bugs, we should delete it.
If the functionality would be needed in the future, it would be better to rely as much as possible in existing implementations like some of the POSIX / C lib apis.
To give some kind of notice, we first deprecate it.