### PR TITLE
concurrency: characterize InterruptibleState SetValue and SetError

### DIFF
--- a/score/concurrency/future/interruptible_state_test.cpp
+++ b/score/concurrency/future/interruptible_state_test.cpp
@@ -10,8 +10,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+#include "score/concurrency/future/interruptible_state.h"
+
 #include "score/concurrency/future/interruptible_future.h"
 #include "score/concurrency/future/interruptible_promise.h"
+#include "score/concurrency/future/test_types.h"
 
 #include "score/stop_token.hpp"
 
@@ -19,6 +22,9 @@
 #include "gtest/gtest.h"
 
 #include <future>
+#include <memory>
+#include <type_traits>
+#include <utility>
 
 namespace score
 {
@@ -60,6 +66,228 @@ TEST(InterruptibleStateTest, Destruction)
         shared_heap_base_state = std::make_shared<InterruptibleState<void>>();
     }
     shared_heap_base_state.reset();
+}
+
+/*
+ * The remainder of this file characterizes InterruptibleState<>::SetValue() and SetError(): which value types they
+ * accept, and what the state holds afterwards. These tests describe the behaviour that exists today rather than a
+ * behaviour being introduced, so that a change to the way the result is placed into value_ can be shown to preserve
+ * the current API instead of narrowing it.
+ */
+
+// The value is stored as a score::Result<Value>, which inherits the special member functions of Value. A Value that
+// can be constructed but not assigned therefore yields a Result that can be constructed but not assigned, which is
+// why the setters construct a fresh object over value_ rather than assigning one. An implementation that assigned
+// instead would stop compiling for the value type asserted on below.
+static_assert(std::is_copy_constructible<testing::NonAssignableType>::value,
+              "precondition: the non-assignable test type is still copy constructible");
+static_assert(std::is_move_constructible<testing::NonAssignableType>::value,
+              "precondition: the non-assignable test type is still move constructible");
+static_assert(!std::is_copy_assignable<testing::NonAssignableType>::value,
+              "precondition: the non-assignable test type must not be copy assignable");
+static_assert(!std::is_move_assignable<testing::NonAssignableType>::value,
+              "precondition: the non-assignable test type must not be move assignable");
+
+static_assert(std::is_copy_constructible<score::Result<testing::NonAssignableType>>::value,
+              "the stored result must remain copy constructible for a non-assignable value type");
+static_assert(std::is_move_constructible<score::Result<testing::NonAssignableType>>::value,
+              "the stored result must remain move constructible for a non-assignable value type");
+static_assert(!std::is_copy_assignable<score::Result<testing::NonAssignableType>>::value,
+              "assigning the stored result is not available for a non-assignable value type");
+static_assert(!std::is_move_assignable<score::Result<testing::NonAssignableType>>::value,
+              "assigning the stored result is not available for a non-assignable value type");
+
+// The other edge of the accepted set. Constructing the stored result places no exception requirement on the value
+// type, whereas score::Result<T>::emplace() is constrained on std::is_nothrow_constructible. A value type whose move
+// constructor may throw is therefore accepted by the setters today, and would stop being accepted by an
+// implementation that emplaced into value_ rather than constructing over it.
+static_assert(std::is_move_constructible<testing::ThrowingMoveOnlyType>::value,
+              "precondition: the throwing-move test type is still move constructible");
+static_assert(!std::is_nothrow_move_constructible<testing::ThrowingMoveOnlyType>::value,
+              "precondition: the throwing-move test type must not be nothrow move constructible");
+static_assert(
+    std::is_constructible<score::Result<testing::ThrowingMoveOnlyType>, testing::ThrowingMoveOnlyType&&>::value,
+    "the stored result must remain constructible from a value whose move constructor may throw");
+
+template <typename T>
+class InterruptibleStateSetterTestBase : public ::testing::Test
+{
+  protected:
+    void ExpectHoldsError(const Error expected_error)
+    {
+        auto& result = state_->GetValue();
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(result.error(), expected_error);
+    }
+
+    std::shared_ptr<InterruptibleState<T>> state_{InterruptibleState<T>::Make()};
+};
+
+template <typename T>
+class InterruptibleStateSetterTest : public InterruptibleStateSetterTestBase<T>
+{
+  protected:
+    bool SetValueOnState()
+    {
+        return this->state_->SetValue(value_);
+    }
+
+    void ExpectHoldsExpectedValue()
+    {
+        auto& result = this->state_->GetValue();
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value().GetValue(), expected_value_);
+    }
+
+  private:
+    int expected_value_{1};
+    T value_{expected_value_};
+};
+
+template <typename T>
+class InterruptibleStateSetterTest<T&> : public InterruptibleStateSetterTestBase<T&>
+{
+  protected:
+    bool SetValueOnState()
+    {
+        return this->state_->SetValue(value_);
+    }
+
+    void ExpectHoldsExpectedValue()
+    {
+        auto& result = this->state_->GetValue();
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value().get().GetValue(), expected_value_);
+    }
+
+  private:
+    int expected_value_{1};
+    T value_{expected_value_};
+};
+
+// MoveOnlyType and ThrowingMoveOnlyType both have a deleted copy constructor, so the const-reference overload of
+// SetValue() is disabled for them and the value has to be handed over as an rvalue.
+template <typename T>
+class MoveOnlyInterruptibleStateSetterTest : public InterruptibleStateSetterTestBase<T>
+{
+  protected:
+    bool SetValueOnState()
+    {
+        return this->state_->SetValue(std::move(value_));
+    }
+
+    void ExpectHoldsExpectedValue()
+    {
+        auto& result = this->state_->GetValue();
+        ASSERT_TRUE(result.has_value());
+        EXPECT_EQ(result.value().GetValue(), expected_value_);
+    }
+
+  private:
+    int expected_value_{1};
+    T value_{expected_value_};
+};
+
+template <>
+class InterruptibleStateSetterTest<testing::MoveOnlyType>
+    : public MoveOnlyInterruptibleStateSetterTest<testing::MoveOnlyType>
+{
+};
+
+template <>
+class InterruptibleStateSetterTest<testing::ThrowingMoveOnlyType>
+    : public MoveOnlyInterruptibleStateSetterTest<testing::ThrowingMoveOnlyType>
+{
+};
+
+template <>
+class InterruptibleStateSetterTest<void> : public InterruptibleStateSetterTestBase<void>
+{
+  protected:
+    bool SetValueOnState()
+    {
+        return this->state_->SetValue();
+    }
+
+    void ExpectHoldsExpectedValue()
+    {
+        EXPECT_TRUE(this->state_->GetValue().has_value());
+    }
+};
+
+using SetterTypesUnderTest = ::testing::Types<testing::CopyAndMovableType,
+                                              testing::CopyAndMovableType&,
+                                              testing::CopyOnlyType,
+                                              testing::CopyOnlyType&,
+                                              testing::MoveOnlyType,
+                                              testing::MoveOnlyType&,
+                                              testing::NonAssignableType,
+                                              testing::NonAssignableType&,
+                                              testing::ThrowingMoveOnlyType,
+                                              void>;
+TYPED_TEST_SUITE(InterruptibleStateSetterTest, SetterTypesUnderTest, /*unused*/);
+
+TYPED_TEST(InterruptibleStateSetterTest, SetValueStoresTheValueAndReturnsTrue)
+{
+    EXPECT_TRUE(this->SetValueOnState());
+    this->ExpectHoldsExpectedValue();
+}
+
+TYPED_TEST(InterruptibleStateSetterTest, SetValueASecondTimeReturnsFalseAndKeepsTheFirstValue)
+{
+    ASSERT_TRUE(this->SetValueOnState());
+
+    EXPECT_FALSE(this->SetValueOnState());
+    this->ExpectHoldsExpectedValue();
+}
+
+TYPED_TEST(InterruptibleStateSetterTest, SetErrorStoresTheErrorAndReturnsTrue)
+{
+    EXPECT_TRUE(this->state_->SetError(Error::kPromiseBroken));
+    this->ExpectHoldsError(Error::kPromiseBroken);
+}
+
+TYPED_TEST(InterruptibleStateSetterTest, SetErrorASecondTimeReturnsFalseAndKeepsTheFirstError)
+{
+    ASSERT_TRUE(this->state_->SetError(Error::kPromiseBroken));
+
+    EXPECT_FALSE(this->state_->SetError(Error::kStopRequested));
+    this->ExpectHoldsError(Error::kPromiseBroken);
+}
+
+TYPED_TEST(InterruptibleStateSetterTest, SetErrorAfterSetValueReturnsFalseAndKeepsTheValue)
+{
+    ASSERT_TRUE(this->SetValueOnState());
+
+    EXPECT_FALSE(this->state_->SetError(Error::kPromiseBroken));
+    this->ExpectHoldsExpectedValue();
+}
+
+TYPED_TEST(InterruptibleStateSetterTest, SetValueAfterSetErrorReturnsFalseAndKeepsTheError)
+{
+    ASSERT_TRUE(this->state_->SetError(Error::kPromiseBroken));
+
+    EXPECT_FALSE(this->SetValueOnState());
+    this->ExpectHoldsError(Error::kPromiseBroken);
+}
+
+// The two states below start out differently, and both shapes are relied upon elsewhere: a valued state reports the
+// kUnset error until a setter runs, whereas InterruptibleState<void> default-constructs a score::Result<void> that
+// already holds a value, so readiness rather than the stored result is what marks it as unset.
+TEST(InterruptibleStateInitialResultTest, ValuedStateStartsWithTheUnsetError)
+{
+    const auto state = InterruptibleState<testing::CopyAndMovableType>::Make();
+
+    auto& result = state->GetValue();
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), Error::kUnset);
+}
+
+TEST(InterruptibleStateInitialResultTest, VoidStateStartsWithAValue)
+{
+    const auto state = InterruptibleState<void>::Make();
+
+    EXPECT_TRUE(state->GetValue().has_value());
 }
 
 }  // namespace

