### PR TITLE
Add release-notes-skill for generating GitHub release notes

### DIFF
--- a/.agents/skills/release-notes-skill/SKILL.md
+++ b/.agents/skills/release-notes-skill/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: release-notes-skill
+description: Prepare or verify the human-readable "Notable Changes" section of an eclipse-score/baselibs GitHub release.
+disable-model-invocation: true
+---
+
+# Release Notes
+
+Use this skill for a specific release tag.
+
+## Gather the release scope
+
+1. Load the raw release body and metadata: `GH_PAGER= gh release view <tag> --repo eclipse-score/baselibs --json body,isDraft,name,publishedAt,tagName`. Use the header's `Origin Release Tag` and `Release Commit Hash` when present. Complete when the release tag and unformatted body are known.
+2. Extract every unique PR number from the release body's `What's Changed` list. This list is the release scope, including for a published release. If the list is absent or has no PR links, report that the scope cannot be determined from the release and stop. Do not reconstruct it from `git log` or a comparison view.
+3. Fetch every in-scope PR with `GH_PAGER= gh pr view <number> --repo eclipse-score/baselibs --json number,title,body,author,url`. Complete when every in-scope PR has a title, body, author, and URL from GitHub.
+4. Classify every in-scope PR using the criteria below. For a PR that is notable but whose title and body do not support a precise statement, inspect its diff before writing about it. Complete when every notable bullet is supported by PR metadata or a diff.
+5. Find the two published releases immediately before the target release. For a draft, use the two most recent published releases. Use `GH_PAGER= gh release list --repo eclipse-score/baselibs --exclude-drafts --limit 10 --json tagName,publishedAt` to identify them, increasing the limit when the target's history is not included. Retrieve their bodies with `GH_PAGER= gh release view <tag> --repo eclipse-score/baselibs --json body,tagName`. Match their section granularity and identify any prior release promise fulfilled by the target PRs. Complete when the editorial precedent and prior-release follow-up have both been considered.
+
+## Produce the result
+
+### Draft
+
+Write the complete release body for the user. Preserve every existing non-`Notable Changes` section verbatim, and GitHub-generated `What's Changed` list. Replace only the `Notable Changes` section. Complete when the proposed body retains all source content outside that section and every notable PR is represented accurately.
+
+### Verify
+
+Do not modify the release. Report a missing `Notable Changes` section, or each unsupported, inaccurate, missing, or misleading statement with the relevant PR URL and a corrected statement. State clearly when the section is supported by the in-scope PRs. Complete when every existing Notable Changes claim has been checked against its source PR.
+
+### Update or publish
+
+First provide the proposed complete body. Change GitHub only after the user explicitly asks for the update or publication and confirms the mutation immediately before it is made. Complete when the requested GitHub operation reports success and the release body is retrieved again to confirm the intended content.
+
+## Classifying changes: notable vs. skip
+
+- **Skip**: CI/workflow-only PRs, dependency-bump PRs (author `eclipse-score-bot` / `renovate`), Bazel visibility-only changes, requirements/doc-only PRs, internal repo-sync or agent-tooling PRs, and anything that nets to zero versus the previous release (e.g. a revert immediately undone by its own revert).
+- **Notable**: breaking API/behavior changes and deprecations, new public features or libraries, user-visible bug fixes, and anything that continues or completes a change the previous release's notes flagged as upcoming.
+
+## Style rules for Notable Changes
+
+- Headings use ATX style (`#`, `##`, `###`).
+- Link to PRs/issues with the bare URL, e.g. `https://github.com/eclipse-score/baselibs/pull/NNN`. GitHub auto-links and shortens these; do not use `[text](url)` markdown link syntax.
+- Use `-` for bullets and backticks for code identifiers/paths.
+- Group bullets under `###` subheadings as needed, typically `Breaking changes & deprecations`, `New features`, `Bug fixes` — plus an optional themed `###` (or a short intro paragraph before the first subheading) for a single cross-release effort such as a migration or multi-release deprecation.
+
+## Inspecting diffs: `git` vs `gh` vs the web
+
+- Prefer plain `git` for anything already in your local clone's history: `git log`, `git show`, `git diff`.
+- Use `GH_PAGER= gh pr diff` for an in-scope PR whose diff is not available locally.
+- Only fetch github.com pages through a browser/web tool as a last resort.
+- Prefix every `gh` invocation with `GH_PAGER=` so it never opens an interactive pager.

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -4,33 +4,29 @@ Origin Release Tag: $PREVIOUS_RELEASE_TAG
 Release Commit Hash: $COMMIT_SHA
 Release Date: $RELEASE_DATE
 
