### PR TITLE
fix(rust_log): add safe conversion to replace unsafe conversion

### DIFF
--- a/score/log_rust/score_log_fmt/fmt.rs
+++ b/score/log_rust/score_log_fmt/fmt.rs
@@ -71,7 +71,8 @@ pub struct Placeholder<'a> {
 impl<'a> Placeholder<'a> {
     /// Create the placeholder to be represented using `ScoreDebug`.
     pub const fn new<T: ScoreDebug>(value: &'a T, spec: FormatSpec) -> Self {
-        let value = NonNull::from_ref(value).cast();
+        let value =
+    unsafe { NonNull::new_unchecked(value as *const T as *mut T) }.cast();
         let formatter = |v: NonNull<()>, f: Writer, spec: &FormatSpec| {
             // SAFETY: borrow checker will ensure that value won't be mutated for as long as the returned `Self` instance is alive.
             let typed = unsafe { v.cast::<T>().as_ref() };


### PR DESCRIPTION
## Description

Fix Rust 1.86 compilation of Placeholder::new. NonNull::from_ref is not const-stable in this compiler and cannot be used inside a const fn. This issue was causing compiler errors when used as a bzlmod dependency in other external projects.

The target `//score/mw/log/rust/score_log_bridge:score_log_bridge` command was causing the following error when used as a dependency in external projects:

```
ERROR: /home/ian/.cache/bazel/_bazel_ian/727f4db92e07d4c58e2e4a819b1cc01b/external/score_baselibs+/score/log_rust/score_log_fmt/BUILD:15:13: Compiling Rust rlib score_log_fmt (8 files) [for tool] failed: (Exit 1): process_wrapper failed: error executing Rustc command (from target @@score_baselibs+//score/log_rust/score_log_fmt:score_log_fmt) bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' -- ... (remaining 20 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0658]: use of unstable library feature `non_null_from_ref`
  --> external/score_baselibs+/score/log_rust/score_log_fmt/fmt.rs:74:21
   |
74 |         let value = NonNull::from_ref(value).cast();
   |                     ^^^^^^^^^^^^^^^^^
   |
   = note: see issue #130823 <https://github.com/rust-lang/rust/issues/130823> for more information

error: `NonNull::<T>::from_ref` is not yet stable as a const fn
  --> external/score_baselibs+/score/log_rust/score_log_fmt/fmt.rs:74:21
   |
74 |         let value = NonNull::from_ref(value).cast();
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
   |
help: add `#![feature(non_null_from_ref)]` to the crate attributes to enable
  --> external/score_baselibs+/score/log_rust/score_log_fmt/lib.rs:19:1
   |
19 + #![feature(non_null_from_ref)]
   |

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0658`.
```

## Changes Made

In score_log_fmt:

Replaced NonNull::from_ref with an equivalent const-compatible pointer conversion using NonNull::new_unchecked.
The pointer originates from a valid reference, so it is guaranteed to be non-null.

## Validation

Successfully ran:

`bazel build //score/mw/log/rust/score_log_bridge:score_log_bridge`