### PR TITLE
docs: lower quick-start heading level

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,6 @@ The Components documentation provides detailed documentation for each individual
 
 
 Quick Start - Building and Testing
-==================================
+----------------------------------
 
 For build instructions, usage examples, and configuration options, refer to the `README <https://github.com/eclipse-score/baselibs/blob/main/README.md>`_ in the `eclipse-score/baselibs <https://github.com/eclipse-score/baselibs>`_ repository.


### PR DESCRIPTION
## Why

The Quick Start section is currently rendered at the same top-level hierarchy as the main Baselibs documentation sections. Lowering it by one heading level makes it a subsection of the documentation overview and keeps the page structure consistent.

## What changed

Changed the `Quick Start - Building and Testing` section underline in `docs/index.rst` from `=` to `-`.
