### PR TITLE
libacl import options to address -fPIC and other similar issue

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,9 @@ build --credential_helper="*.qnx.com=%workspace%/.github/tools/qnx_credential_he
 build --features=minimal_warnings --features=-strict_warnings --features=warnings_as_errors
 build --incompatible_strict_action_env
 build --per_file_copt=external/.*google_benchmark.*@-Wno-error
+# acl is vendored third-party source (see third_party/acl/acl.BUILD); it does not
+# meet this repo's strict warning bar (e.g. -Wcast-qual), so demote its warnings.
+build --per_file_copt=external/.*acl-src.*@-Wno-error
 
 # Common flags for tests
 test:_bl_common --build_tests_only

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -160,18 +160,20 @@ llvm.toolchain(
 use_repo(llvm, "llvm_toolchain")
 
 deb = use_repo_rule("@download_utils//download/deb:defs.bzl", "download_deb")
+archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
 
-deb(
-    name = "acl-deb",
+# acl is vendored from upstream source instead of a prebuilt, arch-pinned Ubuntu .deb
+# (see third_party/acl/acl.BUILD and score/os/BUILD's `:acl` target) to avoid the
+# recurring -fPIC/arch breakage tracked by SWP-278650 (eclipse-score/baselibs#172, #496, #78).
+archive(
+    name = "acl-src",
     build = "//third_party/acl:acl.BUILD",
-    urls = ["https://archive.ubuntu.com/ubuntu/pool/main/a/acl/libacl1-dev_2.3.1-1_amd64.deb"],
-    visibility = ["//visibility:public"],
-)
-
-deb(
-    name = "acl-deb-aarch64",
-    build = "//third_party/acl:acl.BUILD",
-    urls = ["https://ports.ubuntu.com/ubuntu-ports/pool/main/a/acl/libacl1-dev_2.3.1-1_arm64.deb"],
+    integrity = "sha256-5mETFFbScIoBxhSg9ADhHX0b+utvPnS3W7mAty8BYaM=",
+    strip_prefix = "acl-2.4.0",
+    urls = [
+        "https://download.savannah.nongnu.org/releases/acl/acl-2.4.0.tar.xz",
+        "http://download-mirror.savannah.nongnu.org/releases/acl/acl-2.4.0.tar.xz",
+    ],
     visibility = ["//visibility:public"],
 )
 

--- a/NOTICE
+++ b/NOTICE
@@ -54,3 +54,16 @@ The license text can be found in licenses/llvm-libcxx.txt.
 //===----------------------------------------------------------------------===//
 
 [1] https://github.com/llvm/llvm-project/tree/main/libcxx
+
+## acl
+
+third_party/acl vendors the plain POSIX ACL portion of libacl's source (excluding
+acl_delete_def_file_at and perm_copy_fd/perm_copy_file) from acl 2.4.0 [2],
+compiled directly as a score_baselibs cc_library instead of installing a prebuilt,
+architecture-pinned Ubuntu .deb package (see SWP-278650 and
+https://github.com/eclipse-score/baselibs/issues/172, /issues/496, /issues/78).
+
+libacl is provided under the GNU Lesser General Public License v2.1 (or later).
+The license text can be found in licenses/acl-lgpl.txt.
+
+[2] https://download.savannah.nongnu.org/releases/acl/acl-2.4.0.tar.xz

--- a/licenses/acl-lgpl.txt
+++ b/licenses/acl-lgpl.txt
@@ -1,0 +1,511 @@
+Most components of the "acl" package are licensed under
+Version 2.1 of the GNU Lesser General Public License (see below).
+below.
+
+Some components (as annotated in the source) are licensed
+under Version 2 of the GNU General Public License (see COPYING).
+
+----------------------------------------------------------------------
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/score/os/test/BUILD
+++ b/score/os/test/BUILD
@@ -354,6 +354,7 @@ cc_test(
     srcs = [
         "acl_test.cpp",
     ],
+    dynamic_deps = ["@score_baselibs//third_party/acl:acl_shared"],
     features = COMPILER_WARNING_FEATURES + [
         "aborts_upon_exception",
     ],

--- a/score/os/utils/acl/BUILD
+++ b/score/os/utils/acl/BUILD
@@ -56,6 +56,7 @@ cc_library(
 cc_test(
     name = "unit_test",
     srcs = ["access_control_list_test.cpp"],
+    dynamic_deps = ["@score_baselibs//third_party/acl:acl_shared"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["unit"],
     visibility = [

--- a/third_party/acl/BUILD
+++ b/third_party/acl/BUILD
@@ -11,11 +11,57 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Bazel-native equivalent of upstream acl's `./configure --enable-nls`: gates
+# whether include/misc.h's `_()` macro (see @acl-src//:acl) routes through gettext().
+bool_flag(
+    name = "enable_nls",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "nls_enabled",
+    flag_values = {":enable_nls": "True"},
+    visibility = ["@acl-src//:__pkg__"],
+)
+
+# Hand-written stand-in for acl's autoconf-generated include/config.h, consumed by
+# @acl-src (see MODULE.bazel and acl.BUILD) which vendors libacl from source.
+cc_library(
+    name = "config_h",
+    hdrs = ["config.h"],
+    defines = select({
+        ":nls_enabled": ["ENABLE_NLS=1"],
+        "//conditions:default": [],
+    }),
+    includes = ["."],
+    visibility = ["@acl-src//:__pkg__"],
+)
+
+# Exposed as plain files (rather than only via the cc_library above) so
+# @acl-src//:config_drift_test (see acl.BUILD) can read config.h as test data and
+# run check_config_drift.py without needing a C++ toolchain.
+exports_files(
+    [
+        "config.h",
+        "check_config_drift.py",
+    ],
+    visibility = ["@acl-src//:__pkg__"],
+)
+
+# Static linking is not exposed to general consumers; score/os:acl is the only
+# target that needs the static compile-time interface, everyone else must use
+# :acl_shared (paired with dynamic_deps) instead.
 alias(
     name = "acl",
-    actual = select({
-        "@platforms//cpu:aarch64": "@acl-deb-aarch64//:acl",
-        "//conditions:default": "@acl-deb//:acl",
-    }),
+    actual = "@acl-src//:acl",
+    visibility = ["@score_baselibs//score/os:__pkg__"],
+)
+
+alias(
+    name = "acl_shared",
+    actual = "@acl-src//:acl_shared",
     visibility = ["//:__subpackages__"],
 )

--- a/third_party/acl/acl.BUILD
+++ b/third_party/acl/acl.BUILD
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -11,18 +11,92 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
+# BUILD file for the vendored acl-2.4.0 source (https://savannah.nongnu.org/projects/acl),
+# used as the `build` file for the `acl-src` download_archive repository declared in
+# MODULE.bazel. Only the plain POSIX ACL API is vendored (see srcs/hdrs below).
+#
+# acl_get_file(), acl_set_file(), acl_extended_file() and acl_extended_file_nofollow()
+# are thin AT_FDCWD wrappers around the fd-relative acl_get_file_at()/acl_set_file_at()/
+# acl_extended_file_at(), so those three "_at" files (and the libmisc getxattrat/
+# setxattrat compat shims they need, since this toolchain's glibc predates those
+# syscalls) are vendored too. acl_delete_def_file_at.c and perm_copy_fd.c/
+# perm_copy_file.c (which pulls in a separate libattr dependency via
+# <attr/error_context.h>) are intentionally excluded because score/os/acl_impl.cpp
+# never calls them.
 
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_python//python:defs.bzl", "py_test")
+load("@score_baselibs//third_party/acl:acl_sources.bzl", "ACL_HDRS", "ACL_SRCS")
+
+# include/acl.h and include/libacl.h declare their public API with a bare `EXPORT`
+# marker. Upstream's install rule (include/Makemodule.am's SUBST_INSTALL_HEADER)
+# rewrites `EXPORT` to `extern` via sed when installing these headers; since we vendor
+# the headers directly instead of installing them, replicate that substitution with a
+# transitive `defines` so any consumer compiling against these headers gets it too.
+
+# include/acl.h remapped to the angle-include path <sys/acl.h>, matching score/os/acl.h.
+cc_library(
+    name = "sys_acl_h",
+    hdrs = ["include/acl.h"],
+    defines = ["EXPORT=extern"],
+    include_prefix = "sys",
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+# include/libacl.h remapped to the angle-include path <acl/libacl.h>, matching score/os/acl.h.
+cc_library(
+    name = "acl_libacl_h",
+    hdrs = ["include/libacl.h"],
+    defines = ["EXPORT=extern"],
+    include_prefix = "acl",
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+# Static compile-time interface, kept private to the one wrapper that needs it
+# (score/os:acl); everyone else must go through :acl_shared instead.
 cc_library(
     name = "acl",
-    srcs = select({
-        "@platforms//cpu:aarch64": ["usr/lib/aarch64-linux-gnu/libacl.a"],
-        "@platforms//cpu:x86_64": ["usr/lib/x86_64-linux-gnu/libacl.a"],
-    }),
-    hdrs = [
-        "usr/include/acl/libacl.h",
-        "usr/include/sys/acl.h",
+    srcs = ACL_SRCS,
+    hdrs = ACL_HDRS,
+    includes = [
+        "include",
+        # Several vendored files quote-include with a redundant leading directory
+        # (e.g. "include/visibility-hidden.h", "libmisc/proc-self-fd.h"); adding the
+        # repo root lets those resolve as-is instead of needing per-file patches.
+        ".",
     ],
-    includes = ["usr/include/"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["@score_baselibs//third_party/acl:__pkg__"],
+    deps = [
+        ":acl_libacl_h",
+        ":sys_acl_h",
+        "@score_baselibs//third_party/acl:config_h",
+    ],
+)
+
+# libacl.so, for consumers that want to link against acl dynamically instead of
+# statically (e.g. so the vendored LGPL code can be replaced at runtime without
+# relinking, per LGPL-2.1 section 6).
+cc_shared_library(
+    name = "acl_shared",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+    deps = [":acl"],
+)
+
+# Fails if a vendored source/header references an autoconf-style feature macro
+# (HAVE_*, ENABLE_*, etc.) that config.h doesn't define or document as intentionally
+# unset, or if a vendored file's header claims the GPL rather than the LGPL, so both
+# kinds of drift are caught automatically on every acl version bump or file-list change.
+py_test(
+    name = "config_drift_test",
+    srcs = ["@score_baselibs//third_party/acl:check_config_drift.py"],
+    main = "@score_baselibs//third_party/acl:check_config_drift.py",
+    args = ["$(location @score_baselibs//third_party/acl:config.h)"] +
+           ["$(location %s)" % f for f in ACL_SRCS + ACL_HDRS],
+    data = ACL_SRCS + ACL_HDRS + ["@score_baselibs//third_party/acl:config.h"],
     visibility = ["//visibility:public"],
 )

--- a/third_party/acl/acl_sources.bzl
+++ b/third_party/acl/acl_sources.bzl
@@ -1,0 +1,102 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Single source of truth for which acl-2.4.0 files are vendored, shared between
+# acl.BUILD (the `:acl` cc_library) and BUILD's `:config_drift_test` (which checks
+# that config.h still covers every autoconf-style macro these files reference).
+
+ACL_SRCS = [
+    # POSIX_CFILES (Makemodule.am).
+    "libacl/acl_add_perm.c",
+    "libacl/acl_calc_mask.c",
+    "libacl/acl_clear_perms.c",
+    "libacl/acl_copy_entry.c",
+    "libacl/acl_copy_ext.c",
+    "libacl/acl_copy_int.c",
+    "libacl/acl_create_entry.c",
+    "libacl/acl_delete_def_file.c",
+    "libacl/acl_delete_entry.c",
+    "libacl/acl_delete_perm.c",
+    "libacl/acl_dup.c",
+    "libacl/acl_free.c",
+    "libacl/acl_from_text.c",
+    "libacl/acl_get_entry.c",
+    "libacl/acl_get_fd.c",
+    "libacl/acl_get_file.c",
+    "libacl/acl_get_file_at.c",
+    "libacl/acl_get_perm.c",
+    "libacl/acl_get_permset.c",
+    "libacl/acl_get_qualifier.c",
+    "libacl/acl_get_tag_type.c",
+    "libacl/acl_init.c",
+    "libacl/acl_set_fd.c",
+    "libacl/acl_set_file.c",
+    "libacl/acl_set_file_at.c",
+    "libacl/acl_set_permset.c",
+    "libacl/acl_set_qualifier.c",
+    "libacl/acl_set_tag_type.c",
+    "libacl/acl_size.c",
+    "libacl/acl_to_text.c",
+    "libacl/acl_valid.c",
+    # LIBACL_CFILES.
+    "libacl/acl_check.c",
+    "libacl/acl_cmp.c",
+    "libacl/acl_entries.c",
+    "libacl/acl_equiv_mode.c",
+    "libacl/acl_error.c",
+    "libacl/acl_extended_fd.c",
+    "libacl/acl_extended_file.c",
+    "libacl/acl_extended_file_at.c",
+    "libacl/acl_extended_file_nofollow.c",
+    "libacl/acl_from_mode.c",
+    "libacl/acl_to_any_text.c",
+    # INTERNAL_CFILES.
+    "libacl/__acl_apply_mask_to_mode.c",
+    "libacl/__acl_from_xattr.c",
+    "libacl/__acl_reorder_obj_p.c",
+    "libacl/__acl_to_any_text.c",
+    "libacl/__acl_to_xattr.c",
+    "libacl/__libobj.c",
+    # libmisc compat shims needed by the "_at" files above (this toolchain's glibc
+    # doesn't provide getxattrat()/setxattrat(), so config.h leaves HAVE_GETXATTRAT/
+    # HAVE_SETXATTRAT undefined and xattrat_compat.h maps them to these instead).
+    # xattrat.c provides the raw syscall-based getxattrat()/setxattrat() that the
+    # *_compat.c shims try first, falling back to proc-self-fd-based emulation
+    # (via ENOSYS) on kernels that predate the getxattrat/setxattrat syscalls.
+    "libmisc/xattrat.c",
+    "libmisc/getxattrat_compat.c",
+    "libmisc/setxattrat_compat.c",
+    "libmisc/proc-self-fd.c",
+    # Helpers used by acl_from_text.c/acl_to_any_text.c (quoting/unquoting of
+    # non-printable user and group names) and acl_get_qualifier.c (uid/gid lookup).
+    "libmisc/quote.c",
+    "libmisc/unquote.c",
+    "libmisc/uid_gid_lookup.c",
+    "libmisc/high_water_alloc.c",
+]
+
+ACL_HDRS = [
+    # HFILES (Makemodule.am): private headers shared between the .c files above.
+    "libacl/libobj.h",
+    "libacl/libacl.h",
+    "libacl/byteorder.h",
+    "libacl/__acl_from_xattr.h",
+    "libacl/__acl_to_xattr.h",
+    # Internal (noinst) headers pulled in by the .c files above.
+    "include/acl_ea.h",
+    "include/misc.h",
+    "include/visibility-hidden.h",
+    "include/xattrat.h",
+    "include/xattrat_compat.h",
+    "libmisc/proc-self-fd.h",
+]

--- a/third_party/acl/check_config_drift.py
+++ b/third_party/acl/check_config_drift.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Checks that config.h accounts for every autoconf-style macro the vendored acl
+sources reference.
+
+config.h (third_party/acl/config.h) is a hand-written stand-in for acl's
+autoconf-generated include/config.h.
+Each `#define`d macro, and each intentionally-left-undefined macro, is documented
+there with a comment explaining why.
+This script scans the vendored acl-2.4.0 sources for `#if`/`#ifdef`/`#ifndef`/`#elif`
+references to autoconf-style feature macros (HAVE_*, ENABLE_*, USE_*, PACKAGE_*, ...)
+and fails if any of them is not mentioned anywhere in config.h, so a future acl
+version bump or file-list change can't silently drop coverage for a macro the code
+actually depends on.
+
+This only catches macros referenced by sources but missing from config.h.
+It does not flag macros defined in config.h that are no longer referenced by any
+source (dead entries are low-risk and can be pruned manually during review).
+
+It also checks that no vendored file's header claims the (non-Lesser) GNU General
+Public License.
+Only the LGPL-2.1(-or-later) portion of acl is meant to be vendored here (see
+NOTICE); acl's GPL-2 portion is the getfacl/setfacl/chacl command-line tools, which
+BUILD's ACL_SRCS/ACL_HDRS never lists, but this guards against a future edit
+accidentally pulling in one of those files.
+"""
+
+import itertools
+import re
+import sys
+
+MACRO_PATTERN = re.compile(
+    r"\b("
+    r"HAVE_[A-Z0-9_]+"
+    r"|ENABLE_[A-Z0-9_]+"
+    r"|USE_[A-Z0-9_]+"
+    r"|PACKAGE_[A-Z0-9_]+"
+    r"|UNSAFE_[A-Z0-9_]+"
+    r"|WORDS_BIGENDIAN"
+    r"|STDC_HEADERS"
+    r"|VERSION"
+    r"|_FILE_OFFSET_BITS"
+    r"|_LARGE_FILES"
+    r"|_TIME_BITS"
+    r"|_GNU_SOURCE"
+    r")\b"
+)
+CONDITIONAL_LINE_PATTERN = re.compile(r"^\s*#\s*(if|ifdef|ifndef|elif)\b")
+GPL_PATTERN = re.compile(r"GNU General Public License")
+LGPL_PATTERN = re.compile(r"Lesser General Public License|LGPL")
+HEADER_LINES_TO_SCAN = 40
+
+
+def is_gpl_only(source_path):
+    with open(source_path, encoding="utf-8") as source_file:
+        header = "".join(itertools.islice(source_file, HEADER_LINES_TO_SCAN))
+    return bool(GPL_PATTERN.search(header)) and not LGPL_PATTERN.search(header)
+
+
+def macros_known_to_config_h(config_h_path):
+    with open(config_h_path, encoding="utf-8") as config_h:
+        text = config_h.read()
+    return set(MACRO_PATTERN.findall(text))
+
+
+def macros_referenced_by(source_path):
+    referenced = {}
+    with open(source_path, encoding="utf-8") as source_file:
+        for line_number, line in enumerate(source_file, start=1):
+            if not CONDITIONAL_LINE_PATTERN.match(line):
+                continue
+            for macro in MACRO_PATTERN.findall(line):
+                referenced.setdefault(macro, []).append(f"{source_path}:{line_number}")
+    return referenced
+
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: check_config_drift.py <config.h> <source>...", file=sys.stderr)
+        return 2
+
+    known_macros = macros_known_to_config_h(argv[0])
+
+    missing = {}
+    for source_path in argv[1:]:
+        for macro, locations in macros_referenced_by(source_path).items():
+            if macro not in known_macros:
+                missing.setdefault(macro, []).extend(locations)
+
+    gpl_only_files = [path for path in argv[1:] if is_gpl_only(path)]
+
+    ok = True
+
+    if missing:
+        ok = False
+        print(
+            "config.h does not mention the following macro(s) referenced by "
+            "vendored acl sources. Add a `#define` or a comment documenting why "
+            "it's intentionally left undefined:",
+            file=sys.stderr,
+        )
+        for macro in sorted(missing):
+            print(f"  {macro}", file=sys.stderr)
+            for location in missing[macro]:
+                print(f"    referenced at {location}", file=sys.stderr)
+
+    if gpl_only_files:
+        ok = False
+        print(
+            "The following vendored file(s) claim the GPL (not LGPL) and must not be "
+            "vendored here (see NOTICE, only acl's LGPL-2.1 portion is in scope):",
+            file=sys.stderr,
+        )
+        for path in gpl_only_files:
+            print(f"  {path}", file=sys.stderr)
+
+    if not ok:
+        return 1
+
+    print(
+        f"OK: config.h accounts for all macros referenced by {len(argv) - 1} vendored file(s), "
+        "and all of them are LGPL-licensed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/third_party/acl/config.h
+++ b/third_party/acl/config.h
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+/*
+ * Hand-written stand-in for acl's autoconf-generated include/config.h.
+ *
+ * Upstream acl (savannah.nongnu.org/projects/acl) is built with autotools, which
+ * probes the host for optional features via `./configure` and emits this file.
+ * We vendor libacl's source directly into a plain cc_library instead of running
+ * autotools, so this file hardcodes the feature set for our only supported
+ * target class: glibc-based 64-bit Linux (Ubuntu, RedHat AutoSD, Elektrobit
+ * Linux) on x86_64/aarch64. It only defines what the vendored translation units
+ * (see //third_party/acl:acl.BUILD) actually need.
+ */
+#ifndef SCORE_BASELIBS_THIRD_PARTY_ACL_CONFIG_H
+#define SCORE_BASELIBS_THIRD_PARTY_ACL_CONFIG_H
+
+/* Enable GNU/glibc extensions, as AC_USE_SYSTEM_EXTENSIONS would on a real configure run. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+/* Visibility attribute for API symbols: irrelevant for a statically linked cc_library. */
+#define EXPORT extern
+
+/* Standard C89/glibc headers: always present on the Linux flavors this repo targets. */
+#define STDC_HEADERS 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_STRINGS_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_UNISTD_H 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_WCHAR_H 1
+#define HAVE_DLFCN_H 1
+
+/* Package metadata (informational; not consumed by the vendored subset). */
+#define PACKAGE "acl"
+#define PACKAGE_NAME "acl"
+#define PACKAGE_VERSION "2.4.0"
+#define PACKAGE_STRING "acl 2.4.0"
+#define PACKAGE_TARNAME "acl"
+#define VERSION "2.4.0"
+
+/*
+ * ENABLE_NLS is deliberately not hardcoded here: it's controlled by the
+ * --@score_baselibs//third_party/acl:enable_nls Bazel flag instead (see BUILD's
+ * config_h target), so consumers get real bazel-style control over it rather
+ * than needing to fork this file.
+ *
+ * Intentionally left undefined (matches upstream's "not detected"/disabled state):
+ * - HAVE_GETTEXT / HAVE_DCGETTEXT / HAVE_ICONV: not referenced by the vendored
+ *   source subset; only ENABLE_NLS itself gates include/misc.h's `_()` macro.
+ * - HAVE_VISIBILITY_ATTRIBUTE: no -fvisibility=hidden; the same compiled objects
+ *   back both the static (:acl) and dynamically-linked (:acl_shared) variants.
+ * - HAVE_OPENAT2 / HAVE_LINUX_OPENAT2_H / USE_OPENAT2 / UNSAFE_RESTORE_WARNINGS,
+ *   HAVE_GETXATTRAT / HAVE_SETXATTRAT / HAVE_LISTXATTRAT / HAVE_REMOVEXATTRAT:
+ *   only used by the "_at" fd-relative source files, which are excluded from
+ *   the vendored source set because score/os/acl_impl.cpp never calls them.
+ * - WORDS_BIGENDIAN: all supported targets (x86_64, aarch64) are little-endian.
+ * - _FILE_OFFSET_BITS / _LARGE_FILES / _TIME_BITS: off_t/time_t are already
+ *   64-bit by default on the 64-bit-only targets this repo supports.
+ */
+
+#endif /* SCORE_BASELIBS_THIRD_PARTY_ACL_CONFIG_H */

--- a/third_party/acl/libacl_import_options.md
+++ b/third_party/acl/libacl_import_options.md
@@ -1,0 +1,68 @@
+# Native dependency vendoring: hermetic sysroot vs. build-from-source
+
+Context:`score_baselibs` repeatedly breaks when native third-party
+libraries (`acl`, `libcap`, `valgrind`) are consumed as prebuilt Ubuntu `.deb`
+archives — architecture mismatches, missing `-fPIC`, and no coverage for
+non-Ubuntu targets (RedHat AutoSD, Elektrobit Linux). Four candidate approaches
+were evaluated; this document compares the two "hermetic" ones in detail:
+**option 2** (hermetic sysroot/toolchain bundling) and **option 4** (build the
+dependency from source as a Bazel target). Option 4 has since been implemented
+and validated for `acl`, so this comparison is grounded in real implementation
+data, not just design discussion.
+
+## Full trade-off table (all four options, for reference)
+
+| Approach | Hermetic | Effort | Distro coverage | Fixes root cause |
+|---|---|---|---|---|
+| 1. System-installed | No | Low | Requires per-image setup | No |
+| 2. Hermetic sysroot | Yes | High (cross-repo) | Best, if built for it | Yes |
+| 3. Parameterized vendoring | Partial | Medium | Still manual per distro | Partially |
+| 4. Build from source | Yes | Medium-High | Best (arch/toolchain-driven) | Yes |
+
+## Option 2 — Hermetic sysroot/toolchain bundling
+
+Extend (or create) a hermetic multi-arch sysroot — similar to how
+`score_gcc_x86_64_toolchain`/`score_gcc_aarch64_toolchain` are already pulled in
+via `score_bazel_cpp_toolchains` in [MODULE.bazel](../../MODULE.bazel#L18-L33) —
+that ships `libacl`, `libcap`, `valgrind` headers/libs for each target arch as
+part of the toolchain package, instead of a separate ad-hoc `download_deb` per
+library.
+
+- **Pros:** Fully hermetic and reproducible; single point of version control
+  (the sysroot artifact); naturally extends the toolchain infrastructure
+  already in place for GCC/QCC.
+- **Cons:** Requires building/maintaining that sysroot artifact (likely
+  upstream in `score_bazel_cpp_toolchains` or a new repo) — work isn't only in
+  this repo; slower to iterate; still needs a strategy per distro if
+  AutoSD/Elektrobit need different library builds (e.g. musl vs glibc,
+  different ABI).
+
+## Option 4 — Build the dependency from source as a Bazel target
+
+Vendor the upstream *source* (e.g. `acl`/`libcap` release tarballs) and compile
+them with Bazel's own toolchain/`-fPIC` flags directly, instead of consuming
+prebuilt distro binaries at all.
+
+- **Pros:** Fully hermetic, arch-agnostic (any target the toolchain supports),
+  immune to distro packaging quirks (no more "was this `.deb` built with
+  `-fPIC`" issues); consistent story across Ubuntu/AutoSD/Elektrobit since none
+  of them are involved at build time.
+- **Cons:** Higher upfront effort (write BUILD files for each source tree,
+  handle their native build systems/autoconf quirks); becomes something this
+  repo now owns and must patch/update over time; still need libc/system
+  headers (e.g. `sys/capability.h`) to match target consistently.
+
+## Side-by-side, informed by the completed `acl` implementation
+
+| | **Option 2: Hermetic sysroot** | **Option 4: Build from source** |
+|---|---|---|
+| **Where the work lives** | Upstream infra repo (`score_bazel_cpp_toolchains` or a new toolchain-artifact repo) — outside `score_baselibs`' control | Entirely inside `score_baselibs` (`third_party/acl/*`, [MODULE.bazel](../../MODULE.bazel)) |
+| **Hermeticity** | Fully hermetic, but only once the sysroot artifact itself is built and versioned somewhere | Fully hermetic — verified directly: `integrity` SRI sha256 pin on the tarball, compiled by the exact `score_gcc_*_toolchain` already used for everything else |
+| **Arch coverage** | One artifact per arch, built once, reused everywhere — no compile step in this repo | Recompiled per target/arch by Bazel automatically; validated on both `bl-x86_64-linux` and `bl-aarch64-linux` (build + test, aarch64 via qemu) |
+| **Distro coverage (Ubuntu/AutoSD/Elektrobit)** | Best *if* the sysroot is built for it — but if AutoSD/Elektrobit need a different libc/ABI (e.g. musl vs glibc), multiple sysroot variants are needed, which is ongoing infra work | Source-vendoring sidesteps distro packaging entirely — same source, same toolchain, any Linux target; no distro branch needed |
+| **Fixes root cause?** | Yes, but the "no `-fPIC` / arch mismatch" bug class only disappears once the sysroot-building pipeline is disciplined about it — a new failure surface (sysroot build) replaces the old one (distro `.deb`) | Yes, directly — the toolchain that compiles `score_baselibs` itself also compiles the dependency, so PIC/ABI can never drift from the rest of the build |
+| **Effort (upfront)** | High, but concentrated: build/patch autoconf once when authoring the sysroot | Medium-high per library, and iterative — the `acl` implementation needed 4 build-fail/investigate/fix round-trips: (1) a combined patch file mis-parsed by Bazel's native patcher, (2) `-Wcast-qual`/`-Werror` failures from stricter warnings, (3) an `EXPORT` macro left undefined (normally stripped by upstream's own `make install`), (4) undefined symbols from transitively-required `_at`/`libmisc` files not obvious from a first read of `Makemodule.am` |
+| **Effort (ongoing)** | Low per-repo (consume the sysroot like today's toolchain deps), but real: someone has to rebuild/republish the sysroot on every `acl`/`libcap`/`valgrind` version bump | This repo now owns the vendoring: any upstream `acl` update means re-auditing the file list/`config.h`/patches again |
+| **Cross-repo blast radius** | High — changes to a shared toolchain artifact affect every consumer of `score_bazel_cpp_toolchains`, so it needs broader review/rollout | Zero — fully contained to `score_baselibs`, no coordination needed with other repos |
+| **Debuggability** | Sysroot is a black box from this repo's perspective; if a symbol/header is wrong, you're often blocked on another team/repo | Every failure surface (missing symbol, missing header, macro) is visible and fixable locally, as demonstrated end-to-end for `acl` |
+| **Best fit** | Scales better if *many* repos/targets need the same set of native libs (shared infra investment pays off) | Scales better for a small, `score_baselibs`-specific set of libraries (`acl`, `libcap`) where a shared sysroot would be overkill |

--- a/third_party/acl/libacl_import_options.md
+++ b/third_party/acl/libacl_import_options.md
@@ -3,21 +3,70 @@
 Context:`score_baselibs` repeatedly breaks when native third-party
 libraries (`acl`, `libcap`, `valgrind`) are consumed as prebuilt Ubuntu `.deb`
 archives — architecture mismatches, missing `-fPIC`, and no coverage for
-non-Ubuntu targets (RedHat AutoSD, Elektrobit Linux). Four candidate approaches
-were evaluated; this document compares the two "hermetic" ones in detail:
-**option 2** (hermetic sysroot/toolchain bundling) and **option 4** (build the
-dependency from source as a Bazel target). Option 4 has since been implemented
-and validated for `acl`, so this comparison is grounded in real implementation
-data, not just design discussion.
+non-Ubuntu targets (RedHat AutoSD, Elektrobit Linux). Six candidate approaches
+were evaluated in total; this document compares the two "hermetic" ones in
+detail: **option 2** (hermetic sysroot/toolchain bundling) and **option 4**
+(build the dependency from source as a Bazel target). Option 4 has since been
+implemented and validated for `acl`, so this comparison is grounded in real
+implementation data, not just design discussion. Options 5 and 6 were
+considered later, specifically to ask whether `acl`'s LGPL-2.1 license
+obligation could be avoided altogether; neither was adopted (see their
+sections below for why).
 
-## Full trade-off table (all four options, for reference)
+## All six options, in simple terms
 
-| Approach | Hermetic | Effort | Distro coverage | Fixes root cause |
-|---|---|---|---|---|
-| 1. System-installed | No | Low | Requires per-image setup | No |
-| 2. Hermetic sysroot | Yes | High (cross-repo) | Best, if built for it | Yes |
-| 3. Parameterized vendoring | Partial | Medium | Still manual per distro | Partially |
-| 4. Build from source | Yes | Medium-High | Best (arch/toolchain-driven) | Yes |
+1. **System-installed** — don't vendor or build `acl` at all; write our own
+   small header declaring the functions we need, and link against whatever
+   `libacl.so` already happens to be installed on the machine at runtime.
+2. **Hermetic sysroot** — bundle a prebuilt `acl` (and `libcap`, `valgrind`)
+   into the same kind of toolchain/sysroot package this repo already uses for
+   the GCC/QCC compilers, so it's version-controlled once, centrally.
+3. **Parameterized vendoring** — keep downloading a prebuilt `.deb` like
+   before, but make the URL/arch/checksum a parameter instead of hardcoding
+   two separate `deb()` rules, so adding a new arch/distro is a small
+   change instead of a copy-paste.
+4. **Build from source (implemented)** — download `acl`'s own source code and
+   compile it ourselves, with our own toolchain and our own `-fPIC` flags,
+   instead of trusting someone else's prebuilt binary.
+5. **Clean-room reimplementation** — stop depending on `acl`'s code entirely;
+   write our own implementation of the handful of ACL functions we actually
+   call, directly against the well-documented kernel ACL format.
+6. **Shell out to system CLI tools** — don't link against any ACL library at
+   all; run the system's `setfacl`/`getfacl`/`chacl` programs as separate
+   processes and read their text output.
+
+## Full trade-off table (all six options)
+
+| Approach | Hermetic | License obligation | Effort | Distro coverage | Fixes root cause |
+|---|---|---|---|---|---|
+| 1. System-installed | No | None — nothing of acl's is ever shipped | Low | Requires per-image setup | No |
+| 2. Hermetic sysroot | Yes | Applies — ships a compiled `acl` | High (cross-repo) | Best, if built for it | Yes |
+| 3. Parameterized vendoring | Partial | Applies — ships a compiled `acl` | Medium | Still manual per distro | Partially |
+| 4. Build from source (implemented) | Yes | Applies — ships a compiled `acl`, but made easy via `:acl_shared` (dynamic linking) | Medium-High | Best (arch/toolchain-driven) | Yes |
+| 5. Clean-room reimplementation | Yes | None — no acl code, ours is Apache-2.0 | Very high, and ongoing forever | Best (our own code, any target) | Yes |
+| 6. Shell out to CLI tools | No | None — separate process, nothing linked | Low-Medium | Requires per-image setup | No |
+
+Only options 2, 4, and 5 are both hermetic *and* fix the root cause; of those,
+only option 5 also removes the license obligation, at the cost of writing and
+maintaining an ACL implementation ourselves indefinitely. Options 1 and 6
+remove the obligation but bring back the "does this image already have a
+working ACL implementation" problem this whole effort started from — see
+their sections below.
+
+## Option 1 — System-installed
+
+Don't vendor or compile any `acl` code in this repo at all. Write a small,
+original header declaring the handful of `acl_*` functions
+`score/os/acl_impl.cpp` needs, and link against `-lacl` so the actual
+`libacl.so` comes from whatever is already on the target machine at runtime.
+
+- **Pros:** No `acl` code is ever distributed by `score_baselibs`, so there is
+  no LGPL obligation to discharge.
+- **Cons:** Only works if the target image already has a working, correctly
+  built `libacl.so` — not guaranteed for AutoSD/Elektrobit, and **not true at
+  all for QNX**, which has no such package. This is the same "requires
+  per-image setup" gap SWP-278650 was filed over, so it does not fix the root
+  cause.
 
 ## Option 2 — Hermetic sysroot/toolchain bundling
 
@@ -37,6 +86,21 @@ library.
   AutoSD/Elektrobit need different library builds (e.g. musl vs glibc,
   different ABI).
 
+## Option 3 — Parameterized vendoring
+
+Keep downloading a prebuilt `.deb`, as before, but parameterize the
+url/architecture/checksum instead of hand-writing a separate `deb()` rule per
+arch (as `acl-deb`/`acl-deb-aarch64` used to be). Adding a new arch or distro
+becomes a small config change instead of a copy-pasted rule.
+
+- **Pros:** Lower effort than options 2/4; keeps using distro-provided
+  binaries, so no need to compile `acl` ourselves.
+- **Cons:** Still consumes someone else's prebuilt binary, so the underlying
+  "was this built with `-fPIC`" risk from SWP-278650 isn't actually removed,
+  just made easier to patch when it recurs; still needs a distro-specific URL
+  for every target (no coverage for QNX, which has no `.deb` at all); still
+  ships a compiled `acl`, so the LGPL obligation is unchanged from today.
+
 ## Option 4 — Build the dependency from source as a Bazel target
 
 Vendor the upstream *source* (e.g. `acl`/`libcap` release tarballs) and compile
@@ -52,7 +116,53 @@ prebuilt distro binaries at all.
   repo now owns and must patch/update over time; still need libc/system
   headers (e.g. `sys/capability.h`) to match target consistently.
 
+## Option 5 — Clean-room reimplementation
+
+Stop depending on `acl`'s code at all. `score/os/acl_impl.cpp` only calls a
+small, fixed set of functions (`acl_get/set_fd`, `acl_get_file`,
+`acl_get/create_entry`, `acl_get/set_tag_type`, `acl_get/set_qualifier`,
+`acl_get/add_perm`, `acl_get_permset`, `acl_clear_perms`, `acl_calc_mask`,
+`acl_valid`, `acl_to_text`, `acl_free`). These are thin wrappers around a
+well-documented, fixed kernel format: `getxattr`/`setxattr` on
+`system.posix_acl_access`/`_default` with a simple binary struct, plus
+POSIX.1e's plain-text ACL grammar for `acl_to_text`. Writing an independent
+implementation against that public format (without reading `acl`'s own
+source) avoids depending on `acl`'s code at all.
+
+- **Pros:** No `acl` code anywhere, so no LGPL obligation; our own code can be
+  Apache-2.0 like the rest of this repo; fully hermetic and fixes the root
+  cause the same way option 4 does (we compile it, with our own toolchain).
+- **Cons:** By far the highest effort of any option, and it doesn't end at
+  first implementation — we'd own correctness and maintenance of an ACL
+  library forever, including edge cases `acl` has presumably already found
+  and fixed over its ~20-year history. Real risk of subtle behavioral
+  divergence from the reference implementation. Not pursued for `acl` given
+  the scope of this repo's actual need (a handful of functions used by one
+  OSAL wrapper).
+
+## Option 6 — Shell out to system CLI tools
+
+Don't link against any ACL library at all. Run the system's
+`setfacl`/`getfacl`/`chacl` binaries as separate processes (`fork`/`exec`) and
+parse their text output instead of calling into `libacl` directly.
+
+- **Pros:** Invoking a separate, unmodified program via `exec` (rather than
+  linking it into our process) is generally understood to fall outside
+  GPL/LGPL's linking obligations, so this removes the license question
+  entirely; no compiling/linking of `acl` code means no PIC concerns either.
+- **Cons:** Same "does the image already have this" gap as option 1 — these
+  CLI tools don't exist on QNX and aren't guaranteed on minimal
+  AutoSD/Elektrobit images, so it doesn't fix the root cause. Also a poor fit
+  for a low-level OSAL primitive: process-spawn-per-ACL-call overhead and
+  fragile text parsing are hard to justify here, independent of the licensing
+  question. Ruled out on engineering grounds alone.
+
 ## Side-by-side, informed by the completed `acl` implementation
+
+The comparison below predates options 5 and 6 and stays focused on the two
+options that are actually hermetic *and* fix the root cause without requiring
+us to reimplement `acl` ourselves (option 5 wasn't pursued, and option 6 isn't
+hermetic at all — see above).
 
 | | **Option 2: Hermetic sysroot** | **Option 4: Build from source** |
 |---|---|---|


### PR DESCRIPTION
This is Just draft PR to compare and finalized the approach to import libacl in baselib repo

### Replace prebuilt acl `.deb` with a hermetic, source-built `libacl`

**Problem:** `score_baselibs` consumed `acl` as an architecture-pinned Ubuntu `.deb` (`libacl1-dev`). This repeatedly broke on non-Ubuntu targets and on `aarch64` (missing `-fPIC`, arch/toolchain mismatches) — tracked as SWP-278650 (#172, #496, #78).

**Fix:** Vendor upstream `acl-2.4.0` source and compile it with this repo's own toolchain instead, so PIC/ABI can never drift from the rest of the build, on any target this repo supports (Ubuntu/AutoSD/Elektrobit, x86_64/aarch64) — no per-distro `.deb` needed.

### What's included

- **`MODULE.bazel`**: replaced the two `deb()` rules (`acl-deb`, `acl-deb-aarch64`) with a single `archive()` rule (`acl-src`) pulling the sha256-pinned `acl-2.4.0` tarball.
- **`acl.BUILD`** / **`acl_sources.bzl`**: `cc_library(:acl)` compiling only the plain POSIX ACL subset actually needed by `acl_impl.cpp` (excludes the GPL-2 CLI tools and the unused `_at`/`perm_copy_*` files).
- **`config.h`**: hand-written stand-in for acl's autoconf-generated `config.h`, scoped to this repo's one supported target class (glibc, 64-bit, little-endian Linux).
  - `ENABLE_NLS` is the one genuine configure-time option (gates `gettext()` in `include/misc.h`), so it's exposed as a real Bazel flag (`bool_flag` + `config_setting`, `--@score_baselibs//third_party/acl:enable_nls`) instead of being hardcoded.
- **`check_config_drift.py`** (`config_drift_test`): fails the build if (a) a vendored source references an autoconf-style macro (`HAVE_*`, `ENABLE_*`, ...) not accounted for in `config.h`, or (b) a vendored file's header claims the GPL rather than the LGPL — both catch drift automatically on future `acl` version bumps.
- **`cc_shared_library(:acl_shared)`**: builds `libacl` as a real shared object, giving consumers a straightforward LGPL-2.1 §6(b) compliance path (swap the `.so` without relinking). Static linking (`:acl`) is now visibility-restricted to the one wrapper that needs it at compile time (`score/os:acl`); every other consumer must go through `:acl_shared` + `dynamic_deps`. `score/os/test:acl_test` and `score/os/utils/acl:unit_test` were switched to dynamic linking as the first (and currently only) consumers.
- **`NOTICE`** / **`acl-lgpl.txt`**: added LGPL-2.1 attribution and license text for the vendored code.
- **`.bazelrc`**: demoted `-Werror` for `external/.*acl-src.*`, since the vendored upstream source doesn't meet this repo's strict warning bar (e.g. `-Wcast-qual`).
- **`libacl_import_options.md`**: design doc comparing this approach (build-from-source) against a hermetic sysroot alternative, grounded in the actual implementation.

### Validation
Built and tested on both `bl-x86_64-linux` and `bl-aarch64-linux` (aarch64 via qemu); verified via `ldd`/runfiles inspection that the dynamic-linked test targets pull in `libacl_shared.so` at runtime with no static duplication; confirmed the visibility restriction blocks unauthorized static consumers and `config_drift_test`/GPL-check both pass.