### PR TITLE
fix(log_rust): replace unstable NonNull::from_ref with manual cast

### DIFF
--- a/score/log_rust/score_log_fmt/fmt.rs
+++ b/score/log_rust/score_log_fmt/fmt.rs
@@ -71,7 +71,7 @@ pub struct Placeholder<'a> {
 impl<'a> Placeholder<'a> {
     /// Create the placeholder to be represented using `ScoreDebug`.
     pub const fn new<T: ScoreDebug>(value: &'a T, spec: FormatSpec) -> Self {
-        let value = NonNull::from_ref(value).cast();
+        let value = NonNull::new(value as *const T as *mut T).unwrap().cast();
         let formatter = |v: NonNull<()>, f: Writer, spec: &FormatSpec| {
             // SAFETY: borrow checker will ensure that value won't be mutated for as long as the returned `Self` instance is alive.
             let typed = unsafe { v.cast::<T>().as_ref() };


### PR DESCRIPTION
- Remove compile crashes on the safety-certified Ferrocene Rust compiler.

- **Removes the patch** used here https://github.com/eclipse-score/inc_security_crypto/pull/204 

- **Unblock** https://github.com/eclipse-score/inc_security_crypto/issues/173