### PR TITLE
Increase `http_connector_retry_max_timeout` to 30s in `.bazelrc` files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,7 @@ common --registry=https://bcr.bazel.build
 common --experimental_repository_downloader_retries=10
 common --experimental_scale_timeouts=2.0
 common --http_connector_attempts=10
-common --http_connector_retry_max_timeout=1s
+common --http_connector_retry_max_timeout=30s
 common --http_timeout_scaling=2.0
 
 # Unset ANDROID_HOME to prevent rules_android from searching for the Android SDK.

--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -17,7 +17,7 @@ common --registry=https://bcr.bazel.build
 common --experimental_repository_downloader_retries=10
 common --experimental_scale_timeouts=2.0
 common --http_connector_attempts=10
-common --http_connector_retry_max_timeout=1s
+common --http_connector_retry_max_timeout=30s
 common --http_timeout_scaling=2.0
 
 # Unset ANDROID_HOME to prevent rules_android from searching for the Android SDK.


### PR DESCRIPTION
It's supposed to address timeout issues we occasionally get when downloading QNX SDP from qnx.com

The Reference Integration has a positive experience with this value
https://github.com/eclipse-score/reference_integration/blob/0315030cb14c7f74f5286420a304d87c79234e8a/.bazelrc#L14