--- a/score/concurrency/future/interruptible_state_test.cpp
+++ b/score/concurrency/future/interruptible_state_test.cpp
@@ -109,6 +109,12 @@ static_assert(
     std::is_constructible<score::Result<testing::ThrowingMoveOnlyType>, testing::ThrowingMoveOnlyType&&>::value,
     "the stored result must remain constructible from a value whose move constructor may throw");
 
+// The two values the setter tests hand to SetValue(). They differ so that a rejected second call can
+// be shown to have left the first value in place, rather than to have overwritten it with an equal
+// one.
+constexpr int kFirstValue{1};
+constexpr int kOtherValue{2};
+
 template <typename T>
 class InterruptibleStateSetterTestBase : public ::testing::Test
 {
@@ -129,19 +135,24 @@ class InterruptibleStateSetterTest : public InterruptibleStateSetterTestBase<T>
   protected:
     bool SetValueOnState()
     {
-        return this->state_->SetValue(value_);
+        return this->state_->SetValue(first_value_);
     }
 
-    void ExpectHoldsExpectedValue()
+    bool SetOtherValueOnState()
+    {
+        return this->state_->SetValue(other_value_);
+    }
+
+    void ExpectHoldsFirstValue()
     {
         auto& result = this->state_->GetValue();
         ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().GetValue(), expected_value_);
+        EXPECT_EQ(result.value().GetValue(), kFirstValue);
     }
 
   private:
