### PR TITLE
Fix pre-commit config to match repo conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,30 +14,12 @@ repos:
   - repo: local
     hooks:
       - id: copyright-fix
-        name: //:copyright-fix
-        entry: bazel run //:copyright-fix
+        name: //:copyright.fix
+        entry: bazel run //:copyright.fix
         language: system
         pass_filenames: false
       - id: format-fix
         name: //:format.fix
         entry: bazel run //:format.fix
         language: system
-        files: (BUILD|BUILD\.bazel|WORKSPACE|\.bazelrc|[^/]+\.(py|bzl|bazel|yaml|yml|rs))$
         pass_filenames: false
-      - id: generate-compile-commands
-        name: bazel-compile-commands (for clang-tidy)
-        entry: bazel-compile-commands
-        language: system
-        files: \.(c|cpp|h|hpp)$
-        pass_filenames: false
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
-    hooks:
-      - id: clang-format
-        args: ["-i", "--style=file"]
-        files: \.(c|cpp|h|hpp)$
-      - id: clang-tidy
-        args: ["--config-file=.clang-tidy-minimal", "-p=$(pwd)", "--warnings-as-errors=*"]
-        # load_buffer_internal.hpp is a private header with no compile commands, so clang-tidy will fail on it.
-        # The header is still checked via load_buffer.cpp.
-        exclude: '(_test\.cpp|load_buffer_internal\.hpp)$'


### PR DESCRIPTION
Points `copyright-fix` at the correct target (`//:copyright.fix`, was the non-existent `//:copyright-fix`), and removes the redundant `clang-format`/`clang-tidy` hooks. `//:format.fix` already runs clang-format for C++ files (see `use_format_targets(languages = [..., "cpp"])` in `BUILD`), and clang-tidy is run separately (not via pre-commit)