### PR TITLE
chore(devcontainer): use a Dockerfile for the SCORE devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Use Dockerfile to get dependabot version bumps after new image is released
+FROM ghcr.io/eclipse-score/devcontainer:v1.4.1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,6 @@
 {
     "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:v1.4.1"
+    "build": {
+      "dockerfile": "Dockerfile"
+    }
 }


### PR DESCRIPTION
## Policy

**`score-devcontainer-dockerfile-migration`**

Replace the image-based SCORE devcontainer configuration with a Dockerfile
so Dependabot can keep the development image up to date.


## Why this repository?

This repository matches this policy because one of `.devcontainer.json`, `.devcontainer/devcontainer.json` matches this policy's file-content condition.

## Changes

- `.devcontainer/Dockerfile`: add Dockerfile
  - Dependabot can update the SCORE development image in Dockerfiles.
- `.devcontainer/devcontainer.json`: configure the devcontainer to build the Dockerfile
  - Dependabot can update the SCORE development image in Dockerfiles.



---

This pull request is managed by SCORE Repository Policy Sync and may be updated by a later policy run.
Please report any issues to [#score-infrastructure](https://sdvworkinggroup.slack.com/archives/C0894QGRZDM).

> [!NOTE]
> This pull request is generated automatically. Review the proposed changes
> before merging.

<!-- repo-policy-sync-policy: score-devcontainer-dockerfile-migration -->
<!-- repo-policy-sync-head: 03cd5eeece616c0f7949772b38ad631872bd3917 -->