-    int expected_value_{1};
-    T value_{expected_value_};
+    T first_value_{kFirstValue};
+    T other_value_{kOtherValue};
 };
 
 template <typename T>
@@ -150,19 +161,24 @@ class InterruptibleStateSetterTest<T&> : public InterruptibleStateSetterTestBase
   protected:
     bool SetValueOnState()
     {
-        return this->state_->SetValue(value_);
+        return this->state_->SetValue(first_value_);
     }
 
-    void ExpectHoldsExpectedValue()
+    bool SetOtherValueOnState()
+    {
+        return this->state_->SetValue(other_value_);
+    }
+
+    void ExpectHoldsFirstValue()
     {
         auto& result = this->state_->GetValue();
         ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().get().GetValue(), expected_value_);
+        EXPECT_EQ(result.value().get().GetValue(), kFirstValue);
     }
 
   private:
-    int expected_value_{1};
-    T value_{expected_value_};
+    T first_value_{kFirstValue};
+    T other_value_{kOtherValue};
 };
 
 // MoveOnlyType and ThrowingMoveOnlyType both have a deleted copy constructor, so the const-reference overload of
@@ -173,19 +189,24 @@ class MoveOnlyInterruptibleStateSetterTest : public InterruptibleStateSetterTest
   protected:
     bool SetValueOnState()
     {
-        return this->state_->SetValue(std::move(value_));
+        return this->state_->SetValue(std::move(first_value_));
     }
 
