### PR TITLE
Fix deprecated implicit copy ctor

### DIFF
--- a/score/language/safecpp/scoped_function/details/invoker.h
+++ b/score/language/safecpp/scoped_function/details/invoker.h
@@ -21,15 +21,7 @@
 namespace score::safecpp::details
 {
 
-// Suppress "AUTOSAR C++14 A12-0-1" rule finding. This rule states: "If a class declares a copy or move operation, or a
-// destructor, either via "=default", "=delete", or via a user-provided declaration, then all others of these five
-// special member functions shall be declared as well.".
-// Suppress "AUTOSAR C++14 A12-8-6" rule finding. This rule states: "Copy and move constructors and copy assignment and
-// move assignment operators shall be declared protected or defined "=delete" in base class.".
-// Rationale: This class is a forward declaration and does not declare any of the special member functions.
 template <class FunctionType>
-// coverity[autosar_cpp14_a12_0_1_violation]
-// coverity[autosar_cpp14_a12_8_6_violation]
 class CallOperatorInterface;
 
 template <class ReturnTypeT, class... Args>
@@ -38,8 +30,16 @@ class CallOperatorInterface<ReturnTypeT(Args...)>
   public:
     using ReturnType = ReturnTypeT;
 
+    CallOperatorInterface() = default;
     virtual ~CallOperatorInterface() = default;
+
     virtual ReturnType operator()(Args... args) = 0;
+
+  protected:
+    CallOperatorInterface(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface(const CallOperatorInterface&) = default;
+    CallOperatorInterface& operator=(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface& operator=(const CallOperatorInterface&) = default;
 };
 
 template <class ReturnTypeT, class... Args>
@@ -47,8 +47,17 @@ class CallOperatorInterface<ReturnTypeT(Args...) const>
 {
   public:
     using ReturnType = ReturnTypeT;
+
+    CallOperatorInterface() = default;
     virtual ~CallOperatorInterface() = default;
+
     virtual ReturnType operator()(Args... args) const = 0;
+
+  protected:
+    CallOperatorInterface(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface(const CallOperatorInterface&) = default;
+    CallOperatorInterface& operator=(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface& operator=(const CallOperatorInterface&) = default;
 };
 
 template <class ReturnTypeT, class... Args>
@@ -56,8 +65,17 @@ class CallOperatorInterface<ReturnTypeT(Args...) noexcept>
 {
   public:
     using ReturnType = ReturnTypeT;
+
+    CallOperatorInterface() = default;
     virtual ~CallOperatorInterface() = default;
+
     virtual ReturnType operator()(Args... args) noexcept = 0;
+
+  protected:
+    CallOperatorInterface(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface(const CallOperatorInterface&) = default;
+    CallOperatorInterface& operator=(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface& operator=(const CallOperatorInterface&) = default;
 };
 
 template <class ReturnTypeT, class... Args>
@@ -65,13 +83,18 @@ class CallOperatorInterface<ReturnTypeT(Args...) const noexcept>
 {
   public:
     using ReturnType = ReturnTypeT;
-    virtual ~CallOperatorInterface() = default;
-    virtual ReturnType operator()(Args... args) const noexcept = 0;
-};
 
-// Suppress "AUTOSAR C++14 A12-8-6" rule finding. This rule states: "Copy and move constructors and copy assignment and
-// move assignment operators shall be declared protected or defined "=delete" in base class.".
-// Rationale: This class is a forward declaration and does not declare any of the special member functions.
+    CallOperatorInterface() = default;
+    virtual ~CallOperatorInterface() = default;
+
+    virtual ReturnType operator()(Args... args) const noexcept = 0;
+
+  protected:
+    CallOperatorInterface(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface(const CallOperatorInterface&) = default;
+    CallOperatorInterface& operator=(CallOperatorInterface&&) noexcept = default;
+    CallOperatorInterface& operator=(const CallOperatorInterface&) = default;
+};
 
 // Suppress "AUTOSAR C++14 M7-3-1" rule finding. This rule states:"The global namespace shall only contain main,
 // namespace declarations and extern "C" declarations.".
@@ -81,7 +104,6 @@ template <template <bool, class> class BaseInvoker,
           class Container,
           class FunctionType,
           class = std::enable_if_t<std::is_base_of_v<CallOperatorInterface<FunctionType>, Interface<FunctionType>>>>
-// coverity[autosar_cpp14_a12_8_6_violation: FALSE]
 // coverity[autosar_cpp14_m7_3_1_violation: FALSE]
 class Invoker;
 


### PR DESCRIPTION
Violation of the rule of five.

No impact on users, since the hole in the ctor/dtor logic was never exposed to users and not violated within the code.

Explicitly declares all constructors of the base type.