### PR TITLE
static_reflection_with_serialization: migrate test requirement links

### DIFF
--- a/score/static_reflection_with_serialization/serialization/test/ut/test_serializer_visitor.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_serializer_visitor.cpp
@@ -202,11 +202,12 @@ enum E
 
 TEST(serializer_visitor, serialized)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the serialization for different data type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that serialized_t computes the expected on-wire size for primitives, pairs, tuples, "
+                   "optional, bitset, strings, vectors, arrays, containers, C arrays, references, and enums.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     EXPECT_EQ(check_serialized<char>(), sizeof(char));
     EXPECT_EQ(check_serialized<uint8_t>(), sizeof(uint8_t));
     EXPECT_EQ(check_serialized<uint16_t>(), sizeof(uint16_t));
@@ -259,11 +260,15 @@ struct subsize_too_small_alloc_t
 
 TEST(serializer_visitor, serializer)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the serialization and deserialization for different data type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__container, "
+                   "comp_req__static_reflect_serial__nested");
+    RecordProperty("Description",
+                   "Check that serialize/deserialize round-trips tuples, pairs, nested structs, optional, bitset, "
+                   "chrono durations, vectors, strings, arrays, and containers to an equal value, and that a "
+                   "corrupted subsize is reported as out-of-bounds or invalid-format.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     using namespace ::score::common::visitor;
     using s = serializer_t<real_alloc_t>;
     std::uint8_t buffer[1024];
@@ -515,11 +520,12 @@ SCORE_MEMCPY_SERIALIZABLE(score::common::visitor::payload_tags::unsigned_le, tim
 
 TEST(serializer_visitor, custom)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the serialization and deserialization for steady clock time_point.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that a type opted into SCORE_MEMCPY_SERIALIZABLE (steady_clock::time_point) round-trips "
+                   "through serialize/deserialize to an equal value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using s = ::score::common::visitor::serializer_t<real_alloc_t>;
     char buffer[1024];
 
@@ -549,11 +555,12 @@ SCORE_MEMCPY_SERIALIZABLE_IF(score::common::visitor::payload_tags::ieee754_float
 
 TEST(serializer_visitor, serialize_unit)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the serialization and deserialization for a struct type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that a type opted into SCORE_MEMCPY_SERIALIZABLE_IF via a type predicate round-trips "
+                   "through serialize/deserialize to an equal value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     using s = ::score::common::visitor::serializer_t<real_alloc_t>;
     char buffer[1024];
 
@@ -648,13 +655,12 @@ class serializer_visitor_overflows : public ::testing::Test
 
 TEST_F(serializer_visitor_overflows, basic__no_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a normal struct shall success when providing the "
-                   "serialized and the deserialized buffers with the same sizes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that a struct round-trips without error when the serialize and deserialize buffers are "
+                   "exactly large enough to hold it.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 2048, 2048);
     EXPECT_EQ(result.first.operator bool(), true);
     EXPECT_EQ(result.second, true);
@@ -662,13 +668,12 @@ TEST_F(serializer_visitor_overflows, basic__no_overflow)
 
 TEST_F(serializer_visitor_overflows, basic__serializer_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a normal struct shall overflow and reach zero offset "
-                   "when deserialize more data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that deserializing a struct into an undersized serialize buffer is detected as a "
+                   "zero-offset error rather than producing an equal value.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 100, 2048);
     EXPECT_EQ(result.first.getZeroOffset(), true);
     EXPECT_EQ(result.second, false);
@@ -676,13 +681,12 @@ TEST_F(serializer_visitor_overflows, basic__serializer_overflow)
 
 TEST_F(serializer_visitor_overflows, basic__derserializer_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a normal struct shall overflow for reaching out of "
-                   "bounds when deserialize less data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that deserializing a struct from an undersized deserialize buffer is detected as an "
+                   "out-of-bounds error rather than producing an equal value.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(normalStructure, 2048, 100);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
     EXPECT_EQ(result.second, false);
@@ -690,13 +694,12 @@ TEST_F(serializer_visitor_overflows, basic__derserializer_overflow)
 
 TEST_F(serializer_visitor_overflows, basic_deserializer_overflow_const)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a normal struct shall overflow for reaching out of "
-                   "bounds when deserialize less data than the serialized one - const type.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that the const-pointer overload of deserialize also detects an undersized deserialize "
+                   "buffer as an out-of-bounds error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     constexpr auto size_in = 2048UL;
     constexpr auto size_out = 100UL;
     result_type result =
@@ -707,14 +710,13 @@ TEST_F(serializer_visitor_overflows, basic_deserializer_overflow_const)
 
 TEST_F(serializer_visitor_overflows, dynamic_part__no_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty(
-        "Description",
-        "The serialization and deserialization for a struct with a huge dynamic part shall success when providing the "
-        "serialized and the deserialized buffers with the same sizes when allocate a dynamic part.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__container");
+    RecordProperty("Description",
+                   "Check that a struct with a large dynamically-sized vector member round-trips without error "
+                   "when the serialize and deserialize buffers are exactly large enough to hold it.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     structureWithHugeDynamicPart.dynamicPart.resize(100);
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, 4096, 4096);
     EXPECT_EQ(result.first.operator bool(), true);
@@ -723,14 +725,13 @@ TEST_F(serializer_visitor_overflows, dynamic_part__no_overflow)
 
 TEST_F(serializer_visitor_overflows, dynamic_part__serializer_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty(
-        "Description",
-        "The serialization and deserialization for a struct with a huge dynamic part shall overflow when providing the "
-        "serialized and the deserialized buffers with the same sizes but without allocating a dynamic part.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__container");
+    RecordProperty("Description",
+                   "Check that deserializing a struct with a large dynamically-sized vector member into a buffer that "
+                   "was never allocated for that dynamic part is detected as a zero-offset error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     constexpr auto size_in_out = 4096UL;
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, size_in_out, size_in_out);
     EXPECT_EQ(result.first.getZeroOffset(), true);
@@ -739,13 +740,13 @@ TEST_F(serializer_visitor_overflows, dynamic_part__serializer_overflow)
 
 TEST_F(serializer_visitor_overflows, dynamic_part_serializer_overflow_too_small_subsize)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__container");
     RecordProperty("Description",
-                   "Logging library shall provide an annotation mechanism for data structures to support automatic "
-                   "serialization/deserialization and handle subsize overflows returning the ZeroOffset status.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that a subsize_t too small to represent a large dynamic part's element count is detected "
+                   "as a zero-offset error rather than silently truncating.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     constexpr auto size_in_out = 4096UL;
     result_type result =
         ThereAndBackWithErrorCheck<subsize_too_small_alloc_t>(structureWithHugeDynamicPart, size_in_out, size_in_out);
@@ -755,13 +756,13 @@ TEST_F(serializer_visitor_overflows, dynamic_part_serializer_overflow_too_small_
 
 TEST_F(serializer_visitor_overflows, dynamic_part__deserilizer_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__container");
     RecordProperty("Description",
-                   "The serialization and deserialization for a struct with a huge dynamic part shall overflow for "
-                   "reaching out of bounds when deserialize less data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that deserializing a struct with a large dynamically-sized vector member from an "
+                   "undersized deserialize buffer is detected as an out-of-bounds error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(structureWithHugeDynamicPart, 8192, 4096);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
     EXPECT_EQ(result.second, false);
@@ -769,13 +770,12 @@ TEST_F(serializer_visitor_overflows, dynamic_part__deserilizer_overflow)
 
 TEST_F(serializer_visitor_overflows, string__no_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a string data shall success when providing the "
-                   "serialized and the deserialized buffers with the same sizes.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that a struct with a maximal-length string member round-trips without error when the "
+                   "serialize and deserialize buffers are exactly large enough to hold it.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 4096, 4096);
     EXPECT_EQ(result.first.operator bool(), true);
     EXPECT_EQ(result.second, true);
@@ -783,13 +783,12 @@ TEST_F(serializer_visitor_overflows, string__no_overflow)
 
 TEST_F(serializer_visitor_overflows, string__serialization_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a string data shall overflow and reach zero offset when "
-                   "deserialize more data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that deserializing a struct with a maximal-length string member into an undersized "
+                   "serialize buffer is detected as a zero-offset error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 2048, 4096);
     EXPECT_EQ(result.first.getZeroOffset(), true);
     EXPECT_EQ(result.second, false);
@@ -797,13 +796,12 @@ TEST_F(serializer_visitor_overflows, string__serialization_overflow)
 
 TEST_F(serializer_visitor_overflows, string_deserialization_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861827, SCR-861550");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "The serialization and deserialization for a string data shall overflow for reaching out of bounds "
-                   "when deserialize less data than the serialized one.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that deserializing a struct with a maximal-length string member from an undersized "
+                   "deserialize buffer is detected as an out-of-bounds error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     result_type result = ThereAndBackWithErrorCheck(structureWithALongString, 4096, 2048);
     EXPECT_EQ(result.first.getOutOfBounds(), true);
     EXPECT_EQ(result.second, false);
@@ -811,11 +809,12 @@ TEST_F(serializer_visitor_overflows, string_deserialization_overflow)
 
 TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Test the inability of logger_type_info API to copy data bigger than the size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that logger_type_info::copy leaves the number-of-characters field at its all-bits-set "
+                   "sentinel when the destination buffer is smaller than the encoded value's own size.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     constexpr auto cmpr = std::numeric_limits<char>::is_signed ? 0x7f : 0xff;
     constexpr auto array_size = 64UL;
     std::array<char, array_size> buffer;
@@ -836,11 +835,12 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_overflow)
 
 TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_not_fit)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Test the inability of logger_type_info API to copy data that does not fit size.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that logger_type_info::copy zero-fills the number-of-characters field when the destination "
+                   "buffer is too small to fit the type's name.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     constexpr auto array_size = 64UL;
     std::array<char, array_size> buffer;
@@ -860,11 +860,12 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_not_fit)
 
 TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_fits)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Test the ability of logger_type_info to copy data.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that logger_type_info::copy writes the type's fully-qualified name into a destination "
+                   "buffer large enough to hold it.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     constexpr auto array_size = 64UL;
     std::array<char, array_size> buffer{0};
@@ -878,8 +879,12 @@ TEST_F(serializer_visitor_overflows, test_logger_type_info_copy_size_fits)
 
 TEST(visit_optional_pack_desc_test, optional_pack_desc_should_return_correct_field_name)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "Test optional_pack_desc's field_name function for providing name to optional variable");
+                   "Check that an optional's serialized pack_desc reports field names 'has_value' and 'data' for its "
+                   "two defined fields, and an empty name for indices beyond them.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     using namespace ::score::common::visitor;
     serialized_visitor<double> visitor_local{};
     EXPECT_EQ(decltype(visit(visitor_local, score::cpp::optional<double>(1.0)))::pack_desc::field_name(0U),
@@ -891,12 +896,12 @@ TEST(visit_optional_pack_desc_test, optional_pack_desc_should_return_correct_fie
 
 TEST(logging_serializer_test, serialize_int_data_with_big_miss_match_size)
 {
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
                    "Verify the inability of serialize integer data by providing a size bigger than"
                    "the original data size.");
-    RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "equivalence-classes");  // equivalence classes
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     std::tuple<int, int> tuple_instance{1, 2};
     std::uint8_t buffer[1024];
@@ -908,12 +913,12 @@ TEST(logging_serializer_test, serialize_int_data_with_big_miss_match_size)
 
 TEST(logging_serializer_test, deserialize_int_data_with_big_miss_match_size)
 {
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
                    "Verify the inability of deserialize integer data by providing a size bigger than"
                    "the original data size.");
-    RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "equivalence-classes");  // equivalence classes
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     std::tuple<int, int> tuple_instance_in{1, 2};
     std::tuple<int, int> tuple_instance_out;
@@ -931,12 +936,12 @@ TEST(logging_serializer_test, deserialize_int_data_with_big_miss_match_size)
 
 TEST(logging_serializer_test, deserialize_byte_data_with_miss_match_size)
 {
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
                    "Verify the inability of deserialize byte data by providing a size bigger than"
                    "the original data size.");
-    RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "equivalence-classes");  // equivalence classes
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     test::StructOneSigned struct_one_signed_out;
     char serialized_buffer[1024];
@@ -962,10 +967,11 @@ class VectorWrapper
 
 TEST(clear_functionality_test, test_that_clear_function_can_clear_vector_of_int32)
 {
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Verify the inability of clearing vector of int32.");
-    RecordProperty("TestingTechnique", "Interface test");
-    RecordProperty("DerivationTechnique", "equivalence-classes");  // equivalence classes
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__container");
+    RecordProperty("Description",
+                   "Check that detail::clear() clears a non-empty vector member via its clear() method.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
 
     VectorWrapper vector_wrapper_instance{};
     score::common::visitor::detail::clear(vector_wrapper_instance);

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_size_visitor.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_size_visitor.cpp
@@ -295,13 +295,17 @@ TYPED_TEST_SUITE_P(SizeVisitorFixture);
 
 TYPED_TEST_P(SizeVisitorFixture, whenDataSerializedAndThenDeserializedDataShouldBeTheSame)
 {
-    ::testing::Test::RecordProperty("ParentRequirement", "SCR-1633893");
-    ::testing::Test::RecordProperty("ASIL", "B");
-    ::testing::Test::RecordProperty("Description",
-                                    "logging library shall provide an annotation mechanism for data structures to "
-                                    "support automatic serialization/deserialization.");
-    ::testing::Test::RecordProperty("TestingTechnique", "Requirements-based test");
-    ::testing::Test::RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    ::testing::Test::RecordProperty(
+        "PartiallyVerifies",
+        "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__container, "
+        "comp_req__static_reflect_serial__nested");
+    ::testing::Test::RecordProperty(
+        "Description",
+        "Check that serializing then deserializing a value round-trips to an equal value, and that the "
+        "deserialized data's computed size matches the serialized byte size, across scalars, containers "
+        "(vector, clearable/resizeable/assignable_container), tuples, pairs, and nested structs.");
+    ::testing::Test::RecordProperty("TestType", "requirements-based");
+    ::testing::Test::RecordProperty("DerivationTechnique", "equivalence-classes");
 
     using s = serializer_t<real_alloc_t>;
     using ssize = serialized_size_t<real_alloc_t>;

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_skip_deserialize.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_skip_deserialize.cpp
@@ -66,13 +66,12 @@ static_assert(std::is_empty<::score::common::visitor::skip_deserialize<int>>(), 
 
 TEST(serializer_visitor, skip_deserialize)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "Logging library shall provide an annotation mechanism for data structures to support automatic "
-                   "serialization/deserialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that skip_deserialize-annotated fields are excluded from the payload compatibility check "
+                   "and correctly skipped when deserializing into a struct with fewer or reordered payload fields.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // S has an "added" std::vector member compared to S3;, it should be detected as incompatible
     EXPECT_FALSE((::score::common::visitor::is_payload_compatible<test::S3s, test::S>()));
 
@@ -102,11 +101,12 @@ TEST(serializer_visitor, skip_deserialize)
 
 TEST(serializer_visitor, skip_deserialize_test_overflow)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893, SCR-861550");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Skip deserialization in case the data to be serialized is bigger than the buffer.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that serialize returns zero when the destination buffer is too small to hold the "
+                   "serialized data.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     std::array<char, 4> buffer;
     using serializer = ::score::common::visitor::logging_serializer;

--- a/score/static_reflection_with_serialization/serialization/test/ut/test_visitor_type_traits.cpp
+++ b/score/static_reflection_with_serialization/serialization/test/ut/test_visitor_type_traits.cpp
@@ -27,14 +27,12 @@ namespace visitor
 
 TEST(vistor_type_traits, is_vector_serializable)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty(
-        "Description",
-        "Logging library shall provide an annotation mechanism for data structures to support automatic "
-        "serialization/deserialization, So, we are checking some data types to be treated for vector serialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__container");
+    RecordProperty("Description",
+                   "Check that is_vector_serializable identifies std::vector, nested vectors, std::string, and "
+                   "clearable_container as automatically container-iterable types.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     using test::clearable_container;
     using std_basic_string = std::basic_string<char, std::char_traits<char>, std::allocator<char>>;
@@ -52,14 +50,12 @@ TEST(vistor_type_traits, is_vector_serializable)
 
 TEST(vistor_type_traits, is_not_vector_serializable)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__container");
     RecordProperty("Description",
-                   "Logging library shall provide an annotation mechanism for data structures to support automatic "
-                   "serialization/deserialization. So, we are checking those some data types shouldn't be treated as "
-                   "vector serialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that is_vector_serializable rejects std::array and a container type not opted into "
+                   "automatic iteration (unserializable_container).");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     using test::unserializable_container;
     static_assert(!is_vector_serializable<std::array<int, 3>>::value,

--- a/score/static_reflection_with_serialization/visitor/examples/ostream/test/ut/test_ostream_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/examples/ostream/test/ut/test_ostream_visitor.cpp
@@ -42,9 +42,12 @@ SCORE_STRUCT_VISITABLE(S2, f1, f2)
 /// @req{VISIT-OSTREAM}
 TEST(ostream_visitor, basic)
 {
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Test the basic types.");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that ostream_visitor, a custom visitor implementation, formats scalars, strings, arrays, "
+                   "vectors, pairs, tuples, and a visitable struct via the generic visit() dispatch.");
     RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     EXPECT_EQ(test_to_string(char('A')), "A");
     EXPECT_EQ(test_to_string(5), "5");
@@ -82,9 +85,13 @@ SCORE_STRUCT_VISITABLE(SS2S3, s2, s3)
 /// @req{VISIT-OSTREAM-COMPOUND}
 TEST(ostream_visitor, compound)
 {
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Test the compound types.");
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__visitor, comp_req__static_reflect_serial__nested");
+    RecordProperty("Description",
+                   "Check that ostream_visitor formats nested compound types (2D arrays, vectors of vectors, "
+                   "and nested pairs) via the generic visit() dispatch.");
     RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
 
     using namespace std;
 

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_detail.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_detail.cpp
@@ -32,13 +32,12 @@ constexpr inline bool check_type_span(const char (&pretty_name)[N], std::size_t 
 
 TEST(detail, extract_type)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "Logging library shall provide an annotation mechanism for data structures to support automatic "
-                   "serialization/deserialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that visitor_extract_type/visitor_extract_type_span derive a struct's fully-qualified name "
+                   "from a compiler pretty-function string, including malformed bracket and whitespace edge cases.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     const auto& likely_format = "static constexpr auto& test::struct_visitable_impl<test::S1>::namedata()";
     const auto type_string = ::score::common::visitor::detail::visitor_extract_type<std::string>(likely_format);
     EXPECT_STREQ(type_string.c_str(), "test::S1");
@@ -54,13 +53,12 @@ TEST(detail, extract_type)
 
 TEST(detail, skip_trailing_space)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "Verifies that 'strip_trailing_spaces' API shall return the value of the last parameter provided if "
-                   "it gets a value out of range or a value zero for parameter 'end'.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that strip_trailing_spaces clamps an out-of-range or zero end value to the value passed in, "
+                   "and correctly strips a run of trailing spaces at the bound.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     constexpr std::size_t expected_out_of_bounds_end_value = 16;
     constexpr std::size_t expected_zero_output_when_zero_input_end_value = 0;
     auto& simple_text = "simple text";

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_struct_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_struct_visitor.cpp
@@ -176,11 +176,13 @@ bool check_visitable(const char* name, std::size_t fields)
 
 TEST(struct_visitor, struct_visitable)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check visitability of different structures.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies",
+                   "comp_req__static_reflect_serial__reflect, comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that SCORE_STRUCT_VISITABLE registers the correct name, field count, and field names, and "
+                   "that visit() dispatches once per field, for structs with 1 to 20 fields.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
 
     EXPECT_TRUE(check_visitable<test::S1>("test::S1", 1));
     EXPECT_TRUE(check_visitable<test::S2>("test::S2", 2));
@@ -206,11 +208,12 @@ TEST(struct_visitor, struct_visitable)
 
 TEST(struct_visitor, visit_as)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check visitability of different structures fields.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that visit_as() and visit() both traverse every field of SCORE_STRUCT_VISITABLE-registered "
+                   "structs with 1 to 20 fields.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S1{}), 1);
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S2{}), 2);
     EXPECT_EQ(visit_as(test_visitor_t{}, test::S3{}), 3);
@@ -275,11 +278,12 @@ auto visit_as_struct(test_visitor2_t, S&&, Args&&...)
 
 TEST(struct_visitor, namespaces)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check visitability fields.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that struct_visitable field names and the visited type name are correctly resolved for "
+                   "structs declared in the global namespace versus a named namespace.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     using namespace ::score::common::visitor;
     EXPECT_EQ(struct_visitable<S1>::field_name(0), "x1");
     EXPECT_EQ(struct_visitable<test::S1>::field_name(0), "f1");
@@ -300,13 +304,12 @@ SCORE_STRUCT_VISITABLE(TemplateStructDefaultSize, arr)
 
 TEST(struct_visitor, TemplatedStructShallNotContainTrailingWhitespace)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
     RecordProperty("Description",
-                   "Verifies that the templated structs shall not contain trailing whaitspace."
-                   "serialization/deserialization.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+                   "Check that the compiler-generated trailing whitespace in a templated struct's pretty-function "
+                   "name is stripped from the name reported by visit().");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "error-guessing");
     using namespace ::score::common::visitor;
 
     // GCC inserts a trailing whitespace for templated structs in __PRETTY__FUNCTION__.
@@ -316,6 +319,11 @@ TEST(struct_visitor, TemplatedStructShallNotContainTrailingWhitespace)
 
 TEST(struct_visitor_utils, TupleToArrayTest)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__reflect");
+    RecordProperty("Description",
+                   "Check that tuple_to_array converts a tuple into a std::array of matching size and element order.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     const std::array<std::string, 4> reference = {"1", "2", "3", "4"};
     const auto result = ::score::common::visitor::detail::tuple_to_array(
         ::score::common::visitor::detail::pack_values("1", "2", "3", "4"));

--- a/score/static_reflection_with_serialization/visitor/test/ut/test_visitor.cpp
+++ b/score/static_reflection_with_serialization/visitor/test/ut/test_visitor.cpp
@@ -51,11 +51,12 @@ struct test_nonvisitable_t
 
 TEST(visitor, visitable_and_nonvisitable)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the visitability and the non-visitability.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that visit() dispatches to a type's visit_as overload when visitable, and falls back to "
+                   "conversion via visitable_type when no visit_as overload is found.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     test_visitable_t v1;
     test_nonvisitable_t nv1;
     EXPECT_EQ(::score::common::visitor::visit(test_visitor_t{}, v1), 123);
@@ -132,11 +133,12 @@ int visit_as(ns2::test_visitor_t, test_visitable_t)
 
 TEST(visitor, namespaces)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check visitability equality from different namespaces.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that visit() resolves the correct visit_as overload via argument-dependent lookup when "
+                   "the visitor and visitable types live in different namespaces.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(ns1::test_visitor_t{}, ns1::test_visitable_t{}), 11);
     EXPECT_EQ(visit(ns1::test_visitor_t{}, ns2::test_visitable_t{}), 12);
@@ -173,11 +175,12 @@ auto visit_as(const test_visitor_t&, int t)
 
 TEST(visitor, overloads)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the int and float overloads for 'visit' API.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that visit() picks the most specific visit_as overload between a generic scalar template "
+                   "and a non-template int overload.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(test_visitor_t{}, 42.0), 42.0);
     EXPECT_EQ(visit(test_visitor_t{}, 42), 6 * 9);
@@ -199,11 +202,12 @@ struct test_int_convertible_t
 
 TEST(visitor, conversions)
 {
-    RecordProperty("ParentRequirement", "SCR-1633893");
-    RecordProperty("ASIL", "B");
-    RecordProperty("Description", "Check the convertible argument passing to 'visit' API.");
-    RecordProperty("TestingTechnique", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "requirements-analysis");  // requirements
+    RecordProperty("PartiallyVerifies", "comp_req__static_reflect_serial__visitor");
+    RecordProperty("Description",
+                   "Check that visit() accepts an argument implicitly convertible to the target type and a visitor "
+                   "derived from the type expected by visit_as.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     using namespace ::score::common::visitor;
     EXPECT_EQ(visit(test_visitor_derived_t{}, test_int_convertible_t{42}), 6 * 9);
 }


### PR DESCRIPTION
## Summary

Part of the #522 test-to-requirement traceability cleanup, following [`.agents/skills/requirements-management-skill/test-to-requirement-linking.md`](../blob/main/.agents/skills/requirements-management-skill/test-to-requirement-linking.md).

`score/static_reflection_with_serialization` already had a full requirements doc (`docs/requirements/index.rst`, 6 `comp_req` entries) but all 41 tests used legacy `RecordProperty` metadata (`ParentRequirement` with `SCR-*` IDs, `ASIL`, `TestingTechnique`). This PR migrates every test to the current convention: `FullyVerifies`/`PartiallyVerifies` pointing at `comp_req__static_reflect_serial__*`, `TestType`, and `DerivationTechnique`, with a non-mechanical `Description` for each. No test bodies or assertions were changed.

### Files touched
- `serialization/test/ut/test_serializer_visitor.cpp` (23 tests)
- `serialization/test/ut/test_size_visitor.cpp` (1 `TYPED_TEST_P`)
- `serialization/test/ut/test_skip_deserialize.cpp` (2 tests)
- `serialization/test/ut/test_visitor_type_traits.cpp` (2 tests)
- `visitor/test/ut/test_detail.cpp` (2 tests)
- `visitor/test/ut/test_struct_visitor.cpp` (5 tests, one of which — `TupleToArrayTest` — had no `RecordProperty` at all and was linked from scratch)
- `visitor/test/ut/test_visitor.cpp` (4 tests)
- `visitor/examples/ostream/test/ut/test_ostream_visitor.cpp` (2 tests, already had `TestType`, added the missing `PartiallyVerifies`/`DerivationTechnique`)