-Overview
---------
+## Overview
+
 The baselibs module provides a selection of basic C++ utility libraries for common use in the S-CORE project.
 
-Disclaimer
-----------
+## Disclaimer
+
 This release is not intended for production use, as it does not include a safety argumentation or a completed safety assessment.
-The work products compiled in the safety package are created with care according to the [S-CORE process](https://eclipse-score.github.io/process_description/main/index.html). However, as a non-profit, open-source organization, the project cannot assume any liability for its content.
+The work products compiled in the safety package are created with care according to the S-CORE process (https://eclipse-score.github.io/process_description/main/index.html). However, as a non-profit, open-source organization, the project cannot assume any liability for its content.
 
 For details on the features, see https://eclipse-score.github.io/score/main/features/baselibs/index.html
 
-Improvements
-------------
+## Notable Changes
 
-Bug Fixes
----------
+## Compatibility
 
-Compatibility
--------------
-The following platforms are supported using the [bazel_cpp_toolchains](https://github.com/eclipse-score/bazel_cpp_toolchains):
+The following platforms are supported using the bazel_cpp_toolchains (https://github.com/eclipse-score/bazel_cpp_toolchains):
 - `x86_64-unknown-linux-gnu`
 - `aarch64-unknown-linux-gnu`
 - `x86_64-unknown-nto-qnx800`
 - `aarch64-unknown-nto-qnx800`
 
-Performed Verification
-----------------------
+## Performed Verification
+
 - Build on all supported platforms
 - Unit test execution on all supported platforms (some test failures are expected on AArch64 and QNX targets).
 - Address and undefined behavior sanitized unit test execution
@@ -38,13 +34,14 @@ Performed Verification
 
 Report: $ACTION_RUN_URL
 
-Known Issues
-------------
+## Known Issues
 
-Upgrade Instructions
---------------------
+<!-- Remove this section entirely if there are no known issues to report. -->
+
+## Upgrade Instructions
+
 Backward compatibility with the previous release is not guaranteed.
 
-Contact Information
--------------------
+## Contact Information
+
 For any questions or support, please contact the Base Libs Feature Team (https://github.com/orgs/eclipse-score/discussions/1223) or raise an issue/discussion.


### PR DESCRIPTION
This pull request introduces a new skill definition for preparing and verifying the "Notable Changes" section of release notes, and updates the release template to improve clarity and consistency. The main changes are the addition of a detailed skill guide for release note handling and a modernization of the release template's structure and style.

**Release notes skill addition:**

* Added a comprehensive `.agents/skills/release-notes-skill/SKILL.md` file that defines a step-by-step process for gathering release scope, classifying changes as notable or skippable, and drafting or verifying the "Notable Changes" section for releases. This includes clear criteria, style rules, and guidance on using GitHub and git tools for inspection.

**Release template improvements:**

* Updated section headings in `.github/RELEASE_TEMPLATE.md` to use ATX (`##`) Markdown style for better readability and consistency.
* Replaced the "Improvements" and "Bug Fixes" sections with a unified "Notable Changes" section to align with the new skill and streamline release note content.
* Added guidance to remove the "Known Issues" section if there are no issues, and improved the formatting and wording for links and section descriptions throughout the template.