### PR TITLE
result: link tests to requirements

### DIFF
--- a/score/result/details/expected/expected_assignment_test.cpp
+++ b/score/result/details/expected/expected_assignment_test.cpp
@@ -25,6 +25,12 @@ namespace
 
 TEST(ExpectedTest, IsCopyAssignableWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that copy-assigning one value-holding expected to another replaces the target's value "
+                   "with the source's.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
     std::int32_t value{14};
     expected<CopyableType, ErrorType> e1{value};
@@ -42,6 +48,12 @@ TEST(ExpectedTest, IsCopyAssignableWithValue)
 
 TEST(ExpectedTest, IsCopyAssignableWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that copy-assigning one error-holding expected to another replaces the target's error "
+                   "with the source's.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different errors
     std::int32_t error{14};
     expected<ValueType, CopyableType> e1{unexpected{error}};
@@ -59,6 +71,11 @@ TEST(ExpectedTest, IsCopyAssignableWithError)
 
 TEST(ExpectedTest, IsMoveAssignableWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that move-assigning a value-holding expected transfers its value into the target.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
     std::int32_t value{14};
     expected<NothrowMoveOnlyType, ErrorType> e1{value};
@@ -74,6 +91,11 @@ TEST(ExpectedTest, IsMoveAssignableWithValue)
 
 TEST(ExpectedTest, IsMoveAssignableWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that move-assigning an error-holding expected transfers its error into the target.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different errors
     std::int32_t error{14};
     expected<ValueType, NothrowMoveOnlyType> e1{unexpected{error}};
@@ -89,6 +111,12 @@ TEST(ExpectedTest, IsMoveAssignableWithError)
 
 TEST(ExpectedTest, MoveAssignmentHasCorrectNoexcept)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__exception_free_operation");
+    RecordProperty("Description",
+                   "Check that expected's move assignment is noexcept only when both the value and error types "
+                   "are themselves nothrow move-assignable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(std::is_nothrow_move_assignable_v<expected<NothrowMoveOnlyType, NothrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_move_assignable_v<expected<NothrowMoveOnlyType, ThrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_move_assignable_v<expected<ThrowMoveOnlyType, NothrowMoveOnlyType>>);
@@ -96,6 +124,12 @@ TEST(ExpectedTest, MoveAssignmentHasCorrectNoexcept)
 
 TEST(ExpectedTest, CanCopyAssignFromCompatibleType)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that assigning a value of a compatible type sets the expected to hold that value and "
+                   "returns a reference to the expected itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable type and an expected
     std::int32_t value{14};
     CopyableType wrapped{14};
@@ -114,6 +148,12 @@ TEST(ExpectedTest, CanCopyAssignFromCompatibleType)
 
 TEST(ExpectedTest, CanMoveAssignFromCompatibleType)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that move-assigning a value of a compatible type sets the expected to hold that value "
+                   "and returns a reference to the expected itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable type and an expected
     std::int32_t value{14};
     NothrowMoveOnlyType wrapped{14};
@@ -132,6 +172,12 @@ TEST(ExpectedTest, CanMoveAssignFromCompatibleType)
 
 TEST(ExpectedTest, CanCopyAssignFromUnexpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that assigning an unexpected of a compatible type sets the expected to hold that error "
+                   "and returns a reference to the expected itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable unexpected and an expected
     std::int32_t error{14};
     unexpected<CopyableType> wrapped{error};
@@ -150,6 +196,12 @@ TEST(ExpectedTest, CanCopyAssignFromUnexpected)
 
 TEST(ExpectedTest, CanMoveAssignFromUnexpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that move-assigning an unexpected of a compatible type sets the expected to hold that "
+                   "error and returns a reference to the expected itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable unexpected and an expected
     std::int32_t error{14};
     unexpected<NothrowMoveOnlyType> wrapped{error};
@@ -168,6 +220,12 @@ TEST(ExpectedTest, CanMoveAssignFromUnexpected)
 
 TEST(ExpectedTest, CanEmplaceWithArgs)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that emplace() constructs the held value in place from forwarded constructor arguments "
+                   "and returns a reference to that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with error
     expected<ArgumentType, ErrorType> unit{unexpect};
     std::int32_t copyable{29};
@@ -188,6 +246,12 @@ TEST(ExpectedTest, CanEmplaceWithArgs)
 
 TEST(ExpectedTest, CanEmplaceWithInitializerListAndArgs)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that emplace() constructs the held value in place from an initializer list plus "
+                   "forwarded constructor arguments.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with error
     expected<ArgumentInitializerListType, ErrorType> unit{unexpect};
     std::int32_t copyable{29};
@@ -208,6 +272,10 @@ TEST(ExpectedTest, CanEmplaceWithInitializerListAndArgs)
 
 TEST(ExpectedTest, CanSwapWithMemberSwap)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that the member swap() function exchanges the value/error states of two expected instances.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
     std::int32_t v1{82};
     expected<CopyableType, NothrowMoveOnlyType> e1{v1};
@@ -226,6 +294,12 @@ TEST(ExpectedTest, CanSwapWithMemberSwap)
 
 TEST(ExpectedTest, SwapHasCorrectNoexceptSpecification)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__exception_free_operation");
+    RecordProperty("Description",
+                   "Check that expected's swap is noexcept only when both the value and error types are "
+                   "themselves nothrow swappable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(std::is_nothrow_swappable_v<expected<NothrowMoveOnlyType, NothrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_swappable_v<expected<ThrowMoveOnlyType, NothrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_swappable_v<expected<NothrowMoveOnlyType, ThrowMoveOnlyType>>);
@@ -233,6 +307,10 @@ TEST(ExpectedTest, SwapHasCorrectNoexceptSpecification)
 
 TEST(ExpectedTest, CanSwapWithStdSwap)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that std::swap exchanges the value/error states of two expected instances.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
     std::int32_t v1{82};
     expected<CopyableType, NothrowMoveOnlyType> e1{v1};
@@ -251,6 +329,12 @@ TEST(ExpectedTest, CanSwapWithStdSwap)
 
 TEST(ExpectedVoidTest, IsCopyAssignableWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that copy-assigning an error-holding expected<void, E> replaces the target's error with "
+                   "the source's.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different errors
     std::int32_t error{14};
     expected<void, CopyableType> e1{unexpected{error}};
@@ -268,6 +352,12 @@ TEST(ExpectedVoidTest, IsCopyAssignableWithError)
 
 TEST(ExpectedVoidTest, IsMoveAssignableWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that move-assigning an error-holding expected<void, E> transfers its error into the "
+                   "target.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different errors
     std::int32_t error{14};
     expected<void, NothrowMoveOnlyType> e1{unexpected{error}};
@@ -283,12 +373,24 @@ TEST(ExpectedVoidTest, IsMoveAssignableWithError)
 
 TEST(ExpectedVoidTest, MoveAssignmentHasCorrectNoexcept)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__exception_free_operation");
+    RecordProperty("Description",
+                   "Check that expected<void, E>'s move assignment is noexcept only when E is itself nothrow "
+                   "move-assignable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(std::is_nothrow_move_assignable_v<expected<void, NothrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_move_assignable_v<expected<void, ThrowMoveOnlyType>>);
 }
 
 TEST(ExpectedVoidTest, CanCopyAssignFromUnexpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that assigning an unexpected of a compatible type sets a value-less expected<void, E> "
+                   "to hold that error and returns a reference to the expected itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable unexpected and an expected
     std::int32_t error{14};
     unexpected<CopyableType> wrapped{error};
@@ -307,6 +409,12 @@ TEST(ExpectedVoidTest, CanCopyAssignFromUnexpected)
 
 TEST(ExpectedVoidTest, CanMoveAssignFromUnexpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that move-assigning an unexpected of a compatible type sets a value-less "
+                   "expected<void, E> to hold that error and returns a reference to the expected itself.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable unexpected and an expected
     std::int32_t error{14};
     unexpected<NothrowMoveOnlyType> wrapped{error};
@@ -325,6 +433,10 @@ TEST(ExpectedVoidTest, CanMoveAssignFromUnexpected)
 
 TEST(ExpectedVoidTest, CanEmplace)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description", "Check that emplace() on a value-less expected<void, E> puts it into the valid state.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with error
     expected<void, ErrorType> unit{unexpect};
 
@@ -337,6 +449,10 @@ TEST(ExpectedVoidTest, CanEmplace)
 
 TEST(ExpectedVoidTest, CanSwapWithMemberSwap)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that the member swap() function exchanges the states of two expected<void, E> instances.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
     expected<void, NothrowMoveOnlyType> e1{};
     std::int32_t error{30};
@@ -353,12 +469,21 @@ TEST(ExpectedVoidTest, CanSwapWithMemberSwap)
 
 TEST(ExpectedVoidTest, SwapHasCorrectNoexceptSpecification)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__exception_free_operation");
+    RecordProperty("Description",
+                   "Check that expected<void, E>'s swap is noexcept only when E is itself nothrow swappable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(std::is_nothrow_swappable_v<expected<void, NothrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_swappable_v<expected<void, ThrowMoveOnlyType>>);
 }
 
 TEST(ExpectedVoidTest, CanSwapWithStdSwap)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that std::swap exchanges the states of two expected<void, E> instances.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
     expected<void, NothrowMoveOnlyType> e1{};
     std::int32_t error{30};

--- a/score/result/details/expected/expected_assignment_test.cpp
+++ b/score/result/details/expected/expected_assignment_test.cpp
@@ -273,7 +273,8 @@ TEST(ExpectedTest, CanEmplaceWithInitializerListAndArgs)
 TEST(ExpectedTest, CanSwapWithMemberSwap)
 {
     RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
-    RecordProperty("Description", "Check that the member swap() function exchanges the value/error states of two expected instances.");
+    RecordProperty("Description",
+                   "Check that the member swap() function exchanges the value/error states of two expected instances.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values
@@ -434,7 +435,8 @@ TEST(ExpectedVoidTest, CanMoveAssignFromUnexpected)
 TEST(ExpectedVoidTest, CanEmplace)
 {
     RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
-    RecordProperty("Description", "Check that emplace() on a value-less expected<void, E> puts it into the valid state.");
+    RecordProperty("Description",
+                   "Check that emplace() on a value-less expected<void, E> puts it into the valid state.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with error
@@ -450,7 +452,8 @@ TEST(ExpectedVoidTest, CanEmplace)
 TEST(ExpectedVoidTest, CanSwapWithMemberSwap)
 {
     RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
-    RecordProperty("Description", "Check that the member swap() function exchanges the states of two expected<void, E> instances.");
+    RecordProperty("Description",
+                   "Check that the member swap() function exchanges the states of two expected<void, E> instances.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two expected with different values

--- a/score/result/details/expected/expected_constructor_test.cpp
+++ b/score/result/details/expected/expected_constructor_test.cpp
@@ -25,6 +25,12 @@ namespace
 
 TEST(ExpectedTest, IsDefaultConstructibleWhenValueTypeIsDefaultConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<T, E> is default constructible and holds a default-constructed value "
+                   "when T is default constructible.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a default-constructible type
     class DefaultConstructibleType
     {
@@ -42,6 +48,11 @@ TEST(ExpectedTest, IsDefaultConstructibleWhenValueTypeIsDefaultConstructible)
 
 TEST(ExpectedTest, IsNotDefaultConstructibleWhenValueTypeIsNotDefaultConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<T, E> is not default constructible when T is not default constructible.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a non-default-constructible type
     class NonDefaultConstructibleType
     {
@@ -55,6 +66,12 @@ TEST(ExpectedTest, IsNotDefaultConstructibleWhenValueTypeIsNotDefaultConstructib
 
 TEST(ExpectedTest, IsCopyConstructibleWhenInnerTypesAreCopyConstructibleAndWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that a value-holding expected<T, E> is trivially copy constructible when T and E are, "
+                   "and that the copy holds the same value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected initialized with a copyable value
     std::int32_t value{14};
     expected<CopyableType, ErrorType> unit{value};
@@ -72,6 +89,12 @@ TEST(ExpectedTest, IsCopyConstructibleWhenInnerTypesAreCopyConstructibleAndWithV
 
 TEST(ExpectedTest, IsCopyConstructibleWhenInnerTypesAreCopyConstructibleAndWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that an error-holding expected<T, E> is trivially copy constructible when T and E are, "
+                   "and that the copy holds the same error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an unexpected initialized with a copyable error
     std::int32_t value{14};
     unexpected<CopyableType> wrapped{value};
@@ -90,12 +113,23 @@ TEST(ExpectedTest, IsCopyConstructibleWhenInnerTypesAreCopyConstructibleAndWithE
 
 TEST(ExpectedTest, IsNotCopyConstructibleWhenInnerTypesAreNotCopyConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<T, E> is not copy constructible when either T or E is not copyable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(!std::is_copy_constructible_v<expected<CopyableType, NothrowMoveOnlyType>>);
     static_assert(!std::is_copy_constructible_v<expected<NothrowMoveOnlyType, CopyableType>>);
 }
 
 TEST(ExpectedTest, IsMoveConstructibleWhenInnerTypesAreMoveConstructibleAndWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that a value-holding expected<T, E> is trivially move constructible when T and E are, "
+                   "and that the value is transferred to the moved-to instance.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected initialized with a move-only value
     std::int32_t value{14};
     expected<NothrowMoveOnlyType, ErrorType> unit{value};
@@ -112,6 +146,12 @@ TEST(ExpectedTest, IsMoveConstructibleWhenInnerTypesAreMoveConstructibleAndWithV
 
 TEST(ExpectedTest, IsMoveConstructibleWhenInnerTypesAreMoveConstructibleAndWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that an error-holding expected<T, E> is trivially move constructible when T and E are, "
+                   "and that the error is transferred to the moved-to instance.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected initialized with a move-only value
     std::int32_t value{14};
     expected<ValueType, NothrowMoveOnlyType> unit{unexpected{value}};
@@ -128,12 +168,23 @@ TEST(ExpectedTest, IsMoveConstructibleWhenInnerTypesAreMoveConstructibleAndWithE
 
 TEST(ExpectedTest, IsNotMoveConstructibleWhenInnerTypesAreNotMoveConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<T, E> is not move constructible when either T or E is not movable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(!std::is_move_constructible_v<expected<NothrowMoveOnlyType, UnmovableType>>);
     static_assert(!std::is_move_constructible_v<expected<UnmovableType, NothrowMoveOnlyType>>);
 }
 
 TEST(ExpectedTest, IsOnlyNothrowMoveConstructibleIfInnerTypesAre)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__exception_free_operation");
+    RecordProperty("Description",
+                   "Check that expected<T, E>'s move constructor is noexcept only when both T and E are "
+                   "themselves nothrow move constructible.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(!std::is_nothrow_move_constructible_v<expected<ThrowMoveOnlyType, ThrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_move_constructible_v<expected<NothrowMoveOnlyType, ThrowMoveOnlyType>>);
     static_assert(!std::is_nothrow_move_constructible_v<expected<ThrowMoveOnlyType, NothrowMoveOnlyType>>);
@@ -142,6 +193,12 @@ TEST(ExpectedTest, IsOnlyNothrowMoveConstructibleIfInnerTypesAre)
 
 TEST(ExpectedTest, CanCopyConstructFromCompatibleExpectedWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected holding a value can be copy constructed from another expected with a "
+                   "convertible value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with a value
     std::int32_t value{14};
     expected<CopyableType, ErrorType> e1{value};
@@ -157,6 +214,12 @@ TEST(ExpectedTest, CanCopyConstructFromCompatibleExpectedWithValue)
 
 TEST(ExpectedTest, CanCopyConstructFromCompatibleExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected holding an error can be copy constructed from another expected with a "
+                   "convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with an error
     std::int32_t error{14};
     unexpected<CopyableType> wrapped{error};
@@ -173,6 +236,12 @@ TEST(ExpectedTest, CanCopyConstructFromCompatibleExpectedWithError)
 
 TEST(ExpectedTest, CanMoveConstructFromCompatibleExpectedWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected holding a value can be move constructed from another expected with a "
+                   "convertible value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with a value
     std::int32_t value{14};
     expected<NothrowMoveOnlyType, ErrorType> e1{value};
@@ -187,6 +256,12 @@ TEST(ExpectedTest, CanMoveConstructFromCompatibleExpectedWithValue)
 
 TEST(ExpectedTest, CanMoveConstructFromCompatibleExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected holding an error can be move constructed from another expected with a "
+                   "convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with an error
     std::int32_t error{14};
     expected<ValueType, NothrowMoveOnlyType> e1{unexpected{error}};
@@ -201,6 +276,11 @@ TEST(ExpectedTest, CanMoveConstructFromCompatibleExpectedWithError)
 
 TEST(ExpectedTest, CanCopyConstructFromCompatibleTypeWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected can be copy constructed directly from a value of a convertible type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable value
     std::int32_t value{14};
     CopyableType wrapped{value};
@@ -215,6 +295,12 @@ TEST(ExpectedTest, CanCopyConstructFromCompatibleTypeWithValue)
 
 TEST(ExpectedTest, CanMoveConstructFromCompatibleTypeWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected can be move constructed directly from a move-only value of a "
+                   "convertible type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a move-only a value
     std::int32_t value{14};
     NothrowMoveOnlyType wrapped{value};
@@ -229,6 +315,12 @@ TEST(ExpectedTest, CanMoveConstructFromCompatibleTypeWithValue)
 
 TEST(ExpectedTest, CanCopyConstructFromCompatibleTypeWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected can be copy constructed directly from an unexpected of a convertible "
+                   "error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable error
     std::int32_t error{14};
     unexpected<CopyableType> wrapped{error};
@@ -243,6 +335,12 @@ TEST(ExpectedTest, CanCopyConstructFromCompatibleTypeWithError)
 
 TEST(ExpectedTest, CanMoveConstructFromCompatibleTypeWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an expected can be move constructed directly from an unexpected of a move-only, "
+                   "convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a move-only error
     std::int32_t error{14};
     NothrowMoveOnlyType wrapped{error};
@@ -257,6 +355,12 @@ TEST(ExpectedTest, CanMoveConstructFromCompatibleTypeWithError)
 
 TEST(ExpectedTest, CanInPlaceConstructValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected can be constructed in place, forwarding constructor arguments directly to "
+                   "the value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::int32_t copyable{15};
     std::int32_t moveonly{17};
 
@@ -271,6 +375,12 @@ TEST(ExpectedTest, CanInPlaceConstructValue)
 
 TEST(ExpectedTest, CanInPlaceConstructValueWithInitializerList)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected can be constructed in place from an initializer list plus additional "
+                   "constructor arguments forwarded to the value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::int32_t copyable{15};
     std::int32_t moveonly{17};
 
@@ -286,6 +396,12 @@ TEST(ExpectedTest, CanInPlaceConstructValueWithInitializerList)
 
 TEST(ExpectedTest, CanInPlaceConstructError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected can be constructed in an error state in place, forwarding constructor "
+                   "arguments directly to the error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::int32_t copyable{15};
     std::int32_t moveonly{17};
 
@@ -300,6 +416,12 @@ TEST(ExpectedTest, CanInPlaceConstructError)
 
 TEST(ExpectedTest, CanInPlaceConstructErrorWithInitializerList)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected can be constructed in an error state in place from an initializer list "
+                   "plus additional constructor arguments forwarded to the error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::int32_t copyable{15};
     std::int32_t moveonly{17};
 
@@ -315,11 +437,23 @@ TEST(ExpectedTest, CanInPlaceConstructErrorWithInitializerList)
 
 TEST(ExpectedTest, IsTriviallyDestructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__deterministic_behavior");
+    RecordProperty("Description",
+                   "Check that expected<T, E> is trivially destructible when T and E are, avoiding any dynamic "
+                   "cleanup on teardown.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(std::is_trivially_destructible_v<expected<ValueType, ErrorType>>);
 }
 
 TEST(ExpectedTest, CanWrapExpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that an expected can itself be used as the value type of another expected, preserving "
+                   "constructibility, copyability, and movability.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(std::is_constructible_v<expected<expected<ValueType, ErrorType>, ErrorType>>);
     static_assert(std::is_copy_constructible_v<expected<expected<ValueType, ErrorType>, ErrorType>>);
     static_assert(std::is_move_constructible_v<expected<expected<ValueType, ErrorType>, ErrorType>>);
@@ -329,6 +463,12 @@ TEST(ExpectedTest, CanWrapExpected)
 
 TEST(ExpectedVoidTest, IsDefaultConstructibleWhenValueTypeIsVoid)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<void, E> is default constructible and default-constructs into the valid "
+                   "state.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given default-constructing expected with void type
     expected<void, ErrorType> expected{};
 
@@ -338,6 +478,12 @@ TEST(ExpectedVoidTest, IsDefaultConstructibleWhenValueTypeIsVoid)
 
 TEST(ExpectedVoidTest, IsCopyConstructibleWhenErrorIsCopyConstructuble)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<void, E> is trivially copy constructible when E is, and that the copy "
+                   "holds the same error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a void expected initialized with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -356,11 +502,21 @@ TEST(ExpectedVoidTest, IsCopyConstructibleWhenErrorIsCopyConstructuble)
 
 TEST(ExpectedVoidTest, IsNotCopyConstructibleWhenErrorIsNotCopyConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that expected<void, E> is not copy constructible when E is not copyable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(!std::is_copy_constructible_v<expected<void, NothrowMoveOnlyType>>);
 }
 
 TEST(ExpectedVoidTest, IsMoveConstructibleWhenErrorisMoveConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<void, E> is trivially move constructible when E is, and that the error "
+                   "is transferred to the moved-to instance.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected initialized with a move-only error
     std::int32_t error{14};
     expected<void, NothrowMoveOnlyType> unit{unexpected{error}};
@@ -377,17 +533,33 @@ TEST(ExpectedVoidTest, IsMoveConstructibleWhenErrorisMoveConstructible)
 
 TEST(ExpectedVoidTest, IsNotMoveConstructibleWhenErrorIsNotMoveConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that expected<void, E> is not move constructible when E is not movable.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(!std::is_move_constructible_v<expected<void, UnmovableType>>);
 }
 
 TEST(ExpectedVoidTest, IsOnlyNothrowMoveConstructibleIfErrorIs)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__exception_free_operation");
+    RecordProperty("Description",
+                   "Check that expected<void, E>'s move constructor is noexcept only when E is itself nothrow "
+                   "move constructible.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     static_assert(!std::is_nothrow_move_constructible_v<expected<void, ThrowMoveOnlyType>>);
     static_assert(std::is_nothrow_move_constructible_v<expected<void, NothrowMoveOnlyType>>);
 }
 
 TEST(ExpectedVoidTest, CanCopyConstructFromCompatibleExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an error-holding expected<void, E> can be copy constructed from another "
+                   "expected<void, E> with a convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with an error
     std::int32_t error{14};
     unexpected<CopyableType> wrapped{error};
@@ -404,6 +576,12 @@ TEST(ExpectedVoidTest, CanCopyConstructFromCompatibleExpectedWithError)
 
 TEST(ExpectedVoidTest, CanMoveConstructFromCompatibleExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that an error-holding expected<void, E> can be move constructed from another "
+                   "expected<void, E> with a convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an expected with an error
     std::int32_t error{14};
     expected<void, NothrowMoveOnlyType> e1{unexpected{error}};
@@ -418,6 +596,12 @@ TEST(ExpectedVoidTest, CanMoveConstructFromCompatibleExpectedWithError)
 
 TEST(ExpectedVoidTest, CanCopyConstructFromCompatibleTypeWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected<void, E> can be copy constructed directly from an unexpected of a "
+                   "convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a copyable error
     std::int32_t error{14};
     unexpected<CopyableType> wrapped{error};
@@ -432,6 +616,12 @@ TEST(ExpectedVoidTest, CanCopyConstructFromCompatibleTypeWithError)
 
 TEST(ExpectedVoidTest, CanMoveConstructFromCompatibleTypeWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected<void, E> can be move constructed directly from an unexpected of a "
+                   "move-only, convertible error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a move-only error
     std::int32_t error{14};
     NothrowMoveOnlyType wrapped{error};
@@ -446,6 +636,10 @@ TEST(ExpectedVoidTest, CanMoveConstructFromCompatibleTypeWithError)
 
 TEST(ExpectedVoidTest, CanInPlaceConstruct)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description", "Check that expected<void, E> can be constructed in place into the valid state.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // When constructing an expected in-place
     expected<void, ErrorType> unit{std::in_place};
 
@@ -455,6 +649,12 @@ TEST(ExpectedVoidTest, CanInPlaceConstruct)
 
 TEST(ExpectedVoidTest, CanInPlaceConstructError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected<void, E> can be constructed in an error state in place, forwarding "
+                   "constructor arguments directly to the error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::int32_t copyable{15};
     std::int32_t moveonly{17};
 
@@ -469,6 +669,12 @@ TEST(ExpectedVoidTest, CanInPlaceConstructError)
 
 TEST(ExpectedVoidTest, CanInPlaceConstructErrorWithInitializerList)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that expected<void, E> can be constructed in an error state in place from an "
+                   "initializer list plus additional constructor arguments forwarded to the error type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::int32_t copyable{15};
     std::int32_t moveonly{17};
 
@@ -483,11 +689,23 @@ TEST(ExpectedVoidTest, CanInPlaceConstructErrorWithInitializerList)
 
 TEST(ExpectedVoidTest, IsTriviallyDestructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__deterministic_behavior");
+    RecordProperty("Description",
+                   "Check that expected<void, E> is trivially destructible when E is, avoiding any dynamic "
+                   "cleanup on teardown.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(std::is_trivially_destructible_v<expected<void, ErrorType>>);
 }
 
 TEST(ExpectedVoidTest, CanWrapExpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that a value-less expected<void, E> can itself be used as the value type of another "
+                   "expected, preserving constructibility, copyability, and movability.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(std::is_constructible_v<expected<expected<void, ErrorType>, ErrorType>>);
     static_assert(std::is_copy_constructible_v<expected<expected<void, ErrorType>, ErrorType>>);
     static_assert(std::is_move_constructible_v<expected<expected<void, ErrorType>, ErrorType>>);

--- a/score/result/details/expected/expected_equality_test.cpp
+++ b/score/result/details/expected/expected_equality_test.cpp
@@ -49,6 +49,12 @@ bool operator==(const B1& b1, const B2& b2)
 
 TEST(ExpectedTest, EqualityBetweenExpectedBothWithValues)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that two expected holding values of different but comparable types compare equal iff "
+                   "the values compare equal.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given three expected with different but comparable types where the first two shall compare equal and the third
     // not
     std::int32_t same{46};
@@ -65,6 +71,12 @@ TEST(ExpectedTest, EqualityBetweenExpectedBothWithValues)
 
 TEST(ExpectedTest, EqualityBetweenExpectedBothWithErrors)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that two expected holding errors of different but comparable types compare equal iff "
+                   "the errors compare equal.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given three expected with different but comparable types where the first two shall compare equal and the third
     // not
     std::int32_t same{46};
@@ -81,6 +93,12 @@ TEST(ExpectedTest, EqualityBetweenExpectedBothWithErrors)
 
 TEST(ExpectedTest, EqualityBetweenExpectedWithValueAndError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that an expected holding a value never compares equal to one holding an error, "
+                   "regardless of the contained types.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given two expected with different but comparable types where one has a value and the other an error
     std::int32_t same{46};
     expected<A1, B1> lhs{A1{same}};
@@ -93,6 +111,12 @@ TEST(ExpectedTest, EqualityBetweenExpectedWithValueAndError)
 
 TEST(ExpectedTest, EqualityBetweenExpectedAndValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that an expected compares equal to a bare value of a comparable type iff it holds a "
+                   "matching value, and never compares equal while holding an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given two expected and two values where only lhs_value and rhs_same shall be equal
     std::int32_t same{46};
     expected<A1, B1> lhs_value{A1{same}};
@@ -111,6 +135,12 @@ TEST(ExpectedTest, EqualityBetweenExpectedAndValue)
 
 TEST(ExpectedTest, EqualityBetweenExpectedAndUnexpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that an expected compares equal to an unexpected wrapping a comparable error type iff it "
+                   "holds a matching error, and never compares equal while holding a value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given two expected and two values where only lhs_value and rhs_same shall be equal
     std::int32_t same{46};
     expected<A1, B1> lhs_value{A1{same}};
@@ -129,6 +159,12 @@ TEST(ExpectedTest, EqualityBetweenExpectedAndUnexpected)
 
 TEST(ExpectedVoidTest, EqualityBetweenExpectedBothWithErrors)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that two value-less expected<void, E> holding errors of different but comparable types "
+                   "compare equal iff the errors compare equal.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given three expected with different but comparable types where the first two shall compare equal and the third
     // not
     std::int32_t same{46};
@@ -145,6 +181,11 @@ TEST(ExpectedVoidTest, EqualityBetweenExpectedBothWithErrors)
 
 TEST(ExpectedVoidTest, EqualityBetweenExpectedWithValueAndError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that a valid expected<void, E> never compares equal to one holding an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given two expected with different but comparable types where one has a value and the other an error
     std::int32_t error{46};
     expected<void, B1> lhs{};
@@ -157,6 +198,12 @@ TEST(ExpectedVoidTest, EqualityBetweenExpectedWithValueAndError)
 
 TEST(ExpectedVoidTest, EqualityBetweenExpectedAndUnexpected)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that an expected<void, E> compares equal to an unexpected wrapping a comparable error "
+                   "type iff it holds a matching error, and never compares equal while valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given two expected and two values where only lhs_value and rhs_same shall be equal
     std::int32_t same{46};
     expected<void, B1> lhs_value{};

--- a/score/result/details/expected/expected_equality_test.cpp
+++ b/score/result/details/expected/expected_equality_test.cpp
@@ -182,8 +182,7 @@ TEST(ExpectedVoidTest, EqualityBetweenExpectedBothWithErrors)
 TEST(ExpectedVoidTest, EqualityBetweenExpectedWithValueAndError)
 {
     RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
-    RecordProperty("Description",
-                   "Check that a valid expected<void, E> never compares equal to one holding an error.");
+    RecordProperty("Description", "Check that a valid expected<void, E> never compares equal to one holding an error.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given two expected with different but comparable types where one has a value and the other an error

--- a/score/result/details/expected/expected_monadic_operator_test.cpp
+++ b/score/result/details/expected/expected_monadic_operator_test.cpp
@@ -24,6 +24,12 @@ namespace
 
 TEST(ExpectedTest, AndThenLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an lvalue expected holding a value invokes the given function with "
+                   "that value and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -44,6 +50,12 @@ TEST(ExpectedTest, AndThenLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, AndThenLValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an lvalue expected holding an error skips the given function and "
+                   "propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -63,6 +75,12 @@ TEST(ExpectedTest, AndThenLValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, AndThenLValueConstRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-lvalue expected holding a value invokes the given function "
+                   "with that value and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -83,6 +101,12 @@ TEST(ExpectedTest, AndThenLValueConstRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, AndThenLValueConstRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-lvalue expected holding an error skips the given function "
+                   "and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -102,6 +126,12 @@ TEST(ExpectedTest, AndThenLValueConstRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, AndThenRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an rvalue expected holding a value invokes the given function with "
+                   "the moved-out value and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -123,6 +153,12 @@ TEST(ExpectedTest, AndThenRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, AndThenRValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an rvalue expected holding an error skips the given function and "
+                   "propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -142,6 +178,12 @@ TEST(ExpectedTest, AndThenRValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, AndThenRValueConstRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-rvalue expected holding a value invokes the given function "
+                   "with that value and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -163,6 +205,12 @@ TEST(ExpectedTest, AndThenRValueConstRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, AndThenRValueConstRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-rvalue expected holding an error skips the given function "
+                   "and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -182,6 +230,12 @@ TEST(ExpectedTest, AndThenRValueConstRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, OrElseLValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an lvalue expected holding an error invokes the given function with "
+                   "that error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -203,6 +257,12 @@ TEST(ExpectedTest, OrElseLValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedTest, OrElseLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an lvalue expected holding a value skips the given function and "
+                   "propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -222,6 +282,12 @@ TEST(ExpectedTest, OrElseLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, OrElseConstLValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-lvalue expected holding an error invokes the given function "
+                   "with that error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -243,6 +309,12 @@ TEST(ExpectedTest, OrElseConstLValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedTest, OrElseConstLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-lvalue expected holding a value skips the given function and "
+                   "propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -262,6 +334,12 @@ TEST(ExpectedTest, OrElseConstLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, OrElseRValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an rvalue expected holding an error invokes the given function with "
+                   "the moved-out error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -283,6 +361,12 @@ TEST(ExpectedTest, OrElseRValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedTest, OrElseRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an rvalue expected holding a value skips the given function and "
+                   "propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -302,6 +386,12 @@ TEST(ExpectedTest, OrElseRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, OrElseConstRValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-rvalue expected holding an error invokes the given function "
+                   "with that error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -323,6 +413,12 @@ TEST(ExpectedTest, OrElseConstRValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedTest, OrElseConstRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-rvalue expected holding a value skips the given function and "
+                   "propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -342,6 +438,12 @@ TEST(ExpectedTest, OrElseConstRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, TransformLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an lvalue expected holding a value invokes the given function with "
+                   "that value and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -362,6 +464,12 @@ TEST(ExpectedTest, TransformLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformLValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an lvalue expected holding an error skips the given function and "
+                   "propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -381,6 +489,12 @@ TEST(ExpectedTest, TransformLValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, TransformConstLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-lvalue expected holding a value invokes the given function "
+                   "with that value and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -401,6 +515,12 @@ TEST(ExpectedTest, TransformConstLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformConstLValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-lvalue expected holding an error skips the given function "
+                   "and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -420,6 +540,12 @@ TEST(ExpectedTest, TransformConstLValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, TransformRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an rvalue expected holding a value invokes the given function with "
+                   "the moved-out value and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -441,6 +567,12 @@ TEST(ExpectedTest, TransformRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformRValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an rvalue expected holding an error skips the given function and "
+                   "propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -460,6 +592,12 @@ TEST(ExpectedTest, TransformRValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, TransformConstRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-rvalue expected holding a value invokes the given function "
+                   "with that value and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -481,6 +619,12 @@ TEST(ExpectedTest, TransformConstRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformConstRValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-rvalue expected holding an error skips the given function "
+                   "and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -500,6 +644,12 @@ TEST(ExpectedTest, TransformConstRValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedTest, TransformErrorLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an lvalue expected holding an error invokes the given "
+                   "function with that error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -520,6 +670,12 @@ TEST(ExpectedTest, TransformErrorLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformErrorLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an lvalue expected holding a value skips the given function "
+                   "and propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -539,6 +695,12 @@ TEST(ExpectedTest, TransformErrorLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, TransformErrorConstLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-lvalue expected holding an error invokes the given "
+                   "function with that error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -559,6 +721,12 @@ TEST(ExpectedTest, TransformErrorConstLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformErrorConstLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-lvalue expected holding a value skips the given "
+                   "function and propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -578,6 +746,12 @@ TEST(ExpectedTest, TransformErrorConstLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, TransformErrorRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an rvalue expected holding an error invokes the given "
+                   "function with the moved-out error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -599,6 +773,12 @@ TEST(ExpectedTest, TransformErrorRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformErrorRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an rvalue expected holding a value skips the given function "
+                   "and propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -618,6 +798,12 @@ TEST(ExpectedTest, TransformErrorRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedTest, TransformErrorConstRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-rvalue expected holding an error invokes the given "
+                   "function with that error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -639,6 +825,12 @@ TEST(ExpectedTest, TransformErrorConstRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedTest, TransformErrorConstRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-rvalue expected holding a value skips the given "
+                   "function and propagates the rebound value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{83};
     CopyableType wrapped{value};
@@ -658,6 +850,12 @@ TEST(ExpectedTest, TransformErrorConstRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, AndThenLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an lvalue void-valued expected that is valid invokes the given "
+                   "function and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -676,6 +874,12 @@ TEST(ExpectedVoidTest, AndThenLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, AndThenLValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an lvalue void-valued expected holding an error skips the given "
+                   "function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -695,6 +899,12 @@ TEST(ExpectedVoidTest, AndThenLValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, AndThenLValueConstRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-lvalue void-valued expected that is valid invokes the given "
+                   "function and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, ErrorType> unit{};
 
@@ -713,6 +923,12 @@ TEST(ExpectedVoidTest, AndThenLValueConstRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, AndThenLValueConstRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-lvalue void-valued expected holding an error skips the given "
+                   "function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -732,6 +948,12 @@ TEST(ExpectedVoidTest, AndThenLValueConstRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, AndThenRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an rvalue void-valued expected that is valid invokes the given "
+                   "function and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -750,6 +972,12 @@ TEST(ExpectedVoidTest, AndThenRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, AndThenRValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on an rvalue void-valued expected holding an error skips the given "
+                   "function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -769,6 +997,12 @@ TEST(ExpectedVoidTest, AndThenRValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, AndThenRValueConstRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-rvalue void-valued expected that is valid invokes the given "
+                   "function and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, ErrorType> unit{};
 
@@ -787,6 +1021,12 @@ TEST(ExpectedVoidTest, AndThenRValueConstRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, AndThenRValueConstRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that and_then() on a const-rvalue void-valued expected holding an error skips the given "
+                   "function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -806,6 +1046,12 @@ TEST(ExpectedVoidTest, AndThenRValueConstRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, OrElseLValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an lvalue void-valued expected holding an error invokes the given "
+                   "function with that error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -826,6 +1072,12 @@ TEST(ExpectedVoidTest, OrElseLValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedVoidTest, OrElseLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an lvalue void-valued expected that is valid skips the given "
+                   "function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -842,6 +1094,12 @@ TEST(ExpectedVoidTest, OrElseLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, OrElseConstLValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-lvalue void-valued expected holding an error invokes the "
+                   "given function with that error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -862,6 +1120,12 @@ TEST(ExpectedVoidTest, OrElseConstLValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedVoidTest, OrElseConstLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-lvalue void-valued expected that is valid skips the given "
+                   "function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const expected<void, ErrorType> unit{};
 
@@ -878,6 +1142,12 @@ TEST(ExpectedVoidTest, OrElseConstLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, OrElseRValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an rvalue void-valued expected holding an error invokes the given "
+                   "function with the moved-out error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -899,6 +1169,12 @@ TEST(ExpectedVoidTest, OrElseRValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedVoidTest, OrElseRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on an rvalue void-valued expected that is valid skips the given function "
+                   "and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -915,6 +1191,12 @@ TEST(ExpectedVoidTest, OrElseRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, OrElseConstRValueRefWillCallFunctionIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-rvalue void-valued expected holding an error invokes the "
+                   "given function with that error and returns its result.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -936,6 +1218,12 @@ TEST(ExpectedVoidTest, OrElseConstRValueRefWillCallFunctionIfHasNoValue)
 
 TEST(ExpectedVoidTest, OrElseConstRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that or_else() on a const-rvalue void-valued expected that is valid skips the given "
+                   "function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, ErrorType> unit{};
 
@@ -952,6 +1240,12 @@ TEST(ExpectedVoidTest, OrElseConstRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, TransformLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an lvalue void-valued expected that is valid invokes the given "
+                   "function and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -970,6 +1264,12 @@ TEST(ExpectedVoidTest, TransformLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, TransformLValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an lvalue void-valued expected holding an error skips the given "
+                   "function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -989,6 +1289,12 @@ TEST(ExpectedVoidTest, TransformLValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, TransformConstLValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-lvalue void-valued expected that is valid invokes the "
+                   "given function and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, ErrorType> unit{};
 
@@ -1007,6 +1313,12 @@ TEST(ExpectedVoidTest, TransformConstLValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, TransformConstLValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-lvalue void-valued expected holding an error skips the "
+                   "given function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1026,6 +1338,12 @@ TEST(ExpectedVoidTest, TransformConstLValueRefWillReturnReboundErrorIfHasNoValue
 
 TEST(ExpectedVoidTest, TransformRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an rvalue void-valued expected that is valid invokes the given "
+                   "function and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -1044,6 +1362,12 @@ TEST(ExpectedVoidTest, TransformRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, TransformRValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on an rvalue void-valued expected holding an error skips the given "
+                   "function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1063,6 +1387,12 @@ TEST(ExpectedVoidTest, TransformRValueRefWillReturnReboundErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, TransformConstRValueRefWillCallFunctionIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-rvalue void-valued expected that is valid invokes the "
+                   "given function and wraps the result in a rebound expected.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, ErrorType> unit{};
 
@@ -1081,6 +1411,12 @@ TEST(ExpectedVoidTest, TransformConstRValueRefWillCallFunctionIfHasValue)
 
 TEST(ExpectedVoidTest, TransformConstRValueRefWillReturnReboundErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform() on a const-rvalue void-valued expected holding an error skips the "
+                   "given function and propagates the rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1100,6 +1436,12 @@ TEST(ExpectedVoidTest, TransformConstRValueRefWillReturnReboundErrorIfHasNoValue
 
 TEST(ExpectedVoidTest, TransformErrorLValueRefWillCallFunctionIfHasError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an lvalue void-valued expected holding an error invokes the "
+                   "given function with that error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1120,6 +1462,12 @@ TEST(ExpectedVoidTest, TransformErrorLValueRefWillCallFunctionIfHasError)
 
 TEST(ExpectedVoidTest, TransformErrorLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an lvalue void-valued expected that is valid skips the "
+                   "given function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, CopyableType> unit{};
 
@@ -1136,6 +1484,12 @@ TEST(ExpectedVoidTest, TransformErrorLValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, TransformErrorConstLValueRefWillCallFunctionIfHasError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-lvalue void-valued expected holding an error invokes "
+                   "the given function with that error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1156,6 +1510,12 @@ TEST(ExpectedVoidTest, TransformErrorConstLValueRefWillCallFunctionIfHasError)
 
 TEST(ExpectedVoidTest, TransformErrorConstLValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-lvalue void-valued expected that is valid skips the "
+                   "given function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, CopyableType> unit{};
 
@@ -1172,6 +1532,12 @@ TEST(ExpectedVoidTest, TransformErrorConstLValueRefWillReturnReboundValueIfHasVa
 
 TEST(ExpectedVoidTest, TransformErrorRValueRefWillCallFunctionIfHasError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an rvalue void-valued expected holding an error invokes the "
+                   "given function with the moved-out error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1193,6 +1559,12 @@ TEST(ExpectedVoidTest, TransformErrorRValueRefWillCallFunctionIfHasError)
 
 TEST(ExpectedVoidTest, TransformErrorRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on an rvalue void-valued expected that is valid skips the given "
+                   "function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     expected<void, CopyableType> unit{};
 
@@ -1209,6 +1581,12 @@ TEST(ExpectedVoidTest, TransformErrorRValueRefWillReturnReboundValueIfHasValue)
 
 TEST(ExpectedVoidTest, TransformErrorConstRValueRefWillCallFunctionIfHasError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-rvalue void-valued expected holding an error invokes "
+                   "the given function with that error and wraps the result in a rebound error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{83};
     CopyableType wrapped{error};
@@ -1230,6 +1608,12 @@ TEST(ExpectedVoidTest, TransformErrorConstRValueRefWillCallFunctionIfHasError)
 
 TEST(ExpectedVoidTest, TransformErrorConstRValueRefWillReturnReboundValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that transform_error() on a const-rvalue void-valued expected that is valid skips the "
+                   "given function and leaves the expected valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const expected<void, CopyableType> unit{};
 

--- a/score/result/details/expected/expected_observer_test.cpp
+++ b/score/result/details/expected/expected_observer_test.cpp
@@ -26,6 +26,12 @@ namespace
 
 TEST(ExpectedTest, ArrowOperatorConstReturnsPointerToValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator-> on a const expected holding a value returns a const pointer to that "
+                   "value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     const expected<CopyableType, ErrorType> unit{CopyableType{value}};
@@ -42,6 +48,12 @@ TEST(ExpectedTest, ArrowOperatorConstReturnsPointerToValue)
 
 TEST(ExpectedTest, ArrowOperatorConstWillExitIfNoValueIsStored)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator-> on a const expected holding an error aborts instead of returning a "
+                   "dangling pointer.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<ValueType, ErrorType> unit{unexpect};
 
@@ -51,6 +63,12 @@ TEST(ExpectedTest, ArrowOperatorConstWillExitIfNoValueIsStored)
 
 TEST(ExpectedTest, ArrowOperatorReturnsPointerToValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator-> on a mutable expected holding a value returns a mutable pointer to "
+                   "that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     expected<CopyableType, ErrorType> unit{CopyableType{value}};
@@ -67,6 +85,12 @@ TEST(ExpectedTest, ArrowOperatorReturnsPointerToValue)
 
 TEST(ExpectedTest, ArrowOperatorWillExitIfNoValueIsStored)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator-> on a mutable expected holding an error aborts instead of returning a "
+                   "dangling pointer.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -76,6 +100,12 @@ TEST(ExpectedTest, ArrowOperatorWillExitIfNoValueIsStored)
 
 TEST(ExpectedTest, StarOperatorLValueConstReturnsReferenceToValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a const-lvalue expected holding a value returns a const reference to "
+                   "that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     const expected<CopyableType, ErrorType> unit{CopyableType{value}};
@@ -92,6 +122,12 @@ TEST(ExpectedTest, StarOperatorLValueConstReturnsReferenceToValue)
 
 TEST(ExpectedTest, StarOperatorLValueConstWillExitIfNoValueIsStored)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a const-lvalue expected holding an error aborts instead of "
+                   "returning a dangling reference.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<ValueType, ErrorType> unit{unexpect};
 
@@ -101,6 +137,12 @@ TEST(ExpectedTest, StarOperatorLValueConstWillExitIfNoValueIsStored)
 
 TEST(ExpectedTest, StarOperatorLValueReturnsReferenceToValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a mutable lvalue expected holding a value returns a mutable "
+                   "reference to that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     expected<CopyableType, ErrorType> unit{CopyableType{value}};
@@ -117,6 +159,12 @@ TEST(ExpectedTest, StarOperatorLValueReturnsReferenceToValue)
 
 TEST(ExpectedTest, StarOperatorLValueWillExitIfNoValueIsStored)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a mutable lvalue expected holding an error aborts instead of "
+                   "returning a dangling reference.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -126,6 +174,12 @@ TEST(ExpectedTest, StarOperatorLValueWillExitIfNoValueIsStored)
 
 TEST(ExpectedTest, StarOperatorRValueConstReturnsReferenceToValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a const-rvalue expected holding a value returns a const rvalue "
+                   "reference to that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     const expected<NothrowMoveOnlyType, ErrorType> unit{value};
@@ -142,6 +196,12 @@ TEST(ExpectedTest, StarOperatorRValueConstReturnsReferenceToValue)
 
 TEST(ExpectedTest, StarOperatorRValueConstWillExitIfNoValueIsStored)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a const-rvalue expected holding an error aborts instead of "
+                   "returning a dangling reference.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<ValueType, ErrorType> unit{unexpect};
 
@@ -151,6 +211,12 @@ TEST(ExpectedTest, StarOperatorRValueConstWillExitIfNoValueIsStored)
 
 TEST(ExpectedTest, StarOperatorRValueReturnsReferenceToValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a mutable rvalue expected holding a value returns a mutable rvalue "
+                   "reference to that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     expected<NothrowMoveOnlyType, ErrorType> unit{value};
@@ -167,6 +233,12 @@ TEST(ExpectedTest, StarOperatorRValueReturnsReferenceToValue)
 
 TEST(ExpectedTest, StarOperatorRValueWillExitIfNoValueIsStored)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a mutable rvalue expected holding an error aborts instead of "
+                   "returning a dangling reference.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -176,6 +248,11 @@ TEST(ExpectedTest, StarOperatorRValueWillExitIfNoValueIsStored)
 
 TEST(ExpectedTest, ExplicitConversionToBoolIsTrueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that explicit conversion to bool yields true for an expected holding a value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     expected<ValueType, ErrorType> unit{};
 
@@ -188,6 +265,11 @@ TEST(ExpectedTest, ExplicitConversionToBoolIsTrueIfHasValue)
 
 TEST(ExpectedTest, ExplicitConversionToBoolIsFalseIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that explicit conversion to bool yields false for an expected holding an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -200,6 +282,10 @@ TEST(ExpectedTest, ExplicitConversionToBoolIsFalseIfHasNoValue)
 
 TEST(ExpectedTest, HasValueReturnsTrueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that has_value() returns true for an expected holding a value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     expected<ValueType, ErrorType> unit{};
 
@@ -209,6 +295,10 @@ TEST(ExpectedTest, HasValueReturnsTrueIfHasValue)
 
 TEST(ExpectedTest, HasValueReturnsFalseIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that has_value() returns false for an expected holding an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -218,6 +308,12 @@ TEST(ExpectedTest, HasValueReturnsFalseIfHasNoValue)
 
 TEST(ExpectedTest, CanRetrieveValueFromLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on an lvalue expected holding a value returns a mutable reference to that "
+                   "value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     expected<CopyableType, ErrorType> unit{CopyableType{value}};
@@ -231,6 +327,12 @@ TEST(ExpectedTest, CanRetrieveValueFromLValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveValueFromLValueReferenceWithoutValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on an lvalue expected holding an error throws instead of returning a "
+                   "dangling value.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -240,6 +342,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveValueFromLValueReferenceWithoutValue)
 
 TEST(ExpectedTest, CanRetrieveValueFromConstLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on a const-lvalue expected holding a value returns a const reference to "
+                   "that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     const expected<CopyableType, ErrorType> unit{CopyableType{value}};
@@ -253,6 +361,12 @@ TEST(ExpectedTest, CanRetrieveValueFromConstLValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveValueFromConstLValueReferenceWithoutValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on a const-lvalue expected holding an error throws instead of returning a "
+                   "dangling value.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<ValueType, ErrorType> unit{unexpect};
 
@@ -262,6 +376,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveValueFromConstLValueReferenceWithoutValue)
 
 TEST(ExpectedTest, CanRetrieveValueFromRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on an rvalue expected holding a value returns a moved-out rvalue "
+                   "reference to that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     expected<NothrowMoveOnlyType, ErrorType> unit{NothrowMoveOnlyType{value}};
@@ -277,6 +397,12 @@ TEST(ExpectedTest, CanRetrieveValueFromRValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveValueFromRValueReferenceWithoutValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on an rvalue expected holding an error throws instead of returning a "
+                   "dangling value.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     expected<ValueType, ErrorType> unit{unexpect};
 
@@ -286,6 +412,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveValueFromRValueReferenceWithoutValue)
 
 TEST(ExpectedTest, CanRetrieveValueFromConstRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on a const-rvalue expected holding a value returns a const moved-out "
+                   "rvalue reference to that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     std::int32_t value{13};
     const expected<NothrowMoveOnlyType, ErrorType> unit{NothrowMoveOnlyType{value}};
@@ -301,6 +433,12 @@ TEST(ExpectedTest, CanRetrieveValueFromConstRValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveValueFromConstRValueReferenceWithoutValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on a const-rvalue expected holding an error throws instead of returning "
+                   "a dangling value.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<ValueType, ErrorType> unit{unexpect};
 
@@ -310,6 +448,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveValueFromConstRValueReferenceWithoutValue)
 
 TEST(ExpectedTest, CanRetrieveErrorFromLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an lvalue expected holding an error returns a mutable reference to "
+                   "that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     std::int32_t value{13};
     expected<ValueType, CopyableType> unit{unexpect, CopyableType{value}};
@@ -323,6 +467,12 @@ TEST(ExpectedTest, CanRetrieveErrorFromLValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveErrorFromLValueReferenceWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an lvalue expected holding a value aborts instead of returning a "
+                   "dangling error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with a value
     expected<ValueType, ErrorType> unit{};
 
@@ -332,6 +482,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveErrorFromLValueReferenceWithValue)
 
 TEST(ExpectedTest, CanRetrieveErrorFromConstLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-lvalue expected holding an error returns a const reference to "
+                   "that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     std::int32_t value{13};
     const expected<ValueType, CopyableType> unit{unexpect, CopyableType{value}};
@@ -345,6 +501,12 @@ TEST(ExpectedTest, CanRetrieveErrorFromConstLValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveErrorFromConstLValueReferenceWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-lvalue expected holding a value aborts instead of returning a "
+                   "dangling error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with a value
     const expected<ValueType, ErrorType> unit{};
 
@@ -354,6 +516,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveErrorFromConstLValueReferenceWithValue)
 
 TEST(ExpectedTest, CanRetrieveErrorFromRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an rvalue expected holding an error returns a moved-out rvalue "
+                   "reference to that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     std::int32_t value{13};
     expected<ValueType, NothrowMoveOnlyType> unit{unexpect, NothrowMoveOnlyType{value}};
@@ -369,6 +537,12 @@ TEST(ExpectedTest, CanRetrieveErrorFromRValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveErrorFromRValueReferenceWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an rvalue expected holding a value aborts instead of returning a "
+                   "dangling error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with a value
     expected<ValueType, ErrorType> unit{};
 
@@ -378,6 +552,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveErrorFromRValueReferenceWithValue)
 
 TEST(ExpectedTest, CanRetrieveErrorFromConstRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-rvalue expected holding an error returns a const moved-out "
+                   "rvalue reference to that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     std::int32_t value{13};
     const expected<ValueType, NothrowMoveOnlyType> unit{unexpect, NothrowMoveOnlyType{value}};
@@ -393,6 +573,12 @@ TEST(ExpectedTest, CanRetrieveErrorFromConstRValueReference)
 
 TEST(ExpectedTest, AbortsWhenRetrieveErrorFromConstRValueReferenceWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-rvalue expected holding a value aborts instead of returning a "
+                   "dangling error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with a value
     const expected<ValueType, ErrorType> unit{};
 
@@ -402,6 +588,12 @@ TEST(ExpectedTest, AbortsWhenRetrieveErrorFromConstRValueReferenceWithValue)
 
 TEST(ExpectedTest, ValueOrConstLValueReturnsValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value_or() on a const-lvalue expected holding a value returns that value instead "
+                   "of the default.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{19};
     const std::int32_t default_value{11};
@@ -416,6 +608,12 @@ TEST(ExpectedTest, ValueOrConstLValueReturnsValueIfHasValue)
 
 TEST(ExpectedTest, ValueOrConstLValueReturnsDefaultIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value_or() on a const-lvalue expected holding an error returns the supplied "
+                   "default value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t default_value{11};
     const expected<CopyableType, ErrorType> unit{unexpect};
@@ -429,6 +627,12 @@ TEST(ExpectedTest, ValueOrConstLValueReturnsDefaultIfHasNoValue)
 
 TEST(ExpectedTest, ValueOrRValueReturnsValueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value_or() on an rvalue expected holding a value returns the moved-out value "
+                   "instead of the default.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{19};
     const std::int32_t default_value{11};
@@ -443,6 +647,12 @@ TEST(ExpectedTest, ValueOrRValueReturnsValueIfHasValue)
 
 TEST(ExpectedTest, ValueOrRValueReturnsDefaultIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value_or() on an rvalue expected holding an error returns the supplied default "
+                   "value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t default_value{11};
     expected<NothrowMoveOnlyType, ErrorType> unit{unexpect};
@@ -456,6 +666,12 @@ TEST(ExpectedTest, ValueOrRValueReturnsDefaultIfHasNoValue)
 
 TEST(ExpectedTest, ErrorOrConstLValueReturnsErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on a const-lvalue expected holding an error returns that error "
+                   "instead of the default.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t value{19};
     const std::int32_t default_error{11};
@@ -470,6 +686,12 @@ TEST(ExpectedTest, ErrorOrConstLValueReturnsErrorIfHasNoValue)
 
 TEST(ExpectedTest, ErrorOrConstLValueReturnsDefaultIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on a const-lvalue expected holding a value returns the supplied "
+                   "default error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t default_error{11};
     const expected<ValueType, CopyableType> unit{};
@@ -483,6 +705,12 @@ TEST(ExpectedTest, ErrorOrConstLValueReturnsDefaultIfHasValue)
 
 TEST(ExpectedTest, ErrorOrRValueReturnsErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on an rvalue expected holding an error returns the moved-out error "
+                   "instead of the default.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t value{19};
     const std::int32_t default_error{11};
@@ -497,6 +725,12 @@ TEST(ExpectedTest, ErrorOrRValueReturnsErrorIfHasNoValue)
 
 TEST(ExpectedTest, ErrorOrRValueReturnsDefaultIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on an rvalue expected holding a value returns the supplied default "
+                   "error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     const std::int32_t default_error{11};
     expected<ValueType, NothrowMoveOnlyType> unit{};
@@ -510,6 +744,11 @@ TEST(ExpectedTest, ErrorOrRValueReturnsDefaultIfHasValue)
 
 TEST(ExpectedVoidTest, StarOperatorWillNotExitIfValid)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that operator* on a void-valued expected that is valid does not abort or throw.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const expected<void, ErrorType> unit{};
 
@@ -519,6 +758,10 @@ TEST(ExpectedVoidTest, StarOperatorWillNotExitIfValid)
 
 TEST(ExpectedVoidTest, StarOperatorWillExitIfInErrorState)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that operator* on a void-valued expected holding an error aborts.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<void, ErrorType> unit{unexpect};
 
@@ -528,6 +771,12 @@ TEST(ExpectedVoidTest, StarOperatorWillExitIfInErrorState)
 
 TEST(ExpectedVoidTest, ExplicitConversionToBoolIsTrueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that explicit conversion to bool yields true for a void-valued expected that is "
+                   "valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with a value
     expected<void, ErrorType> unit{};
 
@@ -540,6 +789,12 @@ TEST(ExpectedVoidTest, ExplicitConversionToBoolIsTrueIfHasValue)
 
 TEST(ExpectedVoidTest, ExplicitConversionToBoolIsFalseIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that explicit conversion to bool yields false for a void-valued expected holding an "
+                   "error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     expected<void, ErrorType> unit{unexpect};
 
@@ -552,6 +807,10 @@ TEST(ExpectedVoidTest, ExplicitConversionToBoolIsFalseIfHasNoValue)
 
 TEST(ExpectedVoidTest, HasValueReturnsTrueIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that has_value() returns true for a void-valued expected that is valid.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     expected<void, ErrorType> unit{};
 
@@ -561,6 +820,10 @@ TEST(ExpectedVoidTest, HasValueReturnsTrueIfHasValue)
 
 TEST(ExpectedVoidTest, HasValueReturnsFalseIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that has_value() returns false for a void-valued expected holding an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     expected<void, ErrorType> unit{unexpect};
 
@@ -570,6 +833,11 @@ TEST(ExpectedVoidTest, HasValueReturnsFalseIfHasNoValue)
 
 TEST(ExpectedVoidTest, NoAbortWhenCallValueFromConstLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that value() on a const-lvalue void-valued expected that is valid does not throw.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const expected<void, ErrorType> unit{};
 
@@ -579,6 +847,10 @@ TEST(ExpectedVoidTest, NoAbortWhenCallValueFromConstLValueReference)
 
 TEST(ExpectedVoidTest, AbortWhenCallValueFromConstLValueReferenceWithoutValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that value() on a const-lvalue void-valued expected holding an error throws.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     const expected<void, ErrorType> unit{unexpect};
 
@@ -588,6 +860,10 @@ TEST(ExpectedVoidTest, AbortWhenCallValueFromConstLValueReferenceWithoutValue)
 
 TEST(ExpectedVoidTest, NoAbortWhenCallValueFromRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that value() on an rvalue void-valued expected that is valid does not throw.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     expected<void, ErrorType> unit{};
 
@@ -597,6 +873,10 @@ TEST(ExpectedVoidTest, NoAbortWhenCallValueFromRValueReference)
 
 TEST(ExpectedVoidTest, AbortWhenCallValueFromRValueReferenceWithoutValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that value() on an rvalue void-valued expected holding an error throws.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with an error
     expected<void, ErrorType> unit{unexpect};
 
@@ -606,6 +886,12 @@ TEST(ExpectedVoidTest, AbortWhenCallValueFromRValueReferenceWithoutValue)
 
 TEST(ExpectedVoidTest, CanRetrieveErrorFromConstLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-lvalue void-valued expected holding an error returns a const "
+                   "reference to that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     std::int32_t error{13};
     const expected<void, CopyableType> unit{unexpect, CopyableType{error}};
@@ -619,6 +905,12 @@ TEST(ExpectedVoidTest, CanRetrieveErrorFromConstLValueReference)
 
 TEST(ExpectedVoidTest, AbortsWhenRetrieveErrorFromConstLValueReferenceWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-lvalue void-valued expected that is valid aborts instead of "
+                   "returning a dangling error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with a value
     const expected<void, ErrorType> unit{};
 
@@ -628,6 +920,12 @@ TEST(ExpectedVoidTest, AbortsWhenRetrieveErrorFromConstLValueReferenceWithValue)
 
 TEST(ExpectedVoidTest, AbortsWhenRetrieveErrorFromRValueReferenceWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an rvalue void-valued expected that is valid aborts instead of "
+                   "returning a dangling error.");
+    RecordProperty("TestType", "fault-injection");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an expected with a value
     expected<void, ErrorType> unit{};
 
@@ -637,6 +935,12 @@ TEST(ExpectedVoidTest, AbortsWhenRetrieveErrorFromRValueReferenceWithValue)
 
 TEST(ExpectedVoidTest, ErrorOrConstLValueReturnsErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on a const-lvalue void-valued expected holding an error returns that "
+                   "error instead of the default.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{19};
     const std::int32_t default_error{11};
@@ -651,6 +955,12 @@ TEST(ExpectedVoidTest, ErrorOrConstLValueReturnsErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, ErrorOrConstLValueReturnsDefaultIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on a const-lvalue void-valued expected that is valid returns the "
+                   "supplied default error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const std::int32_t default_error{11};
     const expected<void, CopyableType> unit{};
@@ -664,6 +974,12 @@ TEST(ExpectedVoidTest, ErrorOrConstLValueReturnsDefaultIfHasValue)
 
 TEST(ExpectedVoidTest, ErrorOrRValueReturnsErrorIfHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on an rvalue void-valued expected holding an error returns the "
+                   "moved-out error instead of the default.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     const std::int32_t error{19};
     const std::int32_t default_error{11};
@@ -678,6 +994,12 @@ TEST(ExpectedVoidTest, ErrorOrRValueReturnsErrorIfHasNoValue)
 
 TEST(ExpectedVoidTest, ErrorOrRValueReturnsDefaultIfHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error_or() on an rvalue void-valued expected that is valid returns the supplied "
+                   "default error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a valid expected
     const std::int32_t default_error{11};
     expected<void, NothrowMoveOnlyType> unit{};
@@ -691,6 +1013,12 @@ TEST(ExpectedVoidTest, ErrorOrRValueReturnsDefaultIfHasValue)
 
 TEST(ExpectedVoidTest, CanRetrieveErrorFromRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an rvalue void-valued expected holding an error returns a moved-out "
+                   "rvalue reference to that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an expected with an error
     std::int32_t error{13};
     expected<void, NothrowMoveOnlyType> unit{unexpect, NothrowMoveOnlyType{error}};

--- a/score/result/details/expected/expected_type_trait_test.cpp
+++ b/score/result/details/expected/expected_type_trait_test.cpp
@@ -25,6 +25,10 @@ namespace
 
 TEST(ExpectedTest, HasValueTypeTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that expected<T, E>::value_type resolves to T at compile time.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // When wrapping the type as value_type with an expected
     using unit = expected<ValueType, ErrorType>;
 
@@ -34,6 +38,10 @@ TEST(ExpectedTest, HasValueTypeTypeTrait)
 
 TEST(ExpectedTest, HasErrorTypeTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that expected<T, E>::error_type resolves to E at compile time.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // When wrapping the type as error_type with an expected
     using unit = expected<ValueType, ErrorType>;
 
@@ -43,6 +51,11 @@ TEST(ExpectedTest, HasErrorTypeTypeTrait)
 
 TEST(ExpectedTest, HasUnexpectedTypeTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<T, E>::unexpected_type resolves to unexpected<E> at compile time.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // When wrapping the type as error_type with an expected
     using unit = expected<ValueType, ErrorType>;
 
@@ -52,6 +65,12 @@ TEST(ExpectedTest, HasUnexpectedTypeTypeTrait)
 
 TEST(ExpectedTest, HasRebindTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<T, E>::rebind<U> yields expected<U, E>, preserving the error type while "
+                   "exchanging the value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     struct OtherValueType
     {
     };
@@ -66,6 +85,10 @@ TEST(ExpectedTest, HasRebindTypeTrait)
 
 TEST(ExpectedVoidTest, HasValueTypeTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that the value-less expected<void, E>::value_type resolves to void.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // When wrapping the void type with an expected
     using unit = expected<void, ErrorType>;
 
@@ -75,6 +98,10 @@ TEST(ExpectedVoidTest, HasValueTypeTypeTrait)
 
 TEST(ExpectedVoidTest, HasErrorTypeTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that expected<void, E>::error_type resolves to E at compile time.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // When wrapping the type as error_type with an expected
     using unit = expected<void, ErrorType>;
 
@@ -84,6 +111,11 @@ TEST(ExpectedVoidTest, HasErrorTypeTypeTrait)
 
 TEST(ExpectedVoidTest, HasUnexpectedTypeTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<void, E>::unexpected_type resolves to unexpected<E> at compile time.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // When wrapping the type as error_type with an expected
     using unit = expected<void, ErrorType>;
 
@@ -93,6 +125,12 @@ TEST(ExpectedVoidTest, HasUnexpectedTypeTypeTrait)
 
 TEST(ExpectedVoidTest, HasRebindTypeTrait)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that expected<void, E>::rebind<U> yields expected<U, E>, preserving the error type while "
+                   "introducing a value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // When wrapping the type as error_type with an expected
     using unit = expected<void, ErrorType>;
     using rebound = unit::rebind<ValueType>;

--- a/score/result/details/expected/extensions_test.cpp
+++ b/score/result/details/expected/extensions_test.cpp
@@ -27,6 +27,12 @@ namespace
 
 TEST(ExtensionsTest, CanConvertFromExpectedConstLValueRefToAmpExpectedWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_future_cpp_expected() converts a const-lvalue expected holding a value "
+                   "into a score::cpp::expected holding the same value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with a value
     const std::int32_t value{57};
     const score::details::expected<CopyableType, ErrorType> expected{value};
@@ -42,6 +48,12 @@ TEST(ExtensionsTest, CanConvertFromExpectedConstLValueRefToAmpExpectedWithValue)
 
 TEST(ExtensionsTest, CanConvertFromExpectedConstLValueRefToAmpExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_future_cpp_expected() converts a const-lvalue expected holding an error "
+                   "into a score::cpp::expected holding the same error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     const score::details::expected<ValueType, CopyableType> expected{unexpect, value};
@@ -57,6 +69,12 @@ TEST(ExtensionsTest, CanConvertFromExpectedConstLValueRefToAmpExpectedWithError)
 
 TEST(ExtensionsTest, CanConvertFromExpectedRValueRefToAmpExpectedWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_future_cpp_expected() converts an rvalue expected holding a move-only "
+                   "value into a score::cpp::expected holding that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with a value
     const std::int32_t value{57};
     score::details::expected<NothrowMoveOnlyType, ErrorType> expected{value};
@@ -72,6 +90,12 @@ TEST(ExtensionsTest, CanConvertFromExpectedRValueRefToAmpExpectedWithValue)
 
 TEST(ExtensionsTest, CanConvertFromExpectedRValueRefToAmpExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_future_cpp_expected() converts an rvalue expected holding a move-only "
+                   "error into a score::cpp::expected holding that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     score::details::expected<ValueType, NothrowMoveOnlyType> expected{unexpect, value};
@@ -87,6 +111,12 @@ TEST(ExtensionsTest, CanConvertFromExpectedRValueRefToAmpExpectedWithError)
 
 TEST(ExtensionsTest, CanConvertFromAmpExpectedConstLValueRefToExpectedWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_expected() converts a const-lvalue score::cpp::expected holding a value "
+                   "into a score::details::expected holding the same value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an score::cpp::expected with a value
     const std::int32_t value{57};
     const score::cpp::expected<CopyableType, ErrorType> score_future_cpp_expected{value};
@@ -101,6 +131,12 @@ TEST(ExtensionsTest, CanConvertFromAmpExpectedConstLValueRefToExpectedWithValue)
 
 TEST(ExtensionsTest, CanConvertFromAmpExpectedConstLValueRefToExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_expected() converts a const-lvalue score::cpp::expected holding an error "
+                   "into a score::details::expected holding the same error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an score::cpp::expected with an error
     const std::int32_t value{57};
     const score::cpp::expected<ValueType, CopyableType> score_future_cpp_expected{
@@ -116,6 +152,12 @@ TEST(ExtensionsTest, CanConvertFromAmpExpectedConstLValueRefToExpectedWithError)
 
 TEST(ExtensionsTest, CanConvertFromAmpExpectedRValueRefToExpectedWithValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_expected() converts an rvalue score::cpp::expected holding a move-only "
+                   "value into a score::details::expected holding that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an score::cpp::expected with a value
     const std::int32_t value{57};
     score::cpp::expected<NothrowMoveOnlyType, ErrorType> score_future_cpp_expected{value};
@@ -131,6 +173,12 @@ TEST(ExtensionsTest, CanConvertFromAmpExpectedRValueRefToExpectedWithValue)
 
 TEST(ExtensionsTest, CanConvertFromAmpExpectedRValueRefToExpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that to_score_expected() converts an rvalue score::cpp::expected holding a move-only "
+                   "error into a score::details::expected holding that error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an score::cpp::expected with an error
     const std::int32_t value{57};
     score::cpp::expected<ValueType, NothrowMoveOnlyType> score_future_cpp_expected{
@@ -147,6 +195,13 @@ TEST(ExtensionsTest, CanConvertFromAmpExpectedRValueRefToExpectedWithError)
 
 TEST(ExtensionsTest, ConvertToAmpOptionalWhenExpectedConstLValueRefHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_score_future_cpp_optional_or_else() converts a const-lvalue "
+                   "expected holding a value into a score::cpp::optional holding that value, without invoking the "
+                   "error handler.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     const score::details::expected<CopyableType, ErrorType> expected{value};
@@ -166,6 +221,13 @@ TEST(ExtensionsTest, ConvertToAmpOptionalWhenExpectedConstLValueRefHasValue)
 
 TEST(ExtensionsTest, OnConversionToAmpOptionalCallInvocableWhenExpectedConstLValueRefHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_score_future_cpp_optional_or_else() invokes the error handler "
+                   "exactly once and yields an empty score::cpp::optional when the const-lvalue expected holds an "
+                   "error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     const score::details::expected<ValueType, CopyableType> expected{unexpect, value};
@@ -184,6 +246,13 @@ TEST(ExtensionsTest, OnConversionToAmpOptionalCallInvocableWhenExpectedConstLVal
 
 TEST(ExtensionsTest, ConvertToAmpOptionalWhenExpectedRValueRefHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_score_future_cpp_optional_or_else() converts an rvalue expected "
+                   "holding a move-only value into a score::cpp::optional holding that value, without invoking the "
+                   "error handler.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     score::details::expected<NothrowMoveOnlyType, ErrorType> expected{value};
@@ -203,6 +272,13 @@ TEST(ExtensionsTest, ConvertToAmpOptionalWhenExpectedRValueRefHasValue)
 
 TEST(ExtensionsTest, OnConversionToAmpOptionalCallInvocableWhenExpectedLValueRefHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_score_future_cpp_optional_or_else() passes the moved-out error to "
+                   "the error handler and yields an empty score::cpp::optional when the rvalue expected holds an "
+                   "error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     score::details::expected<ValueType, NothrowMoveOnlyType> expected{unexpect, value};
@@ -223,6 +299,12 @@ TEST(ExtensionsTest, OnConversionToAmpOptionalCallInvocableWhenExpectedLValueRef
 
 TEST(ExtensionsTest, ConvertToStdOptionalWhenExpectedConstLValueRefHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_optional_or_else() converts a const-lvalue expected holding a "
+                   "value into an std::optional holding that value, without invoking the error handler.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     const score::details::expected<CopyableType, ErrorType> expected{value};
@@ -241,6 +323,12 @@ TEST(ExtensionsTest, ConvertToStdOptionalWhenExpectedConstLValueRefHasValue)
 
 TEST(ExtensionsTest, OnConversionToStdOptionalCallInvocableWhenExpectedConstLValueRefHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_optional_or_else() invokes the error handler exactly once and "
+                   "yields an empty std::optional when the const-lvalue expected holds an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     const score::details::expected<ValueType, CopyableType> expected{unexpect, value};
@@ -258,6 +346,12 @@ TEST(ExtensionsTest, OnConversionToStdOptionalCallInvocableWhenExpectedConstLVal
 
 TEST(ExtensionsTest, ConvertToStdOptionalWhenExpectedRValueRefHasValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_optional_or_else() converts an rvalue expected holding a "
+                   "move-only value into an std::optional holding that value, without invoking the error handler.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     score::details::expected<NothrowMoveOnlyType, ErrorType> expected{value};
@@ -277,6 +371,12 @@ TEST(ExtensionsTest, ConvertToStdOptionalWhenExpectedRValueRefHasValue)
 
 TEST(ExtensionsTest, OnConversionToStdOptionalCallInvocableWhenExpectedLValueRefHasNoValue)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that expected_value_to_optional_or_else() passes the moved-out error to the error "
+                   "handler and yields an empty std::optional when the rvalue expected holds an error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given a score::details::expected with an error
     const std::int32_t value{57};
     score::details::expected<ValueType, NothrowMoveOnlyType> expected{unexpect, value};

--- a/score/result/details/expected/test_type_traits_test.cpp
+++ b/score/result/details/expected/test_type_traits_test.cpp
@@ -21,6 +21,12 @@ namespace
 
 TEST(ExplicitImplicitConstructibleTest, ChecksWorkCorrectly)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that is_only_explicitly_constructible_v and is_implicitly_constructible_v correctly "
+                   "distinguish an explicit-only default constructor from an implicit one.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an explicitly and an implicitly constructible type
     struct Explicit
     {

--- a/score/result/details/expected/unexpected_test.cpp
+++ b/score/result/details/expected/unexpected_test.cpp
@@ -26,11 +26,21 @@ namespace
 
 TEST(UnexpectTest, UnexpectT_InitializesExplicit)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that unexpect_t, the disambiguation tag for in-place error construction, is only "
+                   "explicitly constructible and cannot be created implicitly.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(is_only_explicitly_constructible_v<unexpect_t>, "unexpect_t must be only explicit constructible");
 }
 
 TEST(UnexpectTest, ProvidesHelperUnexpect)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that the unexpect helper variable has type const unexpect_t.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(std::is_same_v<decltype(unexpect), const unexpect_t>, "unexpect must be of type const unexpect_t");
 }
 
@@ -66,6 +76,12 @@ class MoveOnlyType
 
 TEST(UnexpectedTest, IsCopyConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that unexpected<E> is copy constructible when E is copyable, and that the copy holds the "
+                   "same error as the original.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an unexpected that is copyable
     std::int32_t value{15};
     unexpected unit{CopyableType{value}};
@@ -80,6 +96,12 @@ TEST(UnexpectedTest, IsCopyConstructible)
 
 TEST(UnexpectedTest, IsMoveConstructible)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that unexpected<E> is move constructible when E is move-only, and that the error is "
+                   "transferred to the moved-to instance.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an unexpected that is move-only
     std::int32_t value{13};
     unexpected unit{MoveOnlyType{value}};
@@ -93,6 +115,12 @@ TEST(UnexpectedTest, IsMoveConstructible)
 
 TEST(UnexpectedTest, CanBeConstructedFromCompatibleType)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that unexpected<E> can be constructed directly from a value convertible to E, for use in "
+                   "setting a Result to an error state.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given some value
     std::int32_t value{16};
 
@@ -105,6 +133,12 @@ TEST(UnexpectedTest, CanBeConstructedFromCompatibleType)
 
 TEST(UnexpectedTest, CanBeInPlaceConstructedFromCompatibleArguments)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that unexpected<E> can be constructed in place, forwarding constructor arguments directly "
+                   "to E, without requiring a temporary E to be built first.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a target type that is constructible with arguments based on two other types
     struct TargetType
     {
@@ -130,6 +164,12 @@ TEST(UnexpectedTest, CanBeInPlaceConstructedFromCompatibleArguments)
 
 TEST(UnexpectedTest, CanBeInPlaceConstructedFromInitializerList)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that unexpected<E> can be constructed in place from an initializer list plus additional "
+                   "constructor arguments forwarded to E.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given a target type that is constructible with an initializer list and other arguments based on two other types
     struct TargetType
     {
@@ -155,6 +195,10 @@ TEST(UnexpectedTest, CanBeInPlaceConstructedFromInitializerList)
 
 TEST(UnexpectedTest, IsCopyAssignable)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that copy-assigning one unexpected<E> to another replaces its held error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two unexpected with different values
     std::int32_t value{15};
     unexpected unit{CopyableType{value}};
@@ -172,6 +216,10 @@ TEST(UnexpectedTest, IsCopyAssignable)
 
 TEST(UnexpectedTest, IsMoveAssignable)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that move-assigning one unexpected<E> to another transfers its held error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two unexpected with different values
     std::int32_t value{13};
     unexpected unit{MoveOnlyType{value}};
@@ -188,6 +236,11 @@ TEST(UnexpectedTest, IsMoveAssignable)
 
 TEST(UnexpectedTest, CanRetrieveErrorFromConstLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-lvalue unexpected<E> returns the held error by const reference.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an unexpected with a value
     std::int32_t value{13};
     const unexpected unit{CopyableType{value}};
@@ -201,6 +254,11 @@ TEST(UnexpectedTest, CanRetrieveErrorFromConstLValueReference)
 
 TEST(UnexpectedTest, CanRetrieveErrorFromLValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an lvalue unexpected<E> returns the held error by mutable reference.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an unexpected with a value
     std::int32_t value{13};
     unexpected unit{CopyableType{value}};
@@ -217,6 +275,12 @@ TEST(UnexpectedTest, CanRetrieveErrorFromLValueReference)
 
 TEST(UnexpectedTest, CanRetrieveErrorFromConstRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on a const-rvalue unexpected<E> returns the held error by const rvalue "
+                   "reference.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an unexpected with a value
     std::int32_t value{13};
     const unexpected unit{MoveOnlyType{value}};
@@ -232,6 +296,12 @@ TEST(UnexpectedTest, CanRetrieveErrorFromConstRValueReference)
 
 TEST(UnexpectedTest, CanRetrieveErrorFromRValueReference)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that error() on an rvalue unexpected<E> returns the held error by rvalue reference, "
+                   "enabling the error to be moved out.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an unexpected with a value
     std::int32_t value{13};
     unexpected unit{MoveOnlyType{value}};
@@ -247,6 +317,10 @@ TEST(UnexpectedTest, CanRetrieveErrorFromRValueReference)
 
 TEST(UnexpectedTest, CanCompareEquality)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that two unexpected<E> compare equal iff their held errors compare equal.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an unexpected
     std::int32_t value{13};
     unexpected lhs{CopyableType{value}};
@@ -266,6 +340,10 @@ TEST(UnexpectedTest, CanCompareEquality)
 
 TEST(UnexpectedTest, CanSwapWithStdSwap)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that std::swap exchanges the held errors of two unexpected<E> instances.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two unexpected with different values
     std::int32_t value{13};
     unexpected unit{CopyableType{value}};
@@ -282,6 +360,12 @@ TEST(UnexpectedTest, CanSwapWithStdSwap)
 
 TEST(UnexpectedTest, CanSwapWithTypeSwap)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that the member swap() function exchanges the held errors of two unexpected<E> "
+                   "instances.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given two unexpected with different values
     std::int32_t value{13};
     unexpected unit{CopyableType{value}};
@@ -298,6 +382,12 @@ TEST(UnexpectedTest, CanSwapWithTypeSwap)
 
 TEST(UnexpectedTest, DeductionGuideIsSpecified)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that class template argument deduction constructs unexpected<E> with E deduced from the "
+                   "constructor argument.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an unexpected that was constructed using the type deduction guide
     std::int32_t value{13};
     unexpected unit{CopyableType{value}};

--- a/score/result/error_msg_mapping_test.cpp
+++ b/score/result/error_msg_mapping_test.cpp
@@ -20,6 +20,12 @@ namespace score::result
 
 TEST(RustBridgeTests, GetMessageForErrorCodeFFI)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that the C-ABI bridge function resolves the message for an error code through a "
+                   "user-defined error domain, for consumption from Rust.");
+    RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     std::string_view error_message;
     LibResultErrorDomainGetMessageForErrorCode(
         dummy_error_domain, static_cast<ErrorCode>(DummyErrorCode::kFirstError), error_message);

--- a/score/result/error_test.cpp
+++ b/score/result/error_test.cpp
@@ -80,6 +80,12 @@ score::result::Error MakeError(MyErrorCode2 code, std::string_view user_message 
 
 TEST(Error, CorrectConstructionAndAssignmentGuarantees)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that Error is trivially and nothrow copyable/movable, so it can be passed by value "
+                   "without incurring allocation or throwing.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     static_assert(std::is_trivially_copy_assignable_v<Error>);
     static_assert(std::is_trivially_copy_constructible_v<Error>);
     static_assert(std::is_trivially_move_assignable_v<Error>);
@@ -90,6 +96,12 @@ TEST(Error, CorrectConstructionAndAssignmentGuarantees)
 
 TEST(Error, RetrieveMessage)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that Error::Message() returns the message produced by the user-defined error domain's "
+                   "MessageFor() for the stored error code.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an constructed error with user message
     const score::result::Error unit{MyErrorCode::kFirstError, "We had a parsing failure"};
 
@@ -102,6 +114,11 @@ TEST(Error, RetrieveMessage)
 
 TEST(Error, RetrieveUserMessage)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that Error::UserMessage() returns the caller-supplied user message passed at construction.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an constructed error with user message
     const score::result::Error unit{MyErrorCode::kFirstError, "We had a parsing failure"};
 
@@ -114,6 +131,12 @@ TEST(Error, RetrieveUserMessage)
 
 TEST(Error, RetrieveUserMessageWhenNotProvided)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that Error::UserMessage() returns an empty string when no user message was provided at "
+                   "construction.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an constructed error with user message
     const score::result::Error unit{MyErrorCode::kFirstError};
 
@@ -126,6 +149,10 @@ TEST(Error, RetrieveUserMessageWhenNotProvided)
 
 TEST(Error, CanCompareForEqual)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description", "Check that an Error compares equal to the error code it was constructed from.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an constructed error
     score::result::Error unit{MyErrorCode::kFirstError};
 
@@ -136,6 +163,12 @@ TEST(Error, CanCompareForEqual)
 
 TEST(Error, CanCompareForNotEqualOnDifferentDomains)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that an Error compares not-equal to a code from a different error domain, even if the "
+                   "underlying numeric code value matches.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an constructed error
     score::result::Error unit{MyErrorCode::kFirstError};
 
@@ -146,6 +179,11 @@ TEST(Error, CanCompareForNotEqualOnDifferentDomains)
 
 TEST(Error, CanCompareForNotEqualOnDifferentValues)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__error_handling");
+    RecordProperty("Description",
+                   "Check that an Error compares not-equal to a different error code from the same domain.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     // Given an constructed error
     score::result::Error unit{MyErrorCode::kFirstError};
 
@@ -156,7 +194,12 @@ TEST(Error, CanCompareForNotEqualOnDifferentValues)
 
 TEST(Error, CanDereferenceToUnderlyingType)
 {
-    // Given an constructed error
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description",
+                   "Check that operator*() exposes the Error's underlying numeric error-code value, usable e.g. in a "
+                   "switch-case statement.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     score::result::Error unit{MyErrorCode::kFirstError};
 
     // When comparing it equal
@@ -166,6 +209,12 @@ TEST(Error, CanDereferenceToUnderlyingType)
 
 TEST(Error, ConstructViaMakeFunction)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that constructing an Error via a user-defined domain's make helper produces an Error "
+                   "comparable against that domain's error codes.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // When constructing the error via make function
     auto unit = MakeError(MyErrorCode::kSecondError);
 
@@ -175,6 +224,11 @@ TEST(Error, ConstructViaMakeFunction)
 
 TEST(Error, CanLogCustomMessageToOstream)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that streaming an Error to an ostream formats the domain message and the user message.");
+    RecordProperty("TestType", "interface-test");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an error with a custom message
     auto unit = MakeError(MyErrorCode::kSecondError, "Foo");
 
@@ -188,6 +242,12 @@ TEST(Error, CanLogCustomMessageToOstream)
 
 TEST(Error, WithUserMessagePreservesCodeAndDomain)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that WithUserMessage() returns a copy with the same error code and domain message but a "
+                   "replaced user message.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     // Given an error with a known code/domain
     const score::result::Error original{MyErrorCode::kSecondError, "original message"};
 
@@ -203,6 +263,11 @@ TEST(Error, WithUserMessagePreservesCodeAndDomain)
 
 TEST(Error, WithUserMessageCanClearUserMessage)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__domain_error_information");
+    RecordProperty("Description",
+                   "Check that WithUserMessage(\"\") clears a previously set user message on the returned copy.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     // Given an error with an existing user message
     const score::result::Error original{MyErrorCode::kFirstError, "has message"};
 

--- a/score/result/result_test.cpp
+++ b/score/result/result_test.cpp
@@ -38,6 +38,10 @@ class UnexpectedTests : public ::testing::Test
 
 TEST_F(UnexpectedTests, CanMakeErroneousResultUsingUnexpectedTypeAlias)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description", "Check that a Result can be set to an error state using the Unexpected type alias.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Result<bool> result{Unexpected{error}};
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), error);
@@ -45,6 +49,11 @@ TEST_F(UnexpectedTests, CanMakeErroneousResultUsingUnexpectedTypeAlias)
 
 TEST_F(UnexpectedTests, CanMakeErroneousResultUsingMakeUnexpectedWithCodeAndUserMessage)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that MakeUnexpected(code, user_message) sets a Result to an error state carrying both.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Result<bool> result{MakeUnexpected(DummyErrorCode::kFirstError, error.UserMessage())};
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), error);
@@ -52,6 +61,12 @@ TEST_F(UnexpectedTests, CanMakeErroneousResultUsingMakeUnexpectedWithCodeAndUser
 
 TEST_F(UnexpectedTests, LegacyCanMakeErroneousResultUsingMakeUnexpectedWithError)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__set_result");
+    RecordProperty("Description",
+                   "Check that the legacy MakeUnexpected<T>(Error) overload sets a Result to an error state carrying "
+                   "a pre-built Error.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Result<bool> result{MakeUnexpected<bool>(error)};
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), error);
@@ -96,6 +111,12 @@ class MoveOnlyType
 
 TEST_F(ConversionTests, CanConvertLValueResultWithValueToStdOptional)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that ResultToOptionalOrElse converts an lvalue Result holding a value into an "
+                   "std::optional holding that value, without invoking the error handler.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     CopyableType value{14};
     const Result<CopyableType> result{value};
     EXPECT_CALL(error_handling, Call(_)).Times(0);
@@ -106,6 +127,12 @@ TEST_F(ConversionTests, CanConvertLValueResultWithValueToStdOptional)
 
 TEST_F(ConversionTests, CanConvertLValueResultWithErrorToStdOptional)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that ResultToOptionalOrElse converts an lvalue Result holding an error into an empty "
+                   "std::optional, invoking the error handler exactly once.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     const Result<CopyableType> result{unexpect, error};
     EXPECT_CALL(error_handling, Call(error)).Times(1);
     std::optional<CopyableType> optional = ResultToOptionalOrElse(result, error_handling.AsStdFunction());
@@ -114,6 +141,12 @@ TEST_F(ConversionTests, CanConvertLValueResultWithErrorToStdOptional)
 
 TEST_F(ConversionTests, CanConvertRValueResultWithValueToStdOptional)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that ResultToOptionalOrElse converts an rvalue Result holding a move-only value into an "
+                   "std::optional holding that value.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     const auto raw_value{96};
     MoveOnlyType value{raw_value};
     Result<MoveOnlyType> result{std::move(value)};
@@ -125,6 +158,12 @@ TEST_F(ConversionTests, CanConvertRValueResultWithValueToStdOptional)
 
 TEST_F(ConversionTests, CanConvertRValueResultWithErrorToStdOptional)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__std_integration");
+    RecordProperty("Description",
+                   "Check that ResultToOptionalOrElse converts an rvalue Result holding an error into an empty "
+                   "std::optional, invoking the error handler exactly once.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "requirements-analysis");
     Result<MoveOnlyType> result{unexpect, error};
     EXPECT_CALL(error_handling, Call(error)).Times(1);
     std::optional<MoveOnlyType> optional = ResultToOptionalOrElse(std::move(result), error_handling.AsStdFunction());
@@ -137,16 +176,28 @@ class TypeTraitsTests : public ::testing::Test
 
 TEST_F(TypeTraitsTests, IsResultVIsTrueIfIsTemplatedResult)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that IsResultV is true for a Result<T> instantiation with a concrete value type.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     EXPECT_TRUE(IsResultV<Result<bool>>);
 }
 
 TEST_F(TypeTraitsTests, IsResultVIsTrueIfIsResultBlank)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that IsResultV is true for the value-less Result<void> instantiation.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "boundary-values");
     EXPECT_TRUE(IsResultV<Result<void>>);
 }
 
 TEST_F(TypeTraitsTests, IsResultVIsFalseIfIsNoResult)
 {
+    RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
+    RecordProperty("Description", "Check that IsResultV is false for a type that is not a Result instantiation.");
+    RecordProperty("TestType", "requirements-based");
+    RecordProperty("DerivationTechnique", "equivalence-classes");
     EXPECT_FALSE(IsResultV<bool>);
 }
 

--- a/score/result/result_test.cpp
+++ b/score/result/result_test.cpp
@@ -177,7 +177,8 @@ class TypeTraitsTests : public ::testing::Test
 TEST_F(TypeTraitsTests, IsResultVIsTrueIfIsTemplatedResult)
 {
     RecordProperty("PartiallyVerifies", "comp_req__result__type_safety");
-    RecordProperty("Description", "Check that IsResultV is true for a Result<T> instantiation with a concrete value type.");
+    RecordProperty("Description",
+                   "Check that IsResultV is true for a Result<T> instantiation with a concrete value type.");
     RecordProperty("TestType", "requirements-based");
     RecordProperty("DerivationTechnique", "equivalence-classes");
     EXPECT_TRUE(IsResultV<Result<bool>>);


### PR DESCRIPTION
## Summary

Link all 256 C++ tests in the `score/result` component to the component requirements using the required `RecordProperty` metadata.

This completes Route 1 traceability authoring for a component that had no pre-existing test requirement metadata.

## Files touched

- `score/result/error_test.cpp`
- `score/result/error_msg_mapping_test.cpp`
- `score/result/result_test.cpp`
- `score/result/details/expected/expected_assignment_test.cpp`
- `score/result/details/expected/expected_constructor_test.cpp`
- `score/result/details/expected/expected_equality_test.cpp`
- `score/result/details/expected/expected_monadic_operator_test.cpp`
- `score/result/details/expected/expected_observer_test.cpp`
- `score/result/details/expected/expected_type_trait_test.cpp`
- `score/result/details/expected/extensions_test.cpp`
- `score/result/details/expected/test_type_traits_test.cpp`
- `score/result/details/expected/unexpected_test.cpp`

## Traceability

Each test now has `PartiallyVerifies`, `Description`, `TestType`, and `DerivationTechnique` metadata.

The links cover `error_handling`, `set_result`, `domain_error_information`, `type_safety`, `std_integration`, `deterministic_behavior`, and `exception_free_operation`.

Observer misuse tests use `fault-injection` and `boundary-values`; systematic ref-qualified and type-variant test families use `equivalence-classes`.

## Validation

- `bazel test --config=bl-x86_64-linux //score/result/...` -> all 7 test targets passed.
- `bazel run //:format.fix -- score/result/details/expected/expected_monadic_operator_test.cpp score/result/details/expected/expected_observer_test.cpp` completed successfully.
- `git diff --check` passed.
- Confirmed 256 tests and 256 `FullyVerifies`/`PartiallyVerifies` links.
- Confirmed all 7 referenced `comp_req` IDs exist in `score/result/docs/requirements/index.rst`.

The full docs build remains blocked by the pre-existing root-owned `_build/` permission error, so requirement ID validation used the documented grep fallback.

## Deliberately left unlinked

None. All 256 result tests have traceability metadata.

## Flagged requirement-quality issue

`extensions_test.cpp` includes `score::cpp::expected` and `score::cpp::optional` interoperability tests in addition to `std::optional` interoperability. These tests are linked to `comp_req__result__std_integration`, whose current wording is narrower and explicitly names `std::optional`. The requirement wording may need clarification in a follow-up change.