### PR TITLE
workflows: fix clang-tidy sarif upload ref

### DIFF
--- a/.github/workflows/lint_sarif_upload.yml
+++ b/.github/workflows/lint_sarif_upload.yml
@@ -42,4 +42,4 @@ jobs:
           sarif_file: clang-tidy.sarif
           category: clang-tidy
           sha: ${{ github.event.workflow_run.head_sha }}
-          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head


### PR DESCRIPTION
Ref was refs/pull/<n>/merge but sha was the PR's head commit, not the merge commit, leading to github rejecting the upload. Use refs/pull/<n>/head instead, matching the sha we have.