### PR TITLE
AGENTS.md: clarify copyright header scope and docs layout

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -88,10 +88,18 @@ comp-tracing:
 comp-utils:
   - changed-files:
       - any-glob-to-any-file: 'score/utils/**'
-# Documentation label: applied when a PR changes files under docs/.
+# Documentation label: applied when a PR changes repository or component documentation.
 documentation:
   - changed-files:
-      - any-glob-to-any-file: 'docs/**'
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'score/**/docs/**'
+# CI label: applied when a PR changes GitHub Actions or workflows.
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/actions/**'
+          - '.github/workflows/**'
 # Language labels: applied based on the type of code files changed.
 c++:
   - changed-files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,11 @@
 ```
 score/          # C++ AND Rust libraries side by side (concurrency, containers, containers_rust, filesystem,
                 # json, memory, network, os, result, allocator, pal, sync, thread, testing_macros, log_rust, etc.)
+                # Most components have a docs/ subfolder with requirements, architecture, detailed design, and safety analysis.
 src/            # Deprecated Bazel alias stubs. No real sources here.
 examples/       # Integration and usage examples (C++ and Rust)
 third_party/    # External dependency BUILD files (acl, openssl, libcap2, etc.)
-docs/           # Sphinx documentation sources
+docs/           # Feature-level and module-level Sphinx docs.
 .github/        # CI workflows, CODEOWNERS, tools
 ```
 
@@ -77,14 +78,15 @@ This runs all format checks (C++, Python, Rust, Starlark, YAML) as test targets.
 
 ### Copyright headers
 
-Copyright headers are enforced in this repository; CI will fail if they are missing or incorrect. If unsure how the header should look for a given file type, don't guess: run `copyright.fix` and let it generate the header for you.
+Copyright headers are enforced for specific file extensions (`bazel`, `BUILD`, `bzl`, `c`, `cpp`, `h`, `hpp`, `ini`, `py`, `rs`, `rst`, `sh`, `yaml`, `yml`); CI will fail if a covered file's header is missing or incorrect.
+If unsure how the header should look for a given file type, don't guess: run `copyright.fix` and let it generate the header for you.
 
 ```bash
 bazel run //:copyright.check    # Verify
 bazel run //:copyright.fix      # Auto-fix missing headers
 ```
 
-**Every new file must have a copyright header.** The year must be the year in which the file is being created. If the current year is unknown, use `<YEAR>` as a placeholder.
+**Every new file with a covered extension must have a copyright header.** The year must be the year in which the file is being created. If the current year is unknown, use `<YEAR>` as a placeholder.
 
 C++ files (`.h`, `.cpp`):
 ```cpp
@@ -178,7 +180,9 @@ cd examples/integration && bazel build //...
 
 ## Documentation
 
-Documentation lives in `docs/` and uses Sphinx with the sphinx-needs extension, integrated with Bazel. The project follows the S-CORE process defined at https://github.com/eclipse-score/process_description. The metamodels for Sphinx-needs directives and Bazel integration are maintained at https://github.com/eclipse-score/docs-as-code.
+Documentation uses Sphinx with the sphinx-needs extension, integrated with Bazel. The project follows the S-CORE process defined at https://github.com/eclipse-score/process_description. The metamodels for Sphinx-needs directives and Bazel integration are maintained at https://github.com/eclipse-score/docs-as-code.
+
+`score/<component>/docs/` holds most components' documentation (requirements, architecture, detailed design, safety analysis), colocated with the component's source. `docs/` at the repo root hosts feature-level docs (`docs/features/`), module-level docs (`docs/module/`), and the docs of components not yet migrated to `score/<component>/docs/` (`docs/baselibs/components/<component>/docs/`).
 
 ```bash
 bazel run //:docs    # Build docs, output at _build/index.html


### PR DESCRIPTION
Copyright headers are only enforced for a specific set of file extensions, not every new file. This clarifies the copyright section accordingly, and documents that component docs are split between `score/<component>/docs/` and `docs/baselibs/components/<component>/docs/` depending on migration status.