### PR TITLE
docs(verification_report): render linked tests as a list

### DIFF
--- a/docs/verification_report/requirements_statistics.rst
+++ b/docs/verification_report/requirements_statistics.rst
@@ -21,6 +21,24 @@ results. Use the tables below to drill down into individual requirements.
        max-width: 100%;
        height: auto;
      }
+     /* The "Tests" column lists every test linked to a requirement as a single
+        "; "-separated inline string. In a narrow column that renders as an
+        unreadable wall of text. Render each linked test on its own line
+        instead, like a plain list, and drop the "; " separators. */
+     table.compact-needtable td.needs_testlink p {
+       margin: 0;
+     }
+     table.compact-needtable td.needs_testlink a {
+       display: block;
+       padding: 0.15em 0;
+       word-break: break-word;
+     }
+     table.compact-needtable td.needs_testlink a:not(:last-child) {
+       border-bottom: 1px solid #eee;
+     }
+     table.compact-needtable td.needs_testlink em {
+       display: none;
+     }
    </style>
 
 Overview
@@ -61,4 +79,5 @@ verifying them.
 .. needtable:: REQUIREMENTS WITH TESTS
    :filter: type == "comp_req" and status == "valid" and testlink != ""
    :columns: id;title;satisfied_by as "Satisfied by";safety as "Safety";testlink as "Tests"
+   :colwidths: 10,20,10,8,52
    :class: compact-needtable


### PR DESCRIPTION
## Problem
The "Tests" column of the "REQUIREMENTS WITH TESTS" table in the requirements statistics report rendered every linked test name as a single `"; "`-separated inline string. For requirements covered by many tests (e.g. `comp_req__flatbuffers__buffer_identification`), this produced a long, thin, unreadable wall of text since the column only got ~14% of the table width.

## Fix
- Added CSS scoped to `.needs_testlink` that hides the `"; "` separators and turns each linked test into a block-level element, so every test renders on its own line.
- Added `:colwidths:` to the needtable directive to give the Tests column significantly more horizontal space (52% vs. the previous ~14%).

## Verification
Rebuilt the docs (`bazel run //:docs`) and visually confirmed in-browser that each test linked to a requirement (e.g. `comp_req__flatbuffers__buffer_identification`) now renders as a readable list instead of a dense inline string.