-    void ExpectHoldsExpectedValue()
+    bool SetOtherValueOnState()
+    {
+        return this->state_->SetValue(std::move(other_value_));
+    }
+
+    void ExpectHoldsFirstValue()
     {
         auto& result = this->state_->GetValue();
         ASSERT_TRUE(result.has_value());
-        EXPECT_EQ(result.value().GetValue(), expected_value_);
+        EXPECT_EQ(result.value().GetValue(), kFirstValue);
     }
 
   private:
-    int expected_value_{1};
-    T value_{expected_value_};
+    T first_value_{kFirstValue};
+    T other_value_{kOtherValue};
 };
 
 template <>
@@ -209,7 +230,14 @@ class InterruptibleStateSetterTest<void> : public InterruptibleStateSetterTestBa
         return this->state_->SetValue();
     }
 
-    void ExpectHoldsExpectedValue()
+    // SetValue() carries no value for a void state, so there is no second value to tell apart here;
+    // what the second call has to show is only that it is rejected.
+    bool SetOtherValueOnState()
+    {
+        return this->state_->SetValue();
+    }
+
+    void ExpectHoldsFirstValue()
     {
         EXPECT_TRUE(this->state_->GetValue().has_value());
     }
@@ -230,15 +258,15 @@ TYPED_TEST_SUITE(InterruptibleStateSetterTest, SetterTypesUnderTest, /*unused*/)
 TYPED_TEST(InterruptibleStateSetterTest, SetValueStoresTheValueAndReturnsTrue)
 {
     EXPECT_TRUE(this->SetValueOnState());
-    this->ExpectHoldsExpectedValue();
+    this->ExpectHoldsFirstValue();
 }
 
 TYPED_TEST(InterruptibleStateSetterTest, SetValueASecondTimeReturnsFalseAndKeepsTheFirstValue)
 {
     ASSERT_TRUE(this->SetValueOnState());
 
-    EXPECT_FALSE(this->SetValueOnState());
-    this->ExpectHoldsExpectedValue();
+    EXPECT_FALSE(this->SetOtherValueOnState());
+    this->ExpectHoldsFirstValue();
 }
 
 TYPED_TEST(InterruptibleStateSetterTest, SetErrorStoresTheErrorAndReturnsTrue)
@@ -260,7 +288,7 @@ TYPED_TEST(InterruptibleStateSetterTest, SetErrorAfterSetValueReturnsFalseAndKee
     ASSERT_TRUE(this->SetValueOnState());
 
     EXPECT_FALSE(this->state_->SetError(Error::kPromiseBroken));
-    this->ExpectHoldsExpectedValue();
+    this->ExpectHoldsFirstValue();
 }
 
 TYPED_TEST(InterruptibleStateSetterTest, SetValueAfterSetErrorReturnsFalseAndKeepsTheError)

--- a/score/concurrency/future/test_types.h
+++ b/score/concurrency/future/test_types.h
@@ -55,7 +55,7 @@ class MoveOnlyType : public CopyAndMovableType
     ~MoveOnlyType() noexcept = default;
 };
 
-/// \brief Constructible by copy and by move, but assignable by neither.
+/// @brief Constructible by copy and by move, but assignable by neither.
 ///
 /// This is the shape that forces InterruptibleState to construct its result in place rather than
 /// assign it: score::Result<NonAssignableType> inherits the missing assignment operators, so the
@@ -72,7 +72,7 @@ class NonAssignableType : public CopyAndMovableType
     ~NonAssignableType() noexcept = default;
 };
 
-/// \brief Move constructible only, and its move constructor may throw.
+/// @brief Move constructible only, and its move constructor may throw.
 ///
 /// score::Result<T>::emplace() is constrained on std::is_nothrow_constructible, whereas constructing
 /// the Result accepts any constructible T. This type therefore sits exactly on the boundary: the

--- a/score/concurrency/future/test_types.h
+++ b/score/concurrency/future/test_types.h
@@ -55,6 +55,42 @@ class MoveOnlyType : public CopyAndMovableType
     ~MoveOnlyType() noexcept = default;
 };
 
+/// \brief Constructible by copy and by move, but assignable by neither.
+///
+/// This is the shape that forces InterruptibleState to construct its result in place rather than
+/// assign it: score::Result<NonAssignableType> inherits the missing assignment operators, so the
+/// natural `value_ = ...` does not compile for it.
+class NonAssignableType : public CopyAndMovableType
+{
+  public:
+    using CopyAndMovableType::CopyAndMovableType;
+    NonAssignableType(const NonAssignableType&) noexcept = default;
+    NonAssignableType& operator=(const NonAssignableType&) noexcept = delete;
+    NonAssignableType(NonAssignableType&&) noexcept = default;
+    NonAssignableType& operator=(NonAssignableType&&) noexcept = delete;
+
+    ~NonAssignableType() noexcept = default;
+};
+
+/// \brief Move constructible only, and its move constructor may throw.
+///
+/// score::Result<T>::emplace() is constrained on std::is_nothrow_constructible, whereas constructing
+/// the Result accepts any constructible T. This type therefore sits exactly on the boundary: the
+/// setters accept it today, and an implementation that emplaced instead of constructing would stop
+/// accepting it.
+class ThrowingMoveOnlyType : public CopyAndMovableType
+{
+  public:
+    using CopyAndMovableType::CopyAndMovableType;
+    ThrowingMoveOnlyType(const ThrowingMoveOnlyType&) = delete;
+    ThrowingMoveOnlyType& operator=(const ThrowingMoveOnlyType&) = delete;
+    // Deliberately not noexcept.
+    ThrowingMoveOnlyType(ThrowingMoveOnlyType&& other) : CopyAndMovableType(other) {}
+    ThrowingMoveOnlyType& operator=(ThrowingMoveOnlyType&&) = delete;
+
+    ~ThrowingMoveOnlyType() = default;
+};
+
 }  // namespace testing
 }  // namespace concurrency
 }  // namespace score


### PR DESCRIPTION
Requested by @sankurm in #301:

> Before we can proceed with the code changes in #444, tests for the functions in question like
> `SetValue` and `SetError` should be implemented which will give us the assurance that the changes
> are in line with the existing functionality and we are not narrowing the API or introducing a
> regression.

This is that baseline. It contains **no production change** — two files, additions only, 0 lines
removed, and the existing `Destruction` test is untouched.

### What it pins

A typed suite over the value categories this directory already exercises
(`CopyAndMovableType`, `CopyOnlyType`, `MoveOnlyType`, their reference forms, `void`), plus two new
types that mark the edges of what the setters accept:

| type | why it is there |
|---|---|
| `NonAssignableType` | Constructible by copy and by move, assignable by neither. The stored `score::Result` inherits that, which is *why* the setters construct over `value_` instead of assigning. |
| `ThrowingMoveOnlyType` | Move constructible, move constructor deliberately not `noexcept`. Constructing the `Result` accepts it; `score::Result<T>::emplace()` does not. |

Per type: the value is stored, a second `SetValue` returns `false` and keeps the first value, the
same for `SetError`, and both cross transitions. Two further tests record that a valued state starts
holding `Error::kUnset` while `InterruptibleState<void>` starts holding a value — a real divergence
between the specializations that is easy to break by accident.

### Evidence that these characterize rather than assert a preference

They pass on `main` **unmodified**, and they pass with #444 applied:

```
main as-is                     63 tests from 12 test suites ran.  [  PASSED  ] 63 tests.
main + the #444 fix applied    63 tests from 12 test suites ran.  [  PASSED  ] 63 tests.
```

I ran it both ways on purpose. If they only passed with the fix they would be regression tests for
my patch, which is not what was asked for.

### Why this is a separate PR

#444 cannot merge until this baseline exists, so putting the tests on that branch would have kept
them behind the very thing they are supposed to unblock. This one stands alone and can go in first.

The `static_assert` block also encodes the measurement I posted in
[#301](https://github.com/eclipse-score/baselibs/issues/301#issuecomment-5423367870): `emplace()` is
constrained on `std::is_nothrow_constructible`, so whichever direction the reimplementation takes, a
narrowing of the accepted type set will fail the build here instead of passing silently.

<sub>Disclosure: AI-assisted (Claude Code). Tests were compiled and run locally, both with and
without the #444 change, before this was opened.</sub>
