### PR TITLE
containers: link all unit tests to comp_req requirements

### DIFF
--- a/score/containers/dynamic_array_test.cpp
+++ b/score/containers/dynamic_array_test.cpp
@@ -59,6 +59,13 @@ TYPED_TEST_SUITE(DynamicArrayTestFixture, AllocatorTypes, );
 
 TYPED_TEST(DynamicArrayTestFixture, CanConstructWithTrivialType)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that constructing a DynamicArray of a trivial type with a given size yields that size, "
+                         "with all elements value-initialized to zero.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType, TypeParam> unit{kNonEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
     EXPECT_EQ(unit.size(), 10);
@@ -71,12 +78,24 @@ TYPED_TEST(DynamicArrayTestFixture, CanConstructWithTrivialType)
 
 TYPED_TEST(DynamicArrayTestFixture, ConstructTrivialEmpty)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that constructing a DynamicArray with a size of zero yields size zero.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     DynamicArray<TrivialType, TypeParam> unit{kEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
     EXPECT_EQ(unit.size(), kEmptyArraySize);
 }
 TYPED_TEST(DynamicArrayTestFixture, ConstructNonTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that constructing a DynamicArray of a non-trivial type with a given size default-"
+                         "constructs every element.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonTrivialType>();
 
     DynamicArray<NonTrivialType, decltype(non_trivial_type_alloc)> unit{kNonEmptyArraySize, non_trivial_type_alloc};
@@ -91,6 +110,12 @@ TYPED_TEST(DynamicArrayTestFixture, ConstructNonTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, CopyConstructTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing a DynamicArray copies all of its trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType, TypeParam> source_unit{kNonEmptyArraySize,
                                                      GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
 
@@ -111,6 +136,12 @@ TYPED_TEST(DynamicArrayTestFixture, CopyConstructTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, CopyConstructNonTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing a DynamicArray copies all of its non-trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonTrivialType>();
     DynamicArray<NonTrivialType, decltype(non_trivial_type_alloc)> source_unit{kNonEmptyArraySize,
                                                                                non_trivial_type_alloc};
@@ -134,6 +165,13 @@ TYPED_TEST(DynamicArrayTestFixture, CopyConstructNonTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, ConstructNonTrivialWithDefaultValue)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that constructing a DynamicArray with an explicit default value copy-initializes every "
+                         "element from that value.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonTrivialType>();
     NonTrivialType default_value{99U, 2.0f};
 
@@ -150,6 +188,12 @@ TYPED_TEST(DynamicArrayTestFixture, ConstructNonTrivialWithDefaultValue)
 
 TYPED_TEST(DynamicArrayTestFixture, MoveConstructTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that move-constructing a DynamicArray transfers all of its trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType, TypeParam> unit{kNonEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
 
@@ -170,6 +214,14 @@ TYPED_TEST(DynamicArrayTestFixture, MoveConstructTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, MoveConstructNonTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description",
+        "Check that move-constructing a DynamicArray transfers all of its non-trivial elements without "
+        "destructing the source's elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonMoveableAndCopyableElementType>();
 
     // given a unit with non-trivial element type
@@ -198,6 +250,12 @@ TYPED_TEST(DynamicArrayTestFixture, MoveConstructNonTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, MoveAssignTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description", "Check that move-assigning a DynamicArray transfers all of its trivial elements to the target.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     const std::size_t array_size1{10U};
     const std::size_t array_size2{20U};
     DynamicArray<TrivialType, TypeParam> unit{array_size1,
@@ -223,6 +281,14 @@ TYPED_TEST(DynamicArrayTestFixture, MoveAssignTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, MoveAssignNonTrivial)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that move-assigning a DynamicArray transfers all of its non-trivial elements to the "
+                         "target without destructing them, and that both arrays' elements are destructed exactly once "
+                         "once both go out of scope.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonMoveableAndCopyableElementType>();
     const std::size_t array_size1{10U};
     const std::size_t array_size2{20U};
@@ -257,6 +323,12 @@ TYPED_TEST(DynamicArrayTestFixture, MoveAssignNonTrivial)
 
 TYPED_TEST(DynamicArrayTestFixture, SelfMoveAssign)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that self-move-assigning a DynamicArray leaves its size and element values unchanged.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "error-guessing");
+
     // given a DynamicArray of trivial type
     DynamicArray<TrivialType, TypeParam> unit{kNonEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
@@ -276,6 +348,11 @@ TYPED_TEST(DynamicArrayTestFixture, SelfMoveAssign)
 
 TYPED_TEST(DynamicArrayTestFixture, CanSetValueOfArrayElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that at() allows setting and reading back the value of each element.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType, TypeParam> unit{kNonEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
 
@@ -293,6 +370,13 @@ TYPED_TEST(DynamicArrayTestFixture, CanSetValueOfArrayElements)
 
 TYPED_TEST(DynamicArrayTestFixture, CanConstructWithNonMoveableOrCopyableElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that a DynamicArray can be constructed with a non-moveable, non-copyable element type, "
+                         "since elements are constructed in place.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonMoveableAndCopyableElementType>();
 
     DynamicArray<NonMoveableAndCopyableElementType, decltype(non_trivial_type_alloc)> unit{kNonEmptyArraySize,
@@ -303,6 +387,13 @@ TYPED_TEST(DynamicArrayTestFixture, CanConstructWithNonMoveableOrCopyableElement
 
 TYPED_TEST(DynamicArrayTestFixture, DestructorOfNonTrivialTypesCalled)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that destructing a DynamicArray calls the destructor of every non-trivial element "
+                         "exactly once.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonMoveableAndCopyableElementType>();
 
     {
@@ -315,6 +406,13 @@ TYPED_TEST(DynamicArrayTestFixture, DestructorOfNonTrivialTypesCalled)
 
 TYPED_TEST(DynamicArrayTestFixture, CanConstructWithTriviallyConstructableDestructibleElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that constructing a DynamicArray of a trivially-constructible/destructible type "
+                         "value-initializes every element.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     auto trivially_constructible_destructible_alloc =
         this->template getTypeSpecificAllocator<TriviallyConstructibleDestructibleType>();
 
@@ -331,6 +429,15 @@ TYPED_TEST(DynamicArrayTestFixture, CanConstructWithTriviallyConstructableDestru
 
 TYPED_TEST(DynamicArrayTestFixture, ConstructingDynamicArrayWithTrivialTypeWithTooManyElementsTerminates)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description",
+        "Check that constructing a DynamicArray with a size at the numeric limit of std::size_t fails, "
+        "either via a thrown exception (std::allocator) or a contract violation (fancy pointer "
+        "allocator), instead of succeeding.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr std::size_t array_size_exceeding_limit{std::numeric_limits<std::size_t>::max()};
 
     const auto initialise_dynamic_array = [this] {
@@ -356,6 +463,12 @@ TYPED_TEST(DynamicArrayTestFixture, ConstructingDynamicArrayWithTrivialTypeWithT
 
 TYPED_TEST(DynamicArrayTestFixture, AccessingConstRefArrayOutOfBoundsTerminates)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description", "Check that accessing a const-qualified element via at() out of bounds terminates the program.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     DynamicArray<TrivialType> unit(kNonEmptyArraySize);
 
     const auto access_const_ref_out_of_bounds = [&unit]() {
@@ -368,6 +481,13 @@ TYPED_TEST(DynamicArrayTestFixture, AccessingConstRefArrayOutOfBoundsTerminates)
 
 TYPED_TEST(DynamicArrayTestFixture, IteratingTrivialType)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that iterating a DynamicArray of a trivial type from begin() to end() visits every "
+                         "element in order and allows mutating them.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType, TypeParam> unit{kNonEmptyArraySize,
                                               GetAllocator<TrivialType, TypeParam>(this->memory_resource_)};
 
@@ -387,6 +507,13 @@ TYPED_TEST(DynamicArrayTestFixture, IteratingTrivialType)
 
 TYPED_TEST(DynamicArrayTestFixture, IteratingNonTrivialType)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that iterating a DynamicArray of a non-trivial type from begin() to end() visits every "
+                         "element in order and allows mutating them.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonTrivialType>();
 
     DynamicArray<NonTrivialType, decltype(non_trivial_type_alloc)> unit{kNonEmptyArraySize, non_trivial_type_alloc};
@@ -409,6 +536,13 @@ TYPED_TEST(DynamicArrayTestFixture, IteratingNonTrivialType)
 
 TYPED_TEST(DynamicArrayTestFixture, ConstIteratingNonTrivialType)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description",
+        "Check that iterating a const DynamicArray from begin() to end() visits every element in order.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonTrivialType>();
 
     const DynamicArray<NonTrivialType, decltype(non_trivial_type_alloc)> unit{kNonEmptyArraySize,
@@ -423,6 +557,12 @@ TYPED_TEST(DynamicArrayTestFixture, ConstIteratingNonTrivialType)
 
 TYPED_TEST(DynamicArrayTestFixture, ConstIteratingNonTrivialTypeVariation)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that iterating a DynamicArray via cbegin()/cend() visits every element in order.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     auto non_trivial_type_alloc = this->template getTypeSpecificAllocator<NonTrivialType>();
 
     DynamicArray<NonTrivialType, decltype(non_trivial_type_alloc)> unit{kNonEmptyArraySize, non_trivial_type_alloc};
@@ -439,6 +579,12 @@ TYPED_TEST(DynamicArrayTestFixture, ConstIteratingNonTrivialTypeVariation)
 
 TYPED_TEST(DynamicArrayTestFixture, BracketOperatorAllowsSettingDataAtIndex)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that operator[] allows setting the value of an element at a given index.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType> unit{kNonEmptyArraySize};
     for (TrivialType i = 0; i < unit.size(); ++i)
     {
@@ -453,6 +599,12 @@ TYPED_TEST(DynamicArrayTestFixture, BracketOperatorAllowsSettingDataAtIndex)
 
 TYPED_TEST(DynamicArrayTestFixture, BracketOperatorAllowsGettingDataAtIndex)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that operator[] allows getting the value of an element at a given index.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType> unit{kNonEmptyArraySize};
     for (TrivialType i = 0; i < unit.size(); ++i)
     {
@@ -467,6 +619,14 @@ TYPED_TEST(DynamicArrayTestFixture, BracketOperatorAllowsGettingDataAtIndex)
 
 TYPED_TEST(DynamicArrayTestFixture, ConstBracketOperatorAllowsGettingDataAtIndex)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description",
+        "Check that the const overload of operator[] allows getting the value of an element at a given "
+        "index.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType> unit{kNonEmptyArraySize};
     for (TrivialType i = 0; i < unit.size(); ++i)
     {
@@ -484,18 +644,34 @@ TYPED_TEST(DynamicArrayTestFixture, ConstBracketOperatorAllowsGettingDataAtIndex
 
 TYPED_TEST(DynamicArrayTestFixture, DataShouldReturnPointerToFirstElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that data() returns a pointer to the first element.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     DynamicArray<TrivialType> unit{kNonEmptyArraySize};
     EXPECT_EQ(unit.data(), &unit.at(0));
 }
 
 TYPED_TEST(DynamicArrayTestFixture, ConstDataShouldReturnPointerToFirstElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that the const overload of data() returns a pointer to the first element.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     const DynamicArray<TrivialType> unit{kNonEmptyArraySize};
     EXPECT_EQ(unit.data(), &unit.at(0));
 }
 
 TYPED_TEST(DynamicArrayTestFixture, BeginIsEqualToEndWhenArrayIsEmpty)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that begin() equals end() on an empty DynamicArray.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -508,6 +684,11 @@ TYPED_TEST(DynamicArrayTestFixture, BeginIsEqualToEndWhenArrayIsEmpty)
 
 TYPED_TEST(DynamicArrayTestFixture, CBeginIsEqualToCEndWhenArrayIsEmpty)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that cbegin() equals cend() on an empty DynamicArray.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -520,6 +701,11 @@ TYPED_TEST(DynamicArrayTestFixture, CBeginIsEqualToCEndWhenArrayIsEmpty)
 
 TYPED_TEST(DynamicArrayTestFixture, DataReturnsNullptrWhenArrayIsEmpty)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that data() returns nullptr on an empty DynamicArray.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -532,6 +718,11 @@ TYPED_TEST(DynamicArrayTestFixture, DataReturnsNullptrWhenArrayIsEmpty)
 
 TYPED_TEST(DynamicArrayTestFixture, SizeReturnsZeroWhenArrayIsEmpty)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that size() returns zero on an empty DynamicArray.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -544,6 +735,13 @@ TYPED_TEST(DynamicArrayTestFixture, SizeReturnsZeroWhenArrayIsEmpty)
 
 TYPED_TEST(DynamicArrayTestFixture, SizeReturnsZeroWhenArrayIsEmptyWithValue)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that size() returns zero for a DynamicArray constructed with zero elements and an "
+                         "explicit default value.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray which takes an initial value
     constexpr std::size_t kNumberOfElements{0U};
     constexpr TrivialType kInitialValue{1};
@@ -558,6 +756,12 @@ TYPED_TEST(DynamicArrayTestFixture, SizeReturnsZeroWhenArrayIsEmptyWithValue)
 
 TYPED_TEST(DynamicArrayTestFixture, AccessingElementWithAtWhenArrayIsEmptyTerminates)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that accessing an element via at() on an empty DynamicArray terminates the program.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -568,6 +772,13 @@ TYPED_TEST(DynamicArrayTestFixture, AccessingElementWithAtWhenArrayIsEmptyTermin
 
 TYPED_TEST(DynamicArrayTestFixture, AccessingElementWithIndexOperatorWhenArrayIsEmptyTerminates)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that accessing an element via operator[] on an empty DynamicArray terminates the "
+                         "program.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -578,6 +789,11 @@ TYPED_TEST(DynamicArrayTestFixture, AccessingElementWithIndexOperatorWhenArrayIs
 
 TYPED_TEST(DynamicArrayTestFixture, IteratingOverEmptyArrayIteratesZeroTimes)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description", "Check that iterating over an empty DynamicArray loops zero times.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty DynamicArray
     const DynamicArray<TrivialType> unit{0U};
 
@@ -595,6 +811,14 @@ TYPED_TEST(DynamicArrayTestFixture, IteratingOverEmptyArrayIteratesZeroTimes)
 TEST(EmptyDynamicArrayOfNonTrivialElementTypeMemoryTest,
      TestNeverFailsButMemcheckDoesIfEmptyArrayIsNotCleanedUpCorrectly)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty(
+        "Description",
+        "Check, under a memory checker, that a zero-size DynamicArray of a non-trivial type is cleaned "
+        "up correctly on destruction without leaking memory; the test's own assertion always passes.");
+    this->RecordProperty("TestType", "resource-usage");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     std::size_t array_size{0};
     DynamicArray<NonTrivialType> da(array_size);
     EXPECT_TRUE(true);
@@ -602,6 +826,13 @@ TEST(EmptyDynamicArrayOfNonTrivialElementTypeMemoryTest,
 
 TEST(EmptyDynamicArrayOfTrivialElementTypeMemoryTest, TestNeverFailsButMemcheckDoesIfEmptyArrayIsNotCleanedUpCorrectly)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check, under a memory checker, that a zero-size DynamicArray of a trivial type is cleaned up "
+                         "correctly on destruction without leaking memory; the test's own assertion always passes.");
+    this->RecordProperty("TestType", "resource-usage");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     std::size_t array_size{0};
     DynamicArray<TrivialType> da(array_size);
     EXPECT_TRUE(true);
@@ -611,6 +842,13 @@ TEST(EmptyDynamicArrayOfTrivialElementTypeMemoryTest, TestNeverFailsButMemcheckD
 // but leave dynamic_array_ as nullptr
 TEST(DynamicArrayCopyConstructorMemoryTest, CopyConstructorWithZeroSizeArrayDoesNotLeakMemory)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing from a zero-size DynamicArray of a trivial type does not leak "
+                         "memory and both arrays remain valid empty arrays.");
+    this->RecordProperty("TestType", "resource-usage");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty source array
     DynamicArray<TrivialType> source_array{0U};
     EXPECT_EQ(source_array.size(), 0U);
@@ -629,6 +867,13 @@ TEST(DynamicArrayCopyConstructorMemoryTest, CopyConstructorWithZeroSizeArrayDoes
 // Test the same scenario with non-trivial types to ensure the fix works for both code paths
 TEST(DynamicArrayCopyConstructorMemoryTest, CopyConstructorWithNonTrivialZeroSizeArrayDoesNotLeakMemory)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__dynamic_array");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing from a zero-size DynamicArray of a non-trivial type does not "
+                         "leak memory and both arrays remain valid empty arrays.");
+    this->RecordProperty("TestType", "resource-usage");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // Given an empty source array of non-trivial type
     DynamicArray<NonTrivialType> source_array{0U};
     EXPECT_EQ(source_array.size(), 0U);

--- a/score/containers/intrusive_list_test.cpp
+++ b/score/containers/intrusive_list_test.cpp
@@ -108,6 +108,14 @@ void CheckNonEmpty(ListType& list,
 
 TEST(IntrusiveList, NotLinkedListElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that copy- and move-constructing an intrusive_list_element never links the new instance "
+        "into a list.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     ListElement element;
     ListElement copied_element{element};
     ListElement moved_element{std::move(element)};
@@ -116,6 +124,14 @@ TEST(IntrusiveList, NotLinkedListElement)
 
 TEST(IntrusiveList, EmptyIterator)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty("Description",
+                         "Check that default-constructed iterators, const_iterators, reverse_iterators, and "
+                         "const_reverse_iterators compare equal to themselves and to each other's const/non-const "
+                         "counterpart.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     const List::iterator iterator;
     const List::const_iterator const_iterator;
     EXPECT_TRUE(iterator == iterator);
@@ -137,6 +153,14 @@ TEST(IntrusiveList, EmptyIterator)
 
 TEST(IntrusiveList, EmptyList)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that a default-constructed list, its const view, and a list move-constructed from it are "
+        "all empty.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     List list;
     const List& const_list = list;
 
@@ -151,6 +175,14 @@ TEST(IntrusiveList, EmptyList)
 
 TEST(IntrusiveList, SingleElementMinimalChecks)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that a list constructed from a single-element range is non-empty and becomes empty after "
+        "clear().");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     std::array<ListElement, 1> elements;
     List list{elements.begin(), elements.end()};
     EXPECT_FALSE(list.empty());
@@ -173,6 +205,15 @@ static_assert(refers_to_const_v<decltype(std::declval<List::const_reverse_iterat
 
 TEST(IntrusiveList, SingleElementBasedIteratorChecks)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that on a single-element list, every iterator/const_iterator/reverse_iterator variant "
+        "returned by begin/end/rbegin/rend/iterator_to (mutable and const) refers to that element, has "
+        "the expected const-correct type, and increments/decrements correctly between begin and end.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr std::size_t kMagic = 42;
     std::array<ListElement, 1> elements{kMagic};
     List list{elements.begin(), elements.end()};
@@ -360,6 +401,14 @@ TEST(IntrusiveList, SingleElementBasedIteratorChecks)
 
 TEST(IntrusiveList, SingleElementInsertRemoveChecks)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty("Description",
+                         "Check that on a single element, push_back/pop_back, push_front/pop_front, move-construction, "
+                         "insert/remove, insert/remove_if, and insert/remove of a copied then moved-from element each "
+                         "correctly transition the list between empty and non-empty.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     List list;
     const List& const_list = list;
     ListElement front_back;
@@ -407,6 +456,14 @@ TEST(IntrusiveList, SingleElementInsertRemoveChecks)
 
 TEST(IntrusiveList, TwoElementsInsertRemoveChecks)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty("Description",
+                         "Check that with two elements, every ordering of push_back/push_front/pop_back/pop_front, "
+                         "move-construction, insert/remove, and insert/remove_if preserves the expected front/back "
+                         "element and count.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     List list;
     const List& const_list = list;
     ListElement front;
@@ -474,6 +531,15 @@ TEST(IntrusiveList, TwoElementsInsertRemoveChecks)
 
 TEST(IntrusiveList, SixElementsInsertRemoveChecks)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that with six elements, clear, assign, and range-insert at various split points preserve "
+        "element order and identity, and that remove followed by move-construction and remove_if "
+        "correctly reduce the list to empty.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     constexpr std::size_t num_elements = 6;
     std::array<ListElement, num_elements> elements;
     List list{elements.begin(), elements.end()};
@@ -549,6 +615,14 @@ DISABLE_WARNING_SELF_MOVE  // testing correctness of implementation
 
 TEST(IntrusiveList, MoveAssignmentTest)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that move-assigning a list of zero, one, two, or six elements empties the source and "
+        "transfers its elements to the target, and that self-move-assignment leaves the list unchanged.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "error-guessing");
+
     // NOLINTBEGIN(bugprone-use-after-move): testing correctness of implementation
 
     List list;
@@ -594,6 +668,14 @@ DISABLE_WARNING_POP  // "-Wself-move"
 
 TEST(IntrusiveList, EraseTest)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty("Description",
+                         "Check that erase() removes a single element, a trailing range, and the full range, that an "
+                         "empty range leaves the list unchanged, and that erase returns an iterator to the element "
+                         "following the erased range.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     constexpr std::size_t num_elements = 6;
     std::array<ListElement, num_elements> elements;
     List list{elements.begin(), elements.end()};
@@ -622,6 +704,14 @@ TEST(IntrusiveList, EraseTest)
 
 TEST(IntrusiveList, SwapTest)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that both the member swap() and the free swap() function correctly exchange the "
+        "contents of two lists in every combination of empty/non-empty operands, including self-swap.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "error-guessing");
+
     List list1;
 
     list1.swap(list1);
@@ -675,6 +765,16 @@ TEST(IntrusiveList, SwapTest)
 
 TEST(IntrusiveList, DisposeTest)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty(
+        "Description",
+        "Check that pop_back_and_dispose, pop_front_and_dispose, erase_and_dispose (single and range), "
+        "dispose_and_assign, remove_and_dispose, remove_and_dispose_if, and clear_and_dispose each "
+        "invoke the disposer exactly once per removed element, in the expected order, before the "
+        "element is unlinked.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers): "Magic numbers" here are the test labels by themselves
 
     constexpr std::size_t num_elements = 6;
@@ -734,6 +834,14 @@ class multi_element : public score::containers::intrusive_list_element<>,
 
 TEST(IntrusiveList, MultiTagTest)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__intrusive_list");
+    this->RecordProperty("Description",
+                         "Check that an element deriving from intrusive_list_element for multiple tags can be a member "
+                         "of one list per tag simultaneously, with insertions and clears on one tag's list leaving the "
+                         "others unaffected.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "design-analysis");
+
     constexpr std::size_t num_elements = 6;
     std::array<multi_element, num_elements> elements;
     score::containers::intrusive_list<multi_element> no_tag_list{elements.begin(), elements.end()};

--- a/score/containers/non_relocatable_vector_emplace_back_test.cpp
+++ b/score/containers/non_relocatable_vector_emplace_back_test.cpp
@@ -86,6 +86,11 @@ TYPED_TEST_SUITE(NonRelocatableVectorPolymorphicAllocatorFixture, PolymorphicAll
 
 TYPED_TEST(NonRelocatableVectorFixture, EmplaceBackUpdatesSize)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description", "Check that each call to emplace_back increments the vector's size by one.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -100,6 +105,14 @@ TYPED_TEST(NonRelocatableVectorFixture, EmplaceBackUpdatesSize)
 
 TYPED_TEST(NonRelocatableVectorTrivialFixture, EmplaceBackAllocatesAndReturnsElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description",
+        "Check that emplace_back constructs a trivial element in place at the correct index and returns "
+        "a reference to it.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -118,6 +131,13 @@ TYPED_TEST(NonRelocatableVectorTrivialFixture, EmplaceBackAllocatesAndReturnsEle
 
 TYPED_TEST(NonRelocatableVectorNonTrivialFixture, EmplaceBackAllocatesAndReturnsElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that emplace_back constructs a non-trivial element in place at the correct index and "
+                         "returns a reference to it.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -137,6 +157,13 @@ TYPED_TEST(NonRelocatableVectorNonTrivialFixture, EmplaceBackAllocatesAndReturns
 
 TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, EmplaceBackAllocatesAndReturnsElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that emplace_back default-constructs a trivially-constructible/destructible element in "
+                         "place and returns a reference to it.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -156,6 +183,13 @@ TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, Em
 
 TYPED_TEST(NonRelocatableVectorNonMoveableAndCopyableElementTypeFixture, EmplaceBackAllocatesAndReturnsElement)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that emplace_back default-constructs a non-moveable, non-copyable element in place and "
+                         "returns a reference to it.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -174,6 +208,12 @@ TYPED_TEST(NonRelocatableVectorNonMoveableAndCopyableElementTypeFixture, Emplace
 
 TYPED_TEST(NonRelocatableVectorFixture, CallingEmplaceBackMoreTimesThanWereReservedTerminates)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description", "Check that calling emplace_back beyond the vector's reserved capacity terminates the program.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     // and given that emplace_back was called size() - 1 times
@@ -189,6 +229,14 @@ TYPED_TEST(NonRelocatableVectorFixture, CallingEmplaceBackMoreTimesThanWereReser
 
 TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, EmplaceBackDoesNotAllocate)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description",
+                         "Check that emplace_back does not perform any additional memory allocation beyond what was "
+                         "reserved at construction.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has allocated n bytes on construction
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     const auto allocated_bytes_after_construction = this->memory_resource_.GetUserAllocatedBytes();

--- a/score/containers/non_relocatable_vector_special_member_funcs_test.cpp
+++ b/score/containers/non_relocatable_vector_special_member_funcs_test.cpp
@@ -95,6 +95,12 @@ using NonRelocatableVectorSpecialMemberFunctionRecorderFixture =
 
 TYPED_TEST(NonRelocatableVectorFixture, ConstructingWithZeroElementsSetsSizeAndCapacityToZero)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that constructing a vector with zero elements sets both size and capacity to zero.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // When constructing a NonRelocatableVector with zero elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(0U);
 
@@ -105,6 +111,13 @@ TYPED_TEST(NonRelocatableVectorFixture, ConstructingWithZeroElementsSetsSizeAndC
 
 TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, ConstructingWithZeroElementsDoesNotAllocate)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description",
+                         "Check that constructing a vector with zero elements does not allocate memory.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     // When constructing a NonRelocatableVector with zero elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(0U);
 
@@ -114,6 +127,14 @@ TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, ConstructingWithZero
 
 TYPED_TEST(NonRelocatableVectorFixture, ConstructingWithNonZeroElementsSetsCapacity)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description",
+        "Check that constructing a vector with a non-zero number of elements sets the capacity to that "
+        "number while size remains zero, since no element has been emplaced yet.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // When constructing a NonRelocatableVector with kNonZeroNumberElements elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -124,6 +145,14 @@ TYPED_TEST(NonRelocatableVectorFixture, ConstructingWithNonZeroElementsSetsCapac
 
 TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, ConstructingWithNonZeroElementsAllocatesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description",
+                         "Check that constructing a vector with a non-zero number of elements allocates memory for "
+                         "exactly that many elements up front.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // When constructing a NonRelocatableVector with kNonZeroNumberElements elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -137,6 +166,14 @@ TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, ConstructingWithNonZ
 TEST_F(NonRelocatableVectorSpecialMemberFunctionRecorderFixture,
        ConstructingWithNonZeroElementsDoesNotCallElementConstructors)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description",
+        "Check that constructing a vector with a non-zero number of elements reserves capacity without "
+        "constructing any element.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // When constructing a NonRelocatableVector with kNonZeroNumberElements elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -146,6 +183,13 @@ TEST_F(NonRelocatableVectorSpecialMemberFunctionRecorderFixture,
 
 TYPED_TEST(NonRelocatableVectorFixture, DestructingWithZeroElementsDoesNotDeallocate)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description",
+                         "Check that destructing a vector constructed with zero elements does not deallocate memory.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "boundary-values");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(0U);
 
     // When destructing the NonRelocatableVector with zero elements
@@ -157,6 +201,13 @@ TYPED_TEST(NonRelocatableVectorFixture, DestructingWithZeroElementsDoesNotDeallo
 
 TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, DestructingWithNonZeroElementsDeallocatesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description",
+                         "Check that destructing a vector deallocates memory for every element it had capacity for.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     // When destructing the NonRelocatableVector with non-zero elements
@@ -172,6 +223,13 @@ TYPED_TEST(NonRelocatableVectorPolymorphicAllocatorFixture, DestructingWithNonZe
 TEST_F(NonRelocatableVectorSpecialMemberFunctionRecorderFixture,
        DestructingWithNonZeroElementsDoesNotCallAnyDestructors)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that destructing a vector with reserved but never-emplaced elements does not call any "
+                         "element destructor.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     // When destructing the NonRelocatableVector with non-zero elements (although no emplaced elements)
@@ -184,6 +242,12 @@ TEST_F(NonRelocatableVectorSpecialMemberFunctionRecorderFixture,
 TEST_F(NonRelocatableVectorSpecialMemberFunctionRecorderFixture,
        DestructingWithNonZeroEmplacedElementsCallsDestructorAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description", "Check that destructing a vector calls the destructor of every emplaced element exactly once.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
     // and given that kNonZeroNumberElements have been emplaced
@@ -201,6 +265,12 @@ TEST_F(NonRelocatableVectorSpecialMemberFunctionRecorderFixture,
 
 TYPED_TEST(NonRelocatableVectorTrivialFixture, CopyConstructingCopiesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing from a vector copies all of its trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -223,6 +293,12 @@ TYPED_TEST(NonRelocatableVectorTrivialFixture, CopyConstructingCopiesAllElements
 
 TYPED_TEST(NonRelocatableVectorNonTrivialFixture, CopyConstructingCopiesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing from a vector copies all of its non-trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -247,6 +323,13 @@ TYPED_TEST(NonRelocatableVectorNonTrivialFixture, CopyConstructingCopiesAllEleme
 
 TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, CopyConstructingCopiesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that copy-constructing from a vector copies all of its trivially-constructible/"
+                         "destructible elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -286,6 +369,15 @@ TYPED_TEST(NonRelocatableVectorNonMoveableAndCopyableElementTypeFixture, CannotC
 
 TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, CopyConstructingAllocatesBasedOnCapacity)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty(
+        "Description",
+        "Check that copy-constructing a vector allocates memory based on the source's capacity, not on "
+        "how many elements were actually emplaced.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with less elements than its capacity
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     const auto memory_allocated_for_first_vector = this->memory_resource_.GetUserAllocatedBytes();
@@ -313,6 +405,12 @@ TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, C
 
 TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, CopyConstructingDoesNotDeallocateMemory)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description", "Check that copy-constructing a vector does not deallocate any memory.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -328,6 +426,12 @@ TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, C
 
 TYPED_TEST(NonRelocatableVectorTrivialFixture, MoveConstructingMovesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that move-constructing from a vector transfers all of its trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -350,6 +454,12 @@ TYPED_TEST(NonRelocatableVectorTrivialFixture, MoveConstructingMovesAllElements)
 
 TYPED_TEST(NonRelocatableVectorNonTrivialFixture, MoveConstructingMovesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that move-constructing from a vector transfers all of its non-trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -374,6 +484,13 @@ TYPED_TEST(NonRelocatableVectorNonTrivialFixture, MoveConstructingMovesAllElemen
 
 TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, MoveConstructingMovesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that move-constructing from a vector transfers all of its trivially-constructible/"
+                         "destructible elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -413,6 +530,12 @@ TYPED_TEST(NonRelocatableVectorNonMoveableAndCopyableElementTypeFixture, MoveCon
 
 TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, MoveConstructingDoesNotAllocateNewMemory)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description", "Check that move-constructing a vector does not allocate any new memory.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with less elements than its capacity
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     const auto memory_allocated_for_first_vector = this->memory_resource_.GetUserAllocatedBytes();
@@ -437,6 +560,12 @@ TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, M
 
 TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, MoveConstructingDoesNotDeallocateMemory)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description", "Check that move-constructing a vector does not deallocate any memory.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 
@@ -452,6 +581,12 @@ TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, M
 
 TYPED_TEST(NonRelocatableVectorTrivialFixture, MoveAssigningMovesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that move-assigning a vector transfers all of its trivial elements to the target.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -481,6 +616,12 @@ TYPED_TEST(NonRelocatableVectorTrivialFixture, MoveAssigningMovesAllElements)
 
 TYPED_TEST(NonRelocatableVectorNonTrivialFixture, MoveAssigningMovesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that move-assigning a vector transfers all of its non-trivial elements to the target.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -512,6 +653,13 @@ TYPED_TEST(NonRelocatableVectorNonTrivialFixture, MoveAssigningMovesAllElements)
 
 TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, MoveAssigningMovesAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that move-assigning a vector transfers all of its trivially-constructible/destructible "
+                         "elements to the target.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -560,6 +708,14 @@ TYPED_TEST(NonRelocatableVectorNonMoveableAndCopyableElementTypeFixture, MoveAss
 
 TYPED_TEST(NonRelocatableVectorCopyableAndMoveablePolymorphicAllocatorFixture, MoveAssigningAllocatesBasedOnCapacity)
 {
+    this->RecordProperty("PartiallyVerifies",
+                         "comp_req__containers__non_relocatable_vector, comp_req__containers__deterministic_behavior");
+    this->RecordProperty("Description",
+                         "Check that move-assigning a vector into another does not allocate new memory beyond what the "
+                         "target already had capacity for.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
 

--- a/score/containers/non_relocatable_vector_test.cpp
+++ b/score/containers/non_relocatable_vector_test.cpp
@@ -88,6 +88,11 @@ TYPED_TEST_SUITE(NonRelocatableVectorPolymorphicAllocatorFixture, PolymorphicAll
 
 TYPED_TEST(NonRelocatableVectorTrivialFixture, SwapSwapsAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description", "Check that swapping two vectors exchanges their trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -122,6 +127,11 @@ TYPED_TEST(NonRelocatableVectorTrivialFixture, SwapSwapsAllElements)
 
 TYPED_TEST(NonRelocatableVectorNonTrivialFixture, SwapSwapsAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description", "Check that swapping two vectors exchanges their non-trivial elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "requirements-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -160,6 +170,13 @@ TYPED_TEST(NonRelocatableVectorNonTrivialFixture, SwapSwapsAllElements)
 
 TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, SwapSwapsAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that swapping two vectors exchanges their trivially-constructible/destructible "
+                         "elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -203,6 +220,12 @@ TYPED_TEST(NonRelocatableVectorTriviallyConstructibleDestructibleTypeFixture, Sw
 
 TYPED_TEST(NonRelocatableVectorNonMoveableAndCopyableElementTypeFixture, SwapSwapsAllElements)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that swapping two vectors exchanges their non-moveable, non-copyable elements.");
+    this->RecordProperty("TestType", "requirements-based");
+    this->RecordProperty("DerivationTechnique", "equivalence-classes");
+
     // Given a NonRelocatableVector which has been filled with elements
     this->GivenANonRelocatableVectorConstructedWithNumberOfElements(kNonZeroNumberElements);
     for (std::size_t i = 0; i < kNonZeroNumberElements; ++i)
@@ -295,6 +318,14 @@ using testing::_;
 
 TEST_F(NonRelocatableVectorPointerInteractionFixture, DataDereferencesBeginAndEnd)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description",
+        "Check that data() dereferences the underlying element pointer exactly twice, at the first and "
+        "last element, regardless of the pointer type used by the allocator.");
+    this->RecordProperty("TestType", "interface-test");
+    this->RecordProperty("DerivationTechnique", "design-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     GivenANonRelocatableVectorContainingNumberOfElements(kNonZeroNumberElements);
 
@@ -313,6 +344,14 @@ TEST_F(NonRelocatableVectorPointerInteractionFixture, DataDereferencesBeginAndEn
 
 TEST_F(NonRelocatableVectorPointerInteractionFixture, BeginDereferencesBeginAndEnd)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty(
+        "Description",
+        "Check that begin() dereferences the underlying element pointer exactly twice, at the first and "
+        "last element, regardless of the pointer type used by the allocator.");
+    this->RecordProperty("TestType", "interface-test");
+    this->RecordProperty("DerivationTechnique", "design-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     GivenANonRelocatableVectorContainingNumberOfElements(kNonZeroNumberElements);
 
@@ -331,6 +370,13 @@ TEST_F(NonRelocatableVectorPointerInteractionFixture, BeginDereferencesBeginAndE
 
 TEST_F(NonRelocatableVectorPointerInteractionFixture, EndDereferencesBeginAndEnd)
 {
+    this->RecordProperty("PartiallyVerifies", "comp_req__containers__non_relocatable_vector");
+    this->RecordProperty("Description",
+                         "Check that end() dereferences the underlying element pointer exactly twice, at the first and "
+                         "last element, regardless of the pointer type used by the allocator.");
+    this->RecordProperty("TestType", "interface-test");
+    this->RecordProperty("DerivationTechnique", "design-analysis");
+
     // Given a NonRelocatableVector which has been filled with elements
     GivenANonRelocatableVectorContainingNumberOfElements(kNonZeroNumberElements);
 


### PR DESCRIPTION


Add RecordProperty traceability metadata (linkage, Description, TestType, DerivationTechnique) to all 88 linkable tests across the 5 containers test files, covering dynamic_array, intrusive_list, non_relocatable_vector, and deterministic_behavior,