### PR TITLE
Add repository downloader retries and scale timeouts to bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,9 @@ build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
 common --registry=https://bcr.bazel.build
+
+common --experimental_repository_downloader_retries=10
+common --experimental_scale_timeouts=2.0
 common --http_connector_attempts=10
 common --http_connector_retry_max_timeout=1s
 common --http_timeout_scaling=2.0

--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -14,6 +14,12 @@
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
 common --registry=https://bcr.bazel.build
 
+common --experimental_repository_downloader_retries=10
+common --experimental_scale_timeouts=2.0
+common --http_connector_attempts=10
+common --http_connector_retry_max_timeout=1s
+common --http_timeout_scaling=2.0
+
 # Do not use automatically detected C++ toolchains
 build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 


### PR DESCRIPTION
## Description

Increase resilience against transient network issues during bazel builds by
adding repository downloader retries and scaling timeouts in both `.bazelrc`
and `examples/integration/.bazelrc`.

Changes are made based on https://github.com/eclipse-score/communication/pull/189