### PR TITLE
concurrency: replace legacy Verifies/ASIL tags with comp_req RecordProperty links

### DIFF
--- a/score/concurrency/synchronized_queue_test.cpp
+++ b/score/concurrency/synchronized_queue_test.cpp
@@ -41,10 +41,9 @@ using ::testing::Return;
 
 TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenMaxQueueLengthReached)
 {
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This test check that QueueSender::Push() would return false if queue is full and pushing into the "
                    "queue is impossible");
@@ -75,10 +74,9 @@ TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenMaxQueueLengthReached)
 
 TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenQueueObjectDoesNotExist)
 {
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This test check that QueueSender::Push() would return false "
                    "if queue object doesn't exist anymore");
@@ -105,10 +103,9 @@ TEST(SynchronizedQueue, CheckFalseResponseOnPushWhenQueueObjectDoesNotExist)
 
 TEST(SynchronizedQueue, CallPopForEmptyQueue)
 {
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This test check that SynchronizedQueue::Pop() would return nullopt if queue is empty");
 
@@ -133,10 +130,9 @@ TEST(SynchronizedQueue, CallPopForEmptyQueue)
 
 TEST(SynchronizedQueue, CallPushWhenPopIsWaitingForTimeout)
 {
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This test check that SynchronizedQueue::Pop() would return the value "
                    "if it's in waiting state and QueueSender pushes new value into the queue");
@@ -176,10 +172,9 @@ TEST(SynchronizedQueue, CallPushWhenPopIsWaitingForTimeout)
 
 TEST(SynchronizedQueue, CallPushWithConstValueWhenPopIsWaitingForTimeout)
 {
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This test check that SynchronizedQueue::Pop() would return the value "
                    "if it's in waiting state and QueueSender pushes new const value into the queue");
@@ -219,10 +214,9 @@ TEST(SynchronizedQueue, CallPushWithConstValueWhenPopIsWaitingForTimeout)
 
 TEST(SynchronizedQueue, CallPushAndPopAtForNoneEmptyQueue)
 {
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This test check that SynchronizedQueue::Pop() would return the value "
                    "in the case of none empty queue");
@@ -274,10 +268,9 @@ TEST(SynchronizedQueue, MakeStressTestForPushingFromMultipleThreads)
     constexpr std::size_t num_values_per_thread = 100;
     const std::size_t max_queue_length = num_threads * num_values_per_thread;
 
-    RecordProperty("ASIL", "QM");
     RecordProperty("TestType", "interface-test");
     RecordProperty("DerivationTechnique", "boundary-values");
-    RecordProperty("Verifies", "::score::platform::aas::lib::concurrency::SynchronizedQueue");
+    RecordProperty("PartiallyVerifies", "comp_req__concurrency__synchronized_queue");
     RecordProperty("Description",
                    "This is a smoke test where test 3 threads are created and each of them pushes 100 values "
                    "into the queue. "


### PR DESCRIPTION
## Summary
Part of #522. Replaces the legacy `ASIL`/`Verifies` `RecordProperty` tags in `synchronized_queue_test.cpp` with the current `PartiallyVerifies: comp_req__concurrency__synchronized_queue` linkage convention.

