### PR TITLE
bitmanipulation: link unit tests to comp_req requirements

### DIFF
--- a/.agents/skills/requirements-management-skill/test-to-requirement-linking.md
+++ b/.agents/skills/requirements-management-skill/test-to-requirement-linking.md
@@ -11,7 +11,8 @@ Use this reference when linking, migrating, or reviewing C++ gtest and Rust unit
 3. Choose `TestType` and `DerivationTechnique` from [Metadata Reference](#metadata-reference).
 4. Add a concise `Description` that states objective, input, and expected outcome.
 5. Record the metadata using the language-specific mechanism below.
-6. Run the narrow test target, usually `bazel test --config=bl-x86_64-linux //score/<component>/...`; the route is complete when the test passes and the referenced requirement exists.
+6. Run the narrow test target, usually `bazel test --config=bl-x86_64-linux //score/<component>/...`, to confirm the test still passes.
+7. Run `bazel run //:docs` to confirm the linked requirement ID resolves. A passing test does not prove this: `RecordProperty`/`record_property` values are untyped strings with no compile-time or test-runtime check against the metamodel, so a typoed or removed ID only surfaces as a docs build warning or error. The route is complete when both the test passes and the docs build reports no unresolved-link or missing-property issue for it.
 
 ### Migrate legacy metadata
 
@@ -33,7 +34,7 @@ Use this reference when linking, migrating, or reviewing C++ gtest and Rust unit
 Check every touched test case:
 
 - It records `TestType`, `DerivationTechnique`, `Description`, and exactly one linkage style: `FullyVerifies` or `PartiallyVerifies`.
-- Linked unit tests point at existing `comp_req__...` needs, not feature or stakeholder requirements.
+- Linked unit tests point at existing `comp_req__...` needs only, never at `aou_req__...`, `feat_req__...`/`stkh_req__...`.
 - `FullyVerifies` is used only when this test alone covers the requirement; otherwise use `PartiallyVerifies`.
 - The assertions exercise the linked requirement's normative behavior.
 - No legacy `Verifies`, `ASIL`, `Priority`, `SCR-*`, or raw-symbol requirement links remain.
@@ -48,22 +49,29 @@ Every test case that links to requirements shall carry these metadata properties
 | `FullyVerifies` | One of `FullyVerifies` / `PartiallyVerifies` is mandatory | Requirement/design/interface ID(s) fully covered by this single test |
 | `PartiallyVerifies` | See above | Requirement/design/interface ID(s) partially covered by this test |
 | `Description` | Yes, non-empty | Objective, inputs, expected outcome; add environment or event sequence only when relevant |
-| `TestType` | Yes | `requirements-based`, `interface-test`, `fault-injection`, or `resource-usage` |
+| `TestType` | Yes | One of the values below |
 | `DerivationTechnique` | Yes | One of the values below |
 
-`DerivationTechnique` is chosen from how the test case was derived:
+`TestType` is chosen from what aspect of the test subject is being exercised:
+
+| Use | When the test is exercising... |
+|-----|--------------------------------|
+| `requirements-based` | Whether the unit fulfils a specific requirement's normative statement, and does not exhibit unintended additional functionality |
+| `interface-test` | Correctness of data and control passed across an interface: parameter passing between units, data format/encoding, protocol/sequencing, or how a communication error is handled; for unit tests this covers internal interfaces, external interfaces belong at integration/feature level |
+| `fault-injection` | The unit's detection and handling of a deliberately induced fault: a corrupted value, an error forced from a mocked or wrapped dependency, or injected data corruption, verifying a safety mechanism reacts correctly, not a plain out-of-range argument |
+| `resource-usage` | Whether resource consumption, e.g. execution time, memory or stack usage, or communication bandwidth, stays within its specified budget, including under worst-case or exhausted conditions |
+
+`DerivationTechnique` is chosen from how the test case was derived: 
 
 | Use | When the test is derived from... |
 |-----|--------------------------------|
-| `requirements-analysis` | The requirement's normative statement |
+| `requirements-analysis` | The requirement's normative statement, both its nominal behavior (input x yields output y) and, where the requirement implies it, the negative/off-spec behavior it does not spell out explicitly |
 | `design-analysis` | Design or architecture rather than requirement text |
-| `boundary-values` | Limits, overflow, out-of-bounds, zero, min/max, saturation, off-by-one |
-| `equivalence-classes` | One representative of a class with equivalent behavior |
+| `equivalence-classes` | A representative value from a partition of valid/invalid inputs or outputs, grouped either because the spec treats them alike or because they yield the same functional result; pick this only once boundary values are ruled out |
+| `boundary-values` | A value at, or one step inside/outside, a partition's edge: minimum, maximum, zero, an off-by-one position, a sequence's first/last element, a collection holding zero/one/two items, or a numeric limit stated in the requirement text (e.g. "up to 64 bits"); also covers forcing an *output* to its own limit, not just an input; wins over `equivalence-classes` whenever a value could be read either way |
 | `fuzz-testing` | Randomized or generated inputs |
-| `error-guessing` | Reasoning about likely faults without a formal derivation |
+| `error-guessing` | An atypical value, combination, or timing (e.g. rapid or concurrent calls) added from tester experience, lessons-learned, or FMEA findings on top of the systematically derived set, not from partitioning the spec itself |
 | `explorative-testing` | Ad-hoc manual exploration |
-
-When several techniques apply, choose the one that best explains why this specific case was written. A max-value or overflow case is `boundary-values` even if the feature came from requirements analysis.
 
 ## Description
 

--- a/score/bitmanipulation/bit_manipulation_test.cpp
+++ b/score/bitmanipulation/bit_manipulation_test.cpp
@@ -232,6 +232,23 @@ TEST(SetBit, WithUInt64)
     EXPECT_EQ(input, expectedResult);
 }
 
+TEST(SetBit, WithNegativeInt32)
+{
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty("Description",
+                   "Check that SetBit sets the requested bit of a negative (sign-bit-set) int32_t value, i.e. "
+                   "the internal unsigned promotion and narrowing back to a signed type do not corrupt the result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
+    std::int32_t input{-2};                     // 0xFFFFFFFE
+    constexpr std::int32_t expectedResult{-1};  // 0xFFFFFFFF
+
+    EXPECT_TRUE(::score::platform::SetBit(input, 0U));
+
+    EXPECT_EQ(input, expectedResult);
+}
+
 TEST(SetBit, OverflowWithUInt8)
 {
     RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");

--- a/score/bitmanipulation/bit_manipulation_test.cpp
+++ b/score/bitmanipulation/bit_manipulation_test.cpp
@@ -236,14 +236,19 @@ TEST(SetBit, OverflowWithUInt8)
 {
     RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
     RecordProperty("Description",
-                   "Check that SetBit returns false when the bit position exceeds the width of a uint8_t value.");
+                   "Check that SetBit returns false and leaves the value unmodified when the bit position exceeds "
+                   "the width of a uint8_t value.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "boundary-values");
 
-    std::uint8_t input{0};  // 00000000
+    constexpr std::uint8_t expectedResult{0b1011'0101U};  // must stay unchanged
+    std::uint8_t input{expectedResult};
 
     EXPECT_FALSE(::score::platform::SetBit(input, 8U));
+    EXPECT_EQ(input, expectedResult);
+
     EXPECT_FALSE(::score::platform::SetBit(input, 10U));
+    EXPECT_EQ(input, expectedResult);
 }
 
 TEST(ClearBit, WithUInt8)
@@ -284,14 +289,19 @@ TEST(ClearBit, OverflowWithUInt8)
 {
     RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
     RecordProperty("Description",
-                   "Check that ClearBit returns false when the bit position exceeds the width of a uint8_t value.");
+                   "Check that ClearBit returns false and leaves the value unmodified when the bit position exceeds "
+                   "the width of a uint8_t value.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "boundary-values");
 
-    std::uint8_t input{0};  // 00000000
+    constexpr std::uint8_t expectedResult{0b1011'0101U};  // must stay unchanged
+    std::uint8_t input{expectedResult};
 
     EXPECT_FALSE(::score::platform::ClearBit(input, 8U));
+    EXPECT_EQ(input, expectedResult);
+
     EXPECT_FALSE(::score::platform::ClearBit(input, 10U));
+    EXPECT_EQ(input, expectedResult);
 }
 
 TEST(ToggleBit, WithUInt8)
@@ -334,14 +344,19 @@ TEST(ToggleBit, OverflowWithUInt8)
 {
     RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
     RecordProperty("Description",
-                   "Check that ToggleBit returns false when the bit position exceeds the width of a uint8_t value.");
+                   "Check that ToggleBit returns false and leaves the value unmodified when the bit position exceeds "
+                   "the width of a uint8_t value.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "boundary-values");
 
-    std::uint8_t input{0};  // 00000000
+    constexpr std::uint8_t expectedResult{0b1011'0101U};  // must stay unchanged
+    std::uint8_t input{expectedResult};
 
     EXPECT_FALSE(::score::platform::ToggleBit(input, 8U));
+    EXPECT_EQ(input, expectedResult);
+
     EXPECT_FALSE(::score::platform::ToggleBit(input, 10U));
+    EXPECT_EQ(input, expectedResult);
 }
 
 TEST(CheckBit, WithUInt8)

--- a/score/bitmanipulation/bit_manipulation_test.cpp
+++ b/score/bitmanipulation/bit_manipulation_test.cpp
@@ -28,6 +28,12 @@ using ::testing::Eq;
 
 TEST(HalfByte, CanBeConstructedFromUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that a HalfByte can be constructed from a uint8_t value within its 4-bit range.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     constexpr HalfByte value{std::uint8_t{4u}};
 
     EXPECT_THAT(value, Eq(4u));
@@ -35,6 +41,12 @@ TEST(HalfByte, CanBeConstructedFromUInt8)
 
 TEST(HalfByte, CanBeConstructedFromUInt16IfInRange)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that a HalfByte can be constructed from a uint16_t value that fits within its 4-bit range.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     constexpr HalfByte value{std::uint16_t{4u}};
 
     EXPECT_THAT(value, Eq(4u));
@@ -42,6 +54,13 @@ TEST(HalfByte, CanBeConstructedFromUInt16IfInRange)
 
 TEST(HalfByte, CanBeConstructedFromBigUInt8ButUpperHalfIsDropped)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that constructing a HalfByte from a uint8_t value larger than 4 bits drops the upper bits "
+                   "and keeps only the lower nibble.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr HalfByte value{std::uint8_t{77u}};  // 01001101
 
     EXPECT_THAT(value, Eq(13u));
@@ -49,6 +68,11 @@ TEST(HalfByte, CanBeConstructedFromBigUInt8ButUpperHalfIsDropped)
 
 TEST(Byte, CanBeConstructedFromUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that a Byte can be constructed directly from a uint8_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     constexpr Byte value{std::uint8_t{4u}};
 
     EXPECT_THAT(value, Eq(4u));
@@ -56,6 +80,12 @@ TEST(Byte, CanBeConstructedFromUInt8)
 
 TEST(Byte, CanBeConstructedFromUInt16IfInRange)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that a Byte can be constructed from a uint16_t value that fits within a single byte.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     constexpr Byte value{std::uint16_t{4u}};
 
     EXPECT_THAT(value, Eq(4u));
@@ -63,6 +93,13 @@ TEST(Byte, CanBeConstructedFromUInt16IfInRange)
 
 TEST(Byte, CanBeConstructedFromTwoHalfBytes)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that a Byte constructed from an upper and lower HalfByte concatenates them into the expected "
+                   "combined value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     constexpr HalfByte upperHalfByte{std::uint8_t{13u}};  // 00001101
     constexpr HalfByte lowerHalfByte{std::uint8_t{4u}};   // 00000100
 
@@ -73,6 +110,13 @@ TEST(Byte, CanBeConstructedFromTwoHalfBytes)
 
 TEST(Byte, CanBeConstructedFromTwoBigHalfBytes)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that constructing a Byte from HalfBytes built from oversized values still yields the correct "
+                   "combined byte, since only the lower nibble of each half is kept.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr HalfByte upperHalfByte{77u};  // 01001101
     constexpr HalfByte lowerHalfByte{36u};  // 00100100
 
@@ -83,6 +127,11 @@ TEST(Byte, CanBeConstructedFromTwoBigHalfBytes)
 
 TEST(Byte, CanBeConstructedFromTwoZeroHalfBytes)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that a Byte constructed from two zero HalfBytes results in the value zero.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr HalfByte zeroUpperHalfByte{0};  // 00000000
     constexpr HalfByte zeroLowerHalfByte{0};  // 00000000
 
@@ -93,6 +142,12 @@ TEST(Byte, CanBeConstructedFromTwoZeroHalfBytes)
 
 TEST(Byte, CanBeConstructedFromTwoHalfBytesWithMaxValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that a Byte constructed from two max-value HalfBytes results in the value 255.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr HalfByte halfByteWithMaxValue{255};  // 11111111
 
     constexpr Byte combinedByte{halfByteWithMaxValue, halfByteWithMaxValue};
@@ -102,6 +157,11 @@ TEST(Byte, CanBeConstructedFromTwoHalfBytesWithMaxValue)
 
 TEST(Extract, UpperHalfByteFromAByte)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that UpperHalfByte extracts the upper nibble of a Byte.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     constexpr Byte input{212u};  // 11010100
 
     constexpr auto upperHalfByte = input.UpperHalfByte();
@@ -111,6 +171,11 @@ TEST(Extract, UpperHalfByteFromAByte)
 
 TEST(Extract, LowerHalfByteFromAByte)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that LowerHalfByte extracts the lower nibble of a Byte.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     constexpr Byte input{212};  // 11010100
 
     constexpr auto lowerHalfByte = input.LowerHalfByte();
@@ -120,6 +185,12 @@ TEST(Extract, LowerHalfByteFromAByte)
 
 TEST(Extract, LowerHalfByteFromAByteCanBeConvertedToUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that a HalfByte extracted from a Byte converts implicitly to its underlying uint8_t value.");
+    RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     constexpr Byte input{212};  // 11010100
 
     const std::uint8_t lowerHalfByteAsUInt8{input.LowerHalfByte()};
@@ -129,6 +200,11 @@ TEST(Extract, LowerHalfByteFromAByteCanBeConvertedToUInt8)
 
 TEST(SetBit, WithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty("Description", "Check that SetBit sets the requested bit of a uint8_t value and returns true.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     std::uint8_t input{0};                     // 00000000
     constexpr std::uint8_t expectedResult{4};  // 00000100
 
@@ -139,6 +215,13 @@ TEST(SetBit, WithUInt8)
 
 TEST(SetBit, WithUInt64)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty(
+        "Description",
+        "Check that SetBit sets the requested bit of a uint64_t value, supporting integral types up to 64 bits.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     // 00000000'00000000'00000000'00000000'00000000'00000000'00000000'00000000
     std::uint64_t input{0};
     // 00000000'00000000'00000100'00000000'00000000'00000000'00000000'00000000
@@ -151,6 +234,12 @@ TEST(SetBit, WithUInt64)
 
 TEST(SetBit, OverflowWithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
+    RecordProperty("Description",
+                   "Check that SetBit returns false when the bit position exceeds the width of a uint8_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     std::uint8_t input{0};  // 00000000
 
     EXPECT_FALSE(::score::platform::SetBit(input, 8U));
@@ -159,6 +248,11 @@ TEST(SetBit, OverflowWithUInt8)
 
 TEST(ClearBit, WithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty("Description", "Check that ClearBit clears the requested bit of a uint8_t value and returns true.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     std::uint8_t input{24};                    // 00011000
     constexpr std::uint8_t expectedResult{8};  // 00001000
 
@@ -169,6 +263,13 @@ TEST(ClearBit, WithUInt8)
 
 TEST(ClearBit, WithUInt64)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty(
+        "Description",
+        "Check that ClearBit clears the requested bit of a uint64_t value, supporting integral types up to 64 bits.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     // 00000000'00000000'00011000'00000000'00000000'00000000'00000000'00000000
     std::uint64_t input{26388279066624ULL};
     // 00000000'00000000'00001000'00000000'00000000'00000000'00000000'00000000
@@ -181,6 +282,12 @@ TEST(ClearBit, WithUInt64)
 
 TEST(ClearBit, OverflowWithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
+    RecordProperty("Description",
+                   "Check that ClearBit returns false when the bit position exceeds the width of a uint8_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     std::uint8_t input{0};  // 00000000
 
     EXPECT_FALSE(::score::platform::ClearBit(input, 8U));
@@ -189,6 +296,11 @@ TEST(ClearBit, OverflowWithUInt8)
 
 TEST(ToggleBit, WithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty("Description", "Check that ToggleBit flips the requested bits of a uint8_t value and returns true.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     std::uint8_t input{24};                     // 00011000
     constexpr std::uint8_t expectedResult{20};  // 00010100
 
@@ -200,6 +312,13 @@ TEST(ToggleBit, WithUInt8)
 
 TEST(ToggleBit, WithUInt64)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty(
+        "Description",
+        "Check that ToggleBit flips the requested bits of a uint64_t value, supporting integral types up to 64 bits.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     // 00000000'00000000'00011000'00000000'00000000'00000000'00000000'00000000
     std::uint64_t input{26388279066624ULL};
     // 00000000'00000000'00010100'00000000'00000000'00000000'00000000'00000000
@@ -213,6 +332,12 @@ TEST(ToggleBit, WithUInt64)
 
 TEST(ToggleBit, OverflowWithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
+    RecordProperty("Description",
+                   "Check that ToggleBit returns false when the bit position exceeds the width of a uint8_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     std::uint8_t input{0};  // 00000000
 
     EXPECT_FALSE(::score::platform::ToggleBit(input, 8U));
@@ -221,6 +346,12 @@ TEST(ToggleBit, OverflowWithUInt8)
 
 TEST(CheckBit, WithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty("Description",
+                   "Check that CheckBit reports the correct set/unset state of bits in a uint8_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     std::uint8_t input{24};  // 00011000
 
     ASSERT_TRUE(::score::platform::CheckBit(input, 3U));
@@ -229,6 +360,13 @@ TEST(CheckBit, WithUInt8)
 
 TEST(CheckBit, WithUInt64)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bit_operations");
+    RecordProperty("Description",
+                   "Check that CheckBit reports the correct set/unset state of bits in a uint64_t value, supporting "
+                   "integral types up to 64 bits.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     // 00000000'00000000'00011000'00000000'00000000'00000000'00000000'00000000
     std::uint64_t input{26388279066624ULL};
 
@@ -238,6 +376,12 @@ TEST(CheckBit, WithUInt64)
 
 TEST(CheckBit, OverflowWithUInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bounds_safety");
+    RecordProperty("Description",
+                   "Check that CheckBit returns false when the bit position exceeds the width of a uint8_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     std::uint8_t input{0};  // 00000000
 
     EXPECT_FALSE(::score::platform::CheckBit(input, 8U));
@@ -246,6 +390,11 @@ TEST(CheckBit, OverflowWithUInt8)
 
 TEST(GetByte, FromUint8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that GetByte extracts the single byte of a uint8_t value unchanged.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     std::uint8_t input{42};
     const auto extracted_byte = ::score::platform::GetByte<0>(input);
     EXPECT_EQ(extracted_byte, input);
@@ -253,6 +402,11 @@ TEST(GetByte, FromUint8)
 
 TEST(GetByte, FromInt8)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that GetByte extracts the single byte of a signed int8_t value unchanged.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     std::int8_t input{42};
     const auto extracted_byte = ::score::platform::GetByte<0>(input);
     EXPECT_EQ(extracted_byte, input);
@@ -260,6 +414,11 @@ TEST(GetByte, FromInt8)
 
 TEST(GetByte, FromUint16)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that GetByte extracts the correct byte at each position of a uint16_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     std::uint16_t input{0x0A0B};
 
     EXPECT_EQ(::score::platform::GetByte<1>(input), 0x0A);
@@ -268,6 +427,12 @@ TEST(GetByte, FromUint16)
 
 TEST(GetByte, FromInt16)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that GetByte extracts the correct byte at each position of a signed int16_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     std::int16_t input{0x0A0B};
 
     EXPECT_EQ(::score::platform::GetByte<1>(input), 0x0A);
@@ -276,6 +441,11 @@ TEST(GetByte, FromInt16)
 
 TEST(GetByte, FromUint32)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description", "Check that GetByte extracts the correct byte at each position of a uint32_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     std::uint32_t input{0x0A0B0C0D};
 
     EXPECT_EQ(::score::platform::GetByte<3>(input), 0x0A);
@@ -286,6 +456,12 @@ TEST(GetByte, FromUint32)
 
 TEST(GetByte, FromInt32)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that GetByte extracts the correct byte at each position of a signed int32_t value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     std::int32_t input{0x0A0B0C0D};
 
     EXPECT_EQ(::score::platform::GetByte<3>(input), 0x0A);
@@ -296,6 +472,13 @@ TEST(GetByte, FromInt32)
 
 TEST(GetByte, FromUint64)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that GetByte extracts the correct byte at each position of a uint64_t value, the widest "
+                   "supported integral type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     std::uint64_t input{0x0A0B0C0D04030201};
 
     EXPECT_EQ(::score::platform::GetByte<7>(input), 0x0A);
@@ -310,6 +493,13 @@ TEST(GetByte, FromUint64)
 
 TEST(GetByte, FromInt64)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("Description",
+                   "Check that GetByte extracts the correct byte at each position of a signed int64_t value, the "
+                   "widest supported integral type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     std::int64_t input{0x0A0B0C0D04030201};
 
     EXPECT_EQ(::score::platform::GetByte<7>(input), 0x0A);

--- a/score/bitmanipulation/bit_manipulation_test.cpp
+++ b/score/bitmanipulation/bit_manipulation_test.cpp
@@ -422,7 +422,7 @@ TEST(CheckBit, OverflowWithUInt8)
 
 TEST(GetByte, FromUint8)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description", "Check that GetByte extracts the single byte of a uint8_t value unchanged.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "requirements-analysis");
@@ -434,7 +434,7 @@ TEST(GetByte, FromUint8)
 
 TEST(GetByte, FromInt8)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description", "Check that GetByte extracts the single byte of a signed int8_t value unchanged.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "equivalence-classes");
@@ -446,7 +446,7 @@ TEST(GetByte, FromInt8)
 
 TEST(GetByte, FromUint16)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description", "Check that GetByte extracts the correct byte at each position of a uint16_t value.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "equivalence-classes");
@@ -459,7 +459,7 @@ TEST(GetByte, FromUint16)
 
 TEST(GetByte, FromInt16)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description",
                    "Check that GetByte extracts the correct byte at each position of a signed int16_t value.");
     RecordProperty("TestType", "requirements-based");
@@ -473,7 +473,7 @@ TEST(GetByte, FromInt16)
 
 TEST(GetByte, FromUint32)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description", "Check that GetByte extracts the correct byte at each position of a uint32_t value.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "equivalence-classes");
@@ -488,7 +488,7 @@ TEST(GetByte, FromUint32)
 
 TEST(GetByte, FromInt32)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description",
                    "Check that GetByte extracts the correct byte at each position of a signed int32_t value.");
     RecordProperty("TestType", "requirements-based");
@@ -504,7 +504,7 @@ TEST(GetByte, FromInt32)
 
 TEST(GetByte, FromUint64)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description",
                    "Check that GetByte extracts the correct byte at each position of a uint64_t value, the widest "
                    "supported integral type.");
@@ -525,7 +525,7 @@ TEST(GetByte, FromUint64)
 
 TEST(GetByte, FromInt64)
 {
-    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_operations");
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__byte_extraction");
     RecordProperty("Description",
                    "Check that GetByte extracts the correct byte at each position of a signed int64_t value, the "
                    "widest supported integral type.");

--- a/score/bitmanipulation/bitmask_operators_test.cpp
+++ b/score/bitmanipulation/bitmask_operators_test.cpp
@@ -21,6 +21,7 @@ namespace score
 namespace test
 {
 
+// Enumerators must be distinct, non-zero powers of two, per aou_req__bitmanipulation__enum_constraints.
 enum class MyBitmask : std::int32_t
 {
     a = 1,
@@ -41,15 +42,13 @@ namespace
 {
 using UnderlyingType = std::underlying_type_t<MyBitmask>;
 
-TEST(MyBitmask, UnderlyingValuesMatchExpectations)
-{
-    EXPECT_EQ(static_cast<UnderlyingType>(MyBitmask::a), 1);
-    EXPECT_EQ(static_cast<UnderlyingType>(MyBitmask::b), 2);
-    EXPECT_EQ(static_cast<UnderlyingType>(MyBitmask::c), 4);
-}
-
 TEST(MyBitmask, SupportsOperatorOr)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description", "Check that operator| combines two bitmask enumerators into their bitwise union.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     MyBitmask bitmask{MyBitmask::a | MyBitmask::b};
     EXPECT_EQ(static_cast<UnderlyingType>(bitmask), 3);
     bitmask = MyBitmask::b | MyBitmask::c;
@@ -58,6 +57,12 @@ TEST(MyBitmask, SupportsOperatorOr)
 
 TEST(MyBitmask, SupportsOperatorAnd)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description",
+                   "Check that operator& reports whether each queried bit is present in a combined bitmask.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto func = [](MyBitmask bitmask) {
         EXPECT_TRUE(bitmask & MyBitmask::a);
         EXPECT_TRUE(bitmask & MyBitmask::b);
@@ -69,6 +74,12 @@ TEST(MyBitmask, SupportsOperatorAnd)
 
 TEST(MyBitmask, SupportsOperatorXor)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description",
+                   "Check that operator^ combines two bitmask enumerators into their bitwise exclusive-or.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     MyBitmask bitmask{MyBitmask::a ^ MyBitmask::b};
     EXPECT_EQ(static_cast<UnderlyingType>(bitmask), 3);
     bitmask = bitmask ^ MyBitmask::b;
@@ -77,6 +88,11 @@ TEST(MyBitmask, SupportsOperatorXor)
 
 TEST(MyBitmask, SupportsOperatorNot)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description", "Check that operator~ inverts all bits of a bitmask enumerator.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     MyBitmask bitmask{MyBitmask::a};
     bitmask = ~bitmask;
 
@@ -87,6 +103,12 @@ TEST(MyBitmask, SupportsOperatorNot)
 
 TEST(MyBitmask, SupportsAssignOperatorAnd)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description",
+                   "Check that operator&= clears bits of a bitmask that are not present in the right-hand operand.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     MyBitmask bitmask{MyBitmask::a};
 
     bitmask &= MyBitmask::b;
@@ -96,6 +118,13 @@ TEST(MyBitmask, SupportsAssignOperatorAnd)
 
 TEST(MyBitmask, SupportsAssignOperatorAndMatching)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty(
+        "Description",
+        "Check that operator&= leaves a bitmask unchanged when the right-hand operand matches the same bit.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     MyBitmask bitmask{MyBitmask::b};
 
     bitmask &= MyBitmask::b;
@@ -105,6 +134,12 @@ TEST(MyBitmask, SupportsAssignOperatorAndMatching)
 
 TEST(MyBitmask, SupportsAssignOperatorOr)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description",
+                   "Check that operator|= sets additional bits of a bitmask from the right-hand operand.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     MyBitmask bitmask{MyBitmask::a};
 
     bitmask |= MyBitmask::b;
@@ -114,6 +149,13 @@ TEST(MyBitmask, SupportsAssignOperatorOr)
 
 TEST(MyBitmask, SupportsAssignOperatorOrMatching)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty(
+        "Description",
+        "Check that operator|= leaves a bitmask unchanged when the right-hand operand matches an already-set bit.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
+
     MyBitmask bitmask{MyBitmask::a};
 
     bitmask |= MyBitmask::a;
@@ -123,6 +165,11 @@ TEST(MyBitmask, SupportsAssignOperatorOrMatching)
 
 TEST(MyBitmask, SupportsAssignOperatorXOr)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description", "Check that operator^= toggles bits of a bitmask from the right-hand operand.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
+
     MyBitmask bitmask{MyBitmask::a};
 
     bitmask ^= MyBitmask::b;
@@ -132,6 +179,11 @@ TEST(MyBitmask, SupportsAssignOperatorXOr)
 
 TEST(MyBitmask, SupportsAssignOperatorXOrMatching)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__bitmanipulation__bitmask_operators");
+    RecordProperty("Description", "Check that operator^= clears a bitmask to zero when XOR-ed with itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
+
     MyBitmask bitmask{MyBitmask::a};
 
     bitmask ^= MyBitmask::a;

--- a/score/bitmanipulation/docs/architecture/index.rst
+++ b/score/bitmanipulation/docs/architecture/index.rst
@@ -53,7 +53,7 @@ Static Architecture
    :safety:  ASIL_B
    :status: valid
    :version: 1
-   :fulfils: comp_req__bitmanipulation__bit_operations[version==1],comp_req__bitmanipulation__byte_operations[version==1],comp_req__bitmanipulation__bitmask_operators[version==1],comp_req__bitmanipulation__bounds_safety[version==1],comp_req__bitmanipulation__header_only[version==1]
+   :fulfils: comp_req__bitmanipulation__bit_operations[version==1],comp_req__bitmanipulation__byte_operations[version==2],comp_req__bitmanipulation__byte_extraction[version==1],comp_req__bitmanipulation__bitmask_operators[version==1],comp_req__bitmanipulation__bounds_safety[version==1],comp_req__bitmanipulation__header_only[version==1]
    :belongs_to: comp__baselibs_bit_manipulation[version==1]
 
    .. needarch::
@@ -103,14 +103,6 @@ Interfaces
 
 .. logic_arc_int_op:: Test Bit
    :id: logic_arc_int_op__baselibs__test_bit
-   :security: NO
-   :safety:  ASIL_B
-   :status: valid
-   :version: 1
-   :included_by: logic_arc_int__baselibs__bit_manipulation[version==1]
-
-.. logic_arc_int_op:: Set (Half)-Byte
-   :id: logic_arc_int_op__baselibs__set_byte
    :security: NO
    :safety:  ASIL_B
    :status: valid

--- a/score/bitmanipulation/docs/index.rst
+++ b/score/bitmanipulation/docs/index.rst
@@ -63,6 +63,7 @@ The Bit Manipulation library should provide bit operation and byte extraction ca
 
 * :need:`comp_req__bitmanipulation__bit_operations`
 * :need:`comp_req__bitmanipulation__byte_operations`
+* :need:`comp_req__bitmanipulation__byte_extraction`
 * :need:`comp_req__bitmanipulation__bitmask_operators`
 * :need:`comp_req__bitmanipulation__bounds_safety`
 * :need:`comp_req__bitmanipulation__header_only`

--- a/score/bitmanipulation/docs/requirements/index.rst
+++ b/score/bitmanipulation/docs/requirements/index.rst
@@ -43,8 +43,20 @@ Functional Requirements
 
    The bit manipulation component shall provide an API for setting, clearing, toggling, and checking individual bits for any integral type up to 64 bits, returning boolean success status.
 
-.. comp_req:: Support for Byte and Half-Byte Operations
+.. comp_req:: Support for Byte and Half-Byte Types
    :id: comp_req__bitmanipulation__byte_operations
+   :reqtype: Functional
+   :security: YES
+   :safety: ASIL_B
+   :derived_from: feat_req__baselibs__bitmanipulation[version==2]
+   :status: valid
+   :version: 2
+   :satisfied_by: comp__baselibs_bit_manipulation[version==1]
+
+   The bit manipulation component shall provide byte and half-byte types, with a byte composable from and decomposable into two half-bytes.
+
+.. comp_req:: Support for Byte Extraction
+   :id: comp_req__bitmanipulation__byte_extraction
    :reqtype: Functional
    :security: YES
    :safety: ASIL_B
@@ -52,9 +64,8 @@ Functional Requirements
    :status: valid
    :version: 1
    :satisfied_by: comp__baselibs_bit_manipulation[version==1]
-   :tags: inspected
 
-   The bit manipulation component shall provide an API for extracting and setting bytes and half-bytes for any integral type up to 64 bits, returning boolean success status.
+   The bit manipulation component shall provide an API to extract the byte at a given position from any integral type up to 64 bits.
 
 .. comp_req:: Support for Bitmask Operators for Enum Classes
    :id: comp_req__bitmanipulation__bitmask_operators


### PR DESCRIPTION
Link all `bit_manipulation` and `bitmask_operators` unit tests to the `comp_req__bitmanipulation__*` requirements they verify, using `FullyVerifies`/`PartiallyVerifies`, `TestType`, `DerivationTechnique`, and `Description` metadata per the `test-to-requirement-linking` skill.

Also sharpens the skill's own guidance:
- Tightens the `equivalence-classes` vs `boundary-values` distinction with a concrete decision rule.
- Adds a `TestType` breakdown table (previously only `DerivationTechnique` had one).
- Notes that a passing `bazel test` does not confirm a linked requirement ID actually resolves; only `bazel run //:docs` validates that